### PR TITLE
admin generator fixes

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -43,6 +43,7 @@ module Padrino
 
           ext = fetch_component_choice(:renderer)
 
+          empty_directory destination_root("admin")
           directory "templates/app",     destination_root("admin")
           directory "templates/assets",  destination_root("public", "admin")
 
@@ -78,7 +79,13 @@ module Padrino
           else
             template "templates/account/seeds.rb.tt",                    destination_root("db/seeds.rb")
           end
-          
+
+          empty_directory destination_root("admin/controllers")
+          empty_directory destination_root("admin/views")
+          empty_directory destination_root("admin/views/base")
+          empty_directory destination_root("admin/views/layouts")
+          empty_directory destination_root("admin/views/sessions")
+
           template "templates/#{ext}/app/base/_sidebar.#{ext}.tt",       destination_root("admin/views/base/_sidebar.#{ext}")
           template "templates/#{ext}/app/base/index.#{ext}.tt",          destination_root("admin/views/base/index.#{ext}")
           template "templates/#{ext}/app/layouts/application.#{ext}.tt", destination_root("admin/views/layouts/application.#{ext}")

--- a/padrino-admin/lib/padrino-admin/generators/admin_page.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_page.rb
@@ -34,6 +34,8 @@ module Padrino
             self.behavior = :revoke if options[:destroy]
             ext = fetch_component_choice(:renderer)
 
+            empty_directory destination_root("/admin/views/#{@orm.name_plural}")
+
             template "templates/page/controller.rb.tt",       destination_root("/admin/controllers/#{@orm.name_plural}.rb")
             template "templates/#{ext}/page/_form.#{ext}.tt", destination_root("/admin/views/#{@orm.name_plural}/_form.#{ext}")
             template "templates/#{ext}/page/edit.#{ext}.tt",  destination_root("/admin/views/#{@orm.name_plural}/edit.#{ext}")


### PR DESCRIPTION
fixes #352 - the admin generator was not passing the option[:destroy] to the admin_page generator and was also attempting to rollback an injection on /admin/app.rb when it did not exist anymore. I also added some empty_directory calls to make sure /admin is cleaned up on destroy.

There was also an extra call to add_project_module in the app generator that was duplicating the call in the admin_page generator.
