### PR TITLE
Issue 390

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -501,7 +501,9 @@ module Padrino
             request.path_info =~ /\.([^\.\/]+)$/
             url_format        = $1.to_sym if $1
 
-            if !url_format && matching_types.first
+            if params[:format]
+              accept_format = params[:format]
+            elsif !url_format && matching_types.first
               type = ::Rack::Mime::MIME_TYPES.find { |k, v| v == matching_types.first }[0].sub(/\./,'').to_sym
               accept_format = CONTENT_TYPE_ALIASES[type] || type
             end


### PR DESCRIPTION
I created the issue, but what I wanted to do was really to be able to override the format from a before block.

this patch enabled me to do something like

```
before do
  if request.user_agent ~= /Mobile/
    params[:format] ||= :mobile
   end
end
```
