### PR TITLE
fix for undefined_method crypted_password

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
@@ -43,7 +43,7 @@ class Account < ::Sequel::Model
   # This method is used to retrieve the original password.
   #
   def password_clean
-    crypted_password.decrypt(salt)
+    self.crypted_password.decrypt(salt)
   end
 
   private


### PR DESCRIPTION
When using Sequel ORM with a Postgresql database, I get the error you see at http://gist.github.com/610877

Calling self.crypted_password instead of crypted_password in the Account model in the password_clean method resolves this error.

I'm not sure if this issue is present in all Postgresql database configurations, but I encountered this error after deploying to Heroku.
