### PR TITLE
Simplify and Speed Up Object.classes

### DIFF
--- a/padrino-core/lib/padrino-core/support_lite.rb
+++ b/padrino-core/lib/padrino-core/support_lite.rb
@@ -26,9 +26,9 @@ module ObjectSpace
   class << self
     # Returns all the classes in the object space.
     def classes
-      klasses = ObjectSpace.each_object(Class).map.to_a | ObjectSpace.each_object(Module).map.to_a
-      klasses.reject! { |klass| !Class.class_eval { klass } rescue true  }
-      klasses
+      ObjectSpace.each_object(Module).map.select do |klass|
+        Class.class_eval { klass } rescue false
+      end
     end
   end
 end


### PR DESCRIPTION
This bring padrino's boot time back to 0.9.28 levels:

```
# padrino-0.9.28
real    0m7.359s
user    0m6.304s
sys 0m0.891s

# padrino-master + patch
real  0m7.374s
user  0m6.355s
sys 0m0.981s
```
