### PR TITLE
Fix shoulda generator class name

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
@@ -42,7 +42,7 @@ TEST
 SHOULDA_MODEL_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(SHOULDA_MODEL_TEST)
 require File.expand_path(File.dirname(__FILE__) + '/../test_config.rb')
 
-class !NAME!ControllerTest < Test::Unit::TestCase
+class !NAME!Test < Test::Unit::TestCase
   context "!NAME! Model" do
     should 'construct new instance' do
       @!DNAME! = !NAME!.new


### PR DESCRIPTION
Shoulda model tests are generated with Controller in the classname e.g. AccountControllerTest. This removes the word 'controller' from model tests.
