### PR TITLE
Fix for mounting namespaced apps

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -102,7 +102,16 @@ module Padrino
     # Returns the class object for the app if defined, nil otherwise
     #
     def app_constant
-      app_class.constantize if Object.const_defined?(app_class)
+      klass = Object
+      for piece in app_class.split("::")
+        piece = piece.to_sym
+        if klass.const_defined?(piece)
+          klass = klass.const_get(piece)
+        else
+          return
+        end
+      end
+      klass
     end
 
     protected

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -38,6 +38,15 @@ class TestMounter < Test::Unit::TestCase
       assert_equal AnApp, Padrino.mounted_apps.first.app_obj
       assert_equal ["an_app"], Padrino.mounted_apps.collect(&:name)
     end
+    
+    should 'correctly mount an app in a namespace' do
+      module ::SomeNamespace
+        class AnApp < Padrino::Application; end
+      end
+      Padrino.mount("some_namespace/an_app").to("/")
+      assert_equal SomeNamespace::AnApp, Padrino.mounted_apps.first.app_obj
+      assert_equal ["some_namespace/an_app"], Padrino.mounted_apps.collect(&:name)
+    end
 
     should 'mount a primary app to root uri' do
       mounter = Padrino.mount("test", :app_file => __FILE__).to("/")


### PR DESCRIPTION
I like to put the application file and all the lib files under a proper namespace. I guess that no one else does this, since someone would have found this bug before. Even so, I can see a case in which you have a project that's made up of sub-applications and you want to mount them separately but have them all live in the same namespace.

Unfortunately, during the load process, Padrino will blow up when attempting to mount a namespaced application. What I mean by namespaced is when, instead of this:

```
class MyApp < Padrino::Application
  # ...
end
Padrino.mount("MyApp").to("/")
```

you have this:

```
module MyApp
  class Application < Padrino::Application
    # ...
  end
end
Padrino.mount("my_app/application").to("/")
```

In this case, Padrino crashes with this error:

```
NameError: wrong constant name MyApp::Application
    .../padrino-core/lib/padrino-core/mounter.rb:105:in `const_defined?'
    .../padrino-core/lib/padrino-core/mounter.rb:105:in `app_constant'
    .../padrino-core/lib/padrino-core/mounter.rb:126:in `locate_app_file'
    .../padrino-core/lib/padrino-core/mounter.rb:20:in `initialize'
    .../padrino-core/lib/padrino-core/mounter.rb:180:in `new'
    .../padrino-core/lib/padrino-core/mounter.rb:180:in `mount'
```

The issue is that the mounter constantizes the app name given to Padrino.mount assuming it's not in a namespace, and consequently, `Object.const_defined?("MyApp::Application")` is called, which doesn't work.

I've attached a fix for this, with a test.
