### PR TITLE
Update RSpec 2 configuration for new API

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -2,7 +2,7 @@ RSPEC_SETUP = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_SETUP)
 PADRINO_ENV = 'test' unless defined?(PADRINO_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
 
-Spec::Runner.configure do |conf|
+RSpec.configure do |conf|
   conf.include Rack::Test::Methods
 end
 


### PR DESCRIPTION
A small fix so that spec_helper.rb is correct  generated for RSpec 2-based projects. The old API is no longer supported.
