### PR TITLE
Pluralize heading of the 'List' pages in Admin

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/page/index.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/page/index.erb.tt
@@ -6,7 +6,7 @@
     </ul>
   </div>
   <div class="content">
-    <h2 class="title"><%%= pat(:all) %> <%% mt(:<%= @orm.name_singular %>) %></h2>
+    <h2 class="title"><%%= pat(:all) %> <%% mt(:<%= @orm.name_plural %>) %></h2>
     <div class="inner">
       <table class="table">
         <tr>

--- a/padrino-admin/lib/padrino-admin/generators/templates/haml/page/index.haml.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/haml/page/index.haml.tt
@@ -6,7 +6,7 @@
   .content
     %h2.title
       =pat(:all)
-      =mt(:<%= @orm.name_singular %>)
+      =mt(:<%= @orm.name_plural %>)
     .inner
       %table.table
         %tr


### PR DESCRIPTION
Hey guys.  When I create an admin page for say a blog post or a user account the listing header shows 'All Account' or 'All Post'.  After a bit of digging I found the generator's template files and changed them to pluralize the headings so that the listing header shows 'All Accounts' or 'All Posts'.

Hope this is OK and they were not set to @orm.name_singular for any particular/legitimate reason that I am missing.
