### PR TITLE
Added failing test for App with multiple mountpoints and url helper

### DIFF
--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -134,7 +134,27 @@ class TestMounter < Test::Unit::TestCase
       assert_equal "POST", another_route.verb
       assert_equal "/two_app/users/create", another_route.path
     end
+    
+    should 'correctly build urls for one app with different mount points' do
+      class ::OneApp < Padrino::Application
+        controllers do
+          get(:index) { "index" }
+          get(:foo) { "foo" }
+          get(:bar) { url(:foo) }
+        end
+      end
 
+      Padrino.mount("one_app").to("/one_app")
+      Padrino.mount("one_app", :app_class => "OneApp").to("/two_app")
+      
+      res = Rack::MockRequest.new(Padrino.application).get("/one_app/bar")
+      assert res.ok?
+      assert_equal '/one_app/foo', res.body
+      res = Rack::MockRequest.new(Padrino.application).get("/two_app/bar")
+      assert res.ok?
+      assert_equal '/two_app/foo', res.body
+    end
+    
     should 'correctly instantiate a new padrino application' do
       mock_app do
         get("/demo_1"){ "Im Demo 1" }


### PR DESCRIPTION
Added failing test for App with multiple mountpoints where the urls and Sinatra settings get stuck to the last mounted mountpoint.  

There seem to be a few inconsistencies when one App is mounted to multiple mount points.  I've caught one of the failing examples and hope this will fix the issues with the settings etc.

Josh said he'd fix tonight if I get a failing spec., so here it is.. ;)
