### PR TITLE
Padrino doesn't properly recognize */* in the Accept header

### DIFF
--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -230,6 +230,15 @@ class TestRouting < Test::Unit::TestCase
     assert_equal 'json', body
   end
 
+  should "set content_type to :json if Accept contains */*" do
+    mock_app do
+      get("/foo", :provides => [:json]) { content_type.to_s }
+    end
+
+    get '/foo', {}, { 'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
+    assert_equal 'json', body
+  end
+
   should "send the appropriate number of params" do
     mock_app do
       get('/id/:user_id', :provides => [:json]) { |user_id| user_id}


### PR DESCRIPTION
A controller that provides only :json returns a 405 when called from a browser that supplies an Accept header of: `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8` .

The reason for that is padrino-core/application/routing.rb line 606: `accepts.delete "*/*"`

I have written a test, and will issue a pull request for the test, but am not sure exactly how to fix.
