### PR TITLE
Do not enforce padrino's cookie sessions for Rack:Flash

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -191,7 +191,7 @@ module Padrino
         def register_initializers
           use Padrino::Logger::Rack, uri_root if Padrino.logger && (Padrino.logger.level == 0 && padrino_logging?)
           use Padrino::Reloader::Rack         if reload?
-          use Rack::Flash                     if flash? && sessions?
+          use Rack::Flash                     if flash?
         end
 
         ##


### PR DESCRIPTION
Rack might use some other session stores, such as memcached or datamapper (Ex: I'm using Rack::Session::DataMapper).
