### PR TITLE
log_static setting for Padrino.logger

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -30,6 +30,7 @@ module Padrino
     attr_reader   :buffer
     attr_reader   :log
     attr_reader   :init_args
+    attr_accessor :log_static
 
     ##
     # Ruby (standard) logger levels:
@@ -63,6 +64,7 @@ module Padrino
     #   added. Defaults to true.
     # :format_datetime:: Format of datetime. Defaults to: "%d/%b/%Y %H:%M:%S"
     # :format_message:: Format of message. Defaults to: ""%s - - [%s] \"%s\"""
+    # :log_static:: Whether or not to show log messages for static files. Defaults to: false
     #
     # ==== Examples
     #
@@ -146,6 +148,7 @@ module Padrino
     #   added. Defaults to true.
     # :format_datetime:: Format of datetime. Defaults to: "%d/%b/%Y %H:%M:%S"
     # :format_message:: Format of message. Defaults to: ""%s - - [%s] \"%s\"""
+    # :log_static:: Whether or not to show log messages for static files. Defaults to: false
     #
     def initialize(options={})
       @buffer            = []
@@ -156,6 +159,7 @@ module Padrino
       @mutex             = @@mutex[@log] ||= Mutex.new
       @format_datetime   = options[:format_datetime] || "%d/%b/%Y %H:%M:%S"
       @format_message    = options[:format_message]  || "%s - [%s] \"%s\""
+      @log_static        = options.has_key?(:log_static) ? options[:log_static] : false
     end
 
     ##
@@ -289,6 +293,8 @@ module Padrino
         def log(env, status, header, began_at)
           now = Time.now
           length = extract_content_length(header)
+
+          return if env['sinatra.static_file'] and !logger.log_static
 
           logger.debug FORMAT % [
             env["REQUEST_METHOD"],

--- a/padrino-core/test/test_logger.rb
+++ b/padrino-core/test/test_logger.rb
@@ -51,5 +51,22 @@ class TestPadrinoLogger < Test::Unit::TestCase
       assert_match /GET/, Padrino.logger.log.string
     end
 
+    context "static asset logging" do
+      should 'not log static assets by default' do
+        mock_app { get("/images/something.png"){ env["sinatra.static_file"] = '/public/images/something.png'; "Foo" } }
+        get "/images/something.png"
+        assert_equal "Foo", body
+        assert_match "", Padrino.logger.log.string
+      end
+
+      should 'allow turning on static assets logging' do
+        Padrino.logger.instance_eval{ @log_static = true }
+        mock_app { get("/images/something.png"){ env["sinatra.static_file"] = '/public/images/something.png'; "Foo" } }
+        get "/images/something.png"
+        assert_equal "Foo", body
+        assert_match /GET/, Padrino.logger.log.string
+        Padrino.logger.instance_eval{ @log_static = false }
+      end
+    end
   end
 end


### PR DESCRIPTION
[padrino-core] Added setting log_static setting to Padrino.logger (defaults to false). When true, Padrino will show log messages for static asset http requests. Otherwise it will ignore them.
