### PR TITLE
remove padrino-admin's dependency to padrino-gen

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ PATH
   specs:
     padrino-admin (0.9.15)
       padrino-core (= 0.9.15)
-      padrino-gen (= 0.9.15)
       padrino-helpers (= 0.9.15)
 
 PATH
@@ -27,7 +26,7 @@ PATH
   specs:
     padrino-core (0.9.15)
       activesupport (>= 2.3.8)
-      http_router (>= 0.3.14)
+      http_router (>= 0.3.15)
       sinatra (>= 1.0.0)
       thor (>= 0.13.0)
 
@@ -88,7 +87,7 @@ GEM
     fakeweb (1.2.8)
     git (1.2.5)
     haml (3.0.15)
-    http_router (0.3.14)
+    http_router (0.3.15)
       rack (>= 1.0)
       url_mount (>= 0.2.1)
     i18n (0.4.1)

--- a/padrino-admin/lib/padrino-admin.rb
+++ b/padrino-admin/lib/padrino-admin.rb
@@ -1,5 +1,4 @@
 require 'padrino-core'
-require 'padrino-gen'
 require 'padrino-helpers'
 
 FileSet.glob_require('padrino-admin/*.rb', __FILE__)
@@ -30,4 +29,9 @@ I18n.load_path += Dir["#{File.dirname(__FILE__)}/padrino-admin/locale/**/*.yml"]
 ##
 # Now we need to add admin generators to padrino-gen
 #
-Padrino::Generators.load_paths << Dir[File.dirname(__FILE__) + '/padrino-admin/generators/{actions,orm,admin_app,admin_page}.rb']
+begin
+  require 'padrino-gen'
+  Padrino::Generators.load_paths << Dir[File.dirname(__FILE__) + '/padrino-admin/generators/{actions,orm,admin_app,admin_page}.rb']
+rescue LoadError
+
+end

--- a/padrino-admin/padrino-admin.gemspec
+++ b/padrino-admin/padrino-admin.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_path = "lib"
   s.add_dependency("padrino-core", Padrino.version)
-  s.add_dependency("padrino-gen",   Padrino.version)
   s.add_dependency("padrino-helpers", Padrino.version)
 end


### PR DESCRIPTION
hi,

with these changes users especialy publishing in Heroku can reduce their slug size like below.
# Gemfile

gem 'padrino-core', "0.9.15" # required
gem 'padrino-helpers', "0.9.15" # optional
gem 'padrino-mailer', "0.9.15" # optional
gem 'padrino-admin', "0.9.15" # optional
gem 'padrino-gen', "0.9.15", :group => "development" # only needed for development
