### PR TITLE
Small fix in padrino-core routing.rb

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -494,7 +494,7 @@ module Padrino
             url_format        = $1.to_sym if $1
 
             if !url_format && matching_types.first
-              type = Rack::Mime::MIME_TYPES.find { |k, v| v == matching_types.first }[0].sub(/\./,'').to_sym
+              type = ::Rack::Mime::MIME_TYPES.find { |k, v| v == matching_types.first }[0].sub(/\./,'').to_sym
               accept_format = CONTENT_TYPE_ALIASES[type] || type
             end
 


### PR DESCRIPTION
Hi,

I had some trouble running the server with `padrino start` on ruby 1.9.1.

Turned out that in padrino-core/lib/padrino-core/application/routing.rb the Rack::Mime module was used without an explicit root scope.

I changed the line using the module from:

```
Rack::Mime::MIME_TYPES
```

to 

```
::Rack::Mime::MIME_TYPES
```

All specs still pass on 1.8.7 and 1.9.1 and the server starts again.
