### PR TITLE
Fixed conflict on seeds file when generating admin

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -72,7 +72,13 @@ module Padrino
           admin_app.invoke_all
 
           template "templates/account/#{orm}.rb.tt",                     destination_root("app", "models", "account.rb"), :force => true
-          template "templates/account/seeds.rb.tt",                      destination_root("db/seeds.rb")
+          
+          if File.exist?(destination_root("db/seeds.rb"))
+            append_file(destination_root("db/seeds.rb")) { "\n\n" + File.read(self.class.source_root+"/templates/account/seeds.rb.tt") }
+          else
+            template "templates/account/seeds.rb.tt",                    destination_root("db/seeds.rb")
+          end
+          
           template "templates/#{ext}/app/base/_sidebar.#{ext}.tt",       destination_root("admin/views/base/_sidebar.#{ext}")
           template "templates/#{ext}/app/base/index.#{ext}.tt",          destination_root("admin/views/base/index.#{ext}")
           template "templates/#{ext}/app/layouts/application.#{ext}.tt", destination_root("admin/views/layouts/application.#{ext}")

--- a/padrino-admin/test/helper.rb
+++ b/padrino-admin/test/helper.rb
@@ -7,6 +7,7 @@ require 'rack/test'
 require 'uuid'
 require 'rack'
 require 'shoulda'
+require 'mocha'
 require 'thor/group'
 require 'padrino-core/support_lite' unless defined?(SupportLite)
 require 'padrino-admin'


### PR DESCRIPTION
Hi padrino team,

When I generated the admin after already having a `db/seeds.rb` file I got a conflict.

I changed the `padrino-admin/lib/padrino-admin/generators/admin_app.rb` so the seeds.rb template is appended if there is already a seeds.rb file.

I added a test to isolate the bug.

I had to add mocha to the `padrino-admin/test/helper.rb` file.
I figured this was ok since it is listed in the `padrino-framework/Gemfile`
