### PR TITLE
Grouped options for Select Tags

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -274,7 +274,11 @@ module Padrino
         options[:options] = options_from_collection(collection, fields) if collection
         blank = options.delete(:include_blank)
         options[:options].to_a.unshift(blank.is_a?(String) ? [blank, ''] : '') if blank
-        select_options_html = options_for_select(options.delete(:options), options.delete(:selected))
+        select_options_html = if options[:options]
+          options_for_select(options.delete(:options), options.delete(:selected))
+        elsif options[:grouped_options]
+          grouped_options_for_select(options.delete(:grouped_options), options.delete(:selected))
+        end
         options.merge!(:name => "#{options[:name]}[]") if options[:multiple]
         content_tag(:select, select_options_html, options)
       end
@@ -366,6 +370,27 @@ module Padrino
         option_items.collect do |caption, value|
           value ||= caption
           content_tag(:option, caption, :value => value, :selected => option_is_selected?(value, caption, selected_value))
+        end
+      end
+      
+      #
+      # Returns the optgroups with options tags for a select based on the given :grouped_options items
+      #
+      def grouped_options_for_select(collection,selected=nil)
+        if collection.is_a?(Hash)
+          collection.each.map do |key, value|
+            content_tag :optgroup, :label => key do
+              options_for_select(value, selected)
+            end
+          end
+        elsif collection.is_a?(Array)
+          collection.map do |optgroup|
+            content_tag :optgroup, :label => optgroup.first do
+              options_for_select(optgroup.last, selected)
+            end
+          end
+        else
+          raise "options must be a hash or array, not a #{collection.class}"
         end
       end
 

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -376,13 +376,13 @@ class TestFormHelpers < Test::Unit::TestCase
         ["Enemies", ["Palpatine",['Darth Vader',3]]]
       ]
       actual = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag("select", name:"name") { actual }
-      assert_has_tag("optgroup", label:"Friends") { actual }
-      assert_has_tag("option", value:"Yoda", content:"Yoda") { actual }
-      assert_has_tag("option", value:"2", content:"Obiwan") { actual }
-      assert_has_tag("optgroup", label:"Enemies") { actual }
-      assert_has_tag("option", value:"Palpatine", content:"Palpatine") { actual }
-      assert_has_tag("option", value:"3", content:"Darth Vader") { actual }
+      assert_has_tag(:select, name:"name") { actual }
+      assert_has_tag(:optgroup, label:"Friends") { actual }
+      assert_has_tag(:option, value:"Yoda", content:"Yoda") { actual }
+      assert_has_tag(:option, value:"2", content:"Obiwan") { actual }
+      assert_has_tag(:optgroup, label:"Enemies") { actual }
+      assert_has_tag(:option, value:"Palpatine", content:"Palpatine") { actual }
+      assert_has_tag(:option, value:"3", content:"Darth Vader") { actual }
     end
     
     should "return a select tag with grouped options for a hash" do
@@ -391,13 +391,13 @@ class TestFormHelpers < Test::Unit::TestCase
         "Enemies" => ["Palpatine",['Darth Vader',3]]
       }
       actual = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag("select", name:"name") { actual }
-      assert_has_tag("optgroup", label:"Friends") { actual }
-      assert_has_tag("option", value:"Yoda", content:"Yoda") { actual }
-      assert_has_tag("option", value:"2", content:"Obiwan") { actual }
-      assert_has_tag("optgroup", label:"Enemies") { actual }
-      assert_has_tag("option", value:"Palpatine", content:"Palpatine") { actual }
-      assert_has_tag("option", value:"3", content:"Darth Vader") { actual }
+      assert_has_tag(:select, name:"name") { actual }
+      assert_has_tag(:optgroup, label:"Friends") { actual }
+      assert_has_tag(:option, value:"Yoda", content:"Yoda") { actual }
+      assert_has_tag(:option, value:"2", content:"Obiwan") { actual }
+      assert_has_tag(:optgroup, label:"Enemies") { actual }
+      assert_has_tag(:option, value:"Palpatine", content:"Palpatine") { actual }
+      assert_has_tag(:option, value:"3", content:"Darth Vader") { actual }
     end
 
     should "display select tag in ruby with multiple attribute" do


### PR DESCRIPTION
This now works

```
opts = {
  "Friends" => ["Yoda",["Obiwan",2]],
  "Enemies" => ["Palpatine",['Darth Vader',3]]
}
select_tag('name', :grouped_options => opts)
```

An Array will also do the trick

```
opts = [
   ["Friends",["Yoda",["Obiwan",2]]],
   ["Enemies", ["Palpatine",['Darth Vader',3]]]
]
select_tag('name', :grouped_options => opts)
```

Note: Not sure why this pull request is including a previous commit which you accepted? I definitely pulled from master.. weird
