### PR TITLE
tweaking stylesheet_link_tag and javascript_include_tag (allow array input)

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -167,7 +167,7 @@ module Padrino
       def stylesheet_link_tag(*sources)
         options = sources.extract_options!.symbolize_keys
         options.reverse_merge!(:media => 'screen', :rel => 'stylesheet', :type => 'text/css')
-        sources.map { |source|
+        sources.flatten.map { |source|
           tag(:link, options.reverse_merge(:href => asset_path(:css, source)))
         }.join("\n")
       end
@@ -184,7 +184,7 @@ module Padrino
       def javascript_include_tag(*sources)
         options = sources.extract_options!.symbolize_keys
         options.reverse_merge!(:type => 'text/javascript', :content => "")
-        sources.map { |source|
+        sources.flatten.map { |source|
           tag(:script, options.reverse_merge(:src => asset_path(:js, source)))
         }.join("\n")
       end

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -185,6 +185,7 @@ class TestAssetTagHelpers < Test::Unit::TestCase
       assert_has_tag('link', :href => "/stylesheets/style.css?#{time.to_i}") { actual_html }
       assert_has_tag('link', :href => "/stylesheets/layout.css?#{time.to_i}") { actual_html }
       assert_has_tag('link', :href => "http://google.com/style.css") { actual_html }
+      assert_equal actual_html, stylesheet_link_tag(['style', 'layout.css', 'http://google.com/style.css'])
     end
     should "not use a timestamp if stamp setting is false" do
       self.class.expects(:asset_stamp).returns(false)
@@ -232,6 +233,7 @@ class TestAssetTagHelpers < Test::Unit::TestCase
       assert_has_tag('script', :src => "/javascripts/application.js?#{time.to_i}") { actual_html }
       assert_has_tag('script', :src => "/javascripts/base.js?#{time.to_i}") { actual_html }
       assert_has_tag('script', :src => "http://google.com/lib.js") { actual_html }
+      assert_equal actual_html, javascript_include_tag(['application', 'base.js', 'http://google.com/lib.js'])
     end
     should "not use a timestamp if stamp setting is false" do
       self.class.expects(:asset_stamp).returns(false)


### PR DESCRIPTION
stylesheet_link_tag and javascript_include_tag should allow array inputs for sources (instead of argument array)

reason: [Jammit](http://documentcloud.github.com/jammit/)'s helpers pass plain arrays of js and css strings. This fix allows `Jammit::Helper` to work perfectly with Padrino and should provide better compatibility with other Rails plugins. 

Working on a Padrino compatible version of Jammit, i'll send a pull request for possible inclusion in padrino-contrib or padrino-recipes
