### PR TITLE
shoulda test_config file doesn't load activerecord matchers

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
@@ -56,6 +56,9 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'shoulda', :group => 'test'
   insert_test_suite_setup SHOULDA_SETUP
+  if options[:orm] == "activerecord"
+    inject_into_file destination_root("test/test_config.rb"), "require 'shoulda/active_record'\n\n", :before => /class.*?\n/
+  end
   create_file destination_root("test/test.rake"), SHOULDA_RAKE
 end
 


### PR DESCRIPTION
Wasted a bit of time figuring out that this is because of the way shoulda attempts to detect rails vs. activerecord. By adding this require line shoulda tests in my padrino project supported all of the activerecord matchers e.g. should have_many(:association).

Thanks!
- sob
