### PR TITLE
fix jquery style ajax request detection for dataType: 'script'

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -569,7 +569,8 @@ module Padrino
 
             # per rfc2616-sec14:
             # Assume */* if no ACCEPT header is given.
-            if accepts.empty? || accepts.any? { |a| a == "*/*" }
+            accepts.delete "*/*"
+            if accepts.empty?
               matching_types  = mime_types.slice(0,1)
             else
               matching_types  = (accepts & mime_types)

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -230,6 +230,15 @@ class TestRouting < Test::Unit::TestCase
     assert_equal 'json', body
   end
 
+  should "set correct content_type for Accept not equal to */* even if */* also provided" do
+    mock_app do
+      get("/foo", :provides => [:html, :js, :xml]) { content_type.to_s }
+    end
+
+    get '/foo', {}, { 'HTTP_ACCEPT' => 'application/javascript, */*;q=0.5' }
+    assert_equal 'js', body
+  end
+
   should "return the first content type in provides if accept header is empty" do
     mock_app do
       get(:a, :provides => [:js]){ content_type.to_s }
@@ -839,6 +848,14 @@ class TestRouting < Test::Unit::TestCase
 
     get '/foo', {}, { 'HTTP_ACCEPT' => '*/*;q=0.5' }
     assert_equal 'html', body
+  end
+
+  should "set content_type to :js if Accept includes both application/javascript and */*;q=0.5" do
+    mock_app do
+      get("/foo", :provides => [:html, :js]) { content_type.to_s }
+    end
+    get '/foo', {}, { 'HTTP_ACCEPT' => 'application/javascript, */*;q=0.5' }
+    assert_equal 'js', body
   end
 
   should 'allows custom route-conditions to be set via route options and halt' do


### PR DESCRIPTION
jQuery command `$.ajax({..., dataType: 'script'})` sends HTTP_ACCEPT like 'application/javascript, _/_' (jquery1.5.2, chromium). Padrino sees '_/_' and ignores 'application/javascript'

This patch fixes this behaviour.
