### PR TITLE
Hashes created by BCrypt::Password.create() exceed the default String len

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/datamapper.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/datamapper.rb.tt
@@ -8,7 +8,7 @@ class Account
   property :name,             String
   property :surname,          String
   property :email,            String
-  property :crypted_password, String
+  property :crypted_password, String, :length => 70
   property :role,             String
 
   # Validations


### PR DESCRIPTION
Hashes created by BCrypt::Password.create() exceed the default String length (50).
