### PR TITLE
Simple approach to asset host management

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -251,7 +251,7 @@ module Padrino
           host = self.class.asset_host
           host_count = self.class.asset_host_count if self.class.respond_to?(:asset_host_count)
           host_count ||= 1
-          host.gsub('%d', rand(host_count))
+          host.gsub('%d', rand(host_count).to_s)
         end
 
         ##


### PR DESCRIPTION
Hi,

I have added a very simplistic approach to asset host management.

Basically you provide a configuration, such as within your app.rb:

```
configure :production do
  set :asset_host, "http://assets%d.domain.com"
  set :asset_host_count, 4
end
```

The asset helpers will then output a tag based upon the provided host(s). If the asset_host_count is not provided then it defaults to 1 server, and so will replace %d with 0 if present in the asset_host string.

This works very similar to some of the approaches taken in rails.

I am basically using a random number selection to which host to use if more than one, rather than any form of round robin approach. This seems the simplest approach to take at the moment.

Any feedback given would be most grateful.

Regards
Matthew Winter
