### PR TITLE
fix failing test

### DIFF
--- a/padrino-core/test/test_reloader_simple.rb
+++ b/padrino-core/test/test_reloader_simple.rb
@@ -32,13 +32,13 @@ class TestSimpleReloader < Test::Unit::TestCase
       assert_equal 200, status
       get "/__sinatra__/404.png"
       assert_equal 200, status
-      assert_equal "image/png", response["Content-Type"]
+      assert_equal "image/png;charset=utf-8", response["Content-Type"]
       @app.reset_routes!
       get "/"
       assert_equal 404, status
       get "/__sinatra__/404.png"
       assert_equal 200, status
-      assert_equal "image/png", response["Content-Type"]
+      assert_equal "image/png;charset=utf-8", response["Content-Type"]
     end
   end
 


### PR DESCRIPTION
charset is now included in the response Content-Type header. I've updated the failing test in padrino-core/test/test_reloader_simple.rb
