### PR TITLE
With AS::Dependencies disabled, loading models can fail

### DIFF
--- a/padrino-core/test/fixtures/dependencies/circular/e.rb
+++ b/padrino-core/test/fixtures/dependencies/circular/e.rb
@@ -1,0 +1,13 @@
+class E
+  def self.fields
+    @fields ||= []
+  end
+
+  def self.inherited(subclass)
+    subclass.fields.replace fields.dup
+  end
+
+  G
+
+  fields << "name"
+end

--- a/padrino-core/test/fixtures/dependencies/circular/f.rb
+++ b/padrino-core/test/fixtures/dependencies/circular/f.rb
@@ -1,0 +1,2 @@
+class F < E
+end

--- a/padrino-core/test/fixtures/dependencies/circular/g.rb
+++ b/padrino-core/test/fixtures/dependencies/circular/g.rb
@@ -1,0 +1,2 @@
+class G
+end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -28,5 +28,17 @@ class TestDependencies < Test::Unit::TestCase
       assert_equal ["B", "C"], A_result
       assert_equal "C", B_result
     end
+
+    should 'remove partially loaded constants' do
+      silence_warnings do
+        Padrino.require_dependencies(
+          Padrino.root("fixtures/dependencies/circular/e.rb"),
+          Padrino.root("fixtures/dependencies/circular/f.rb"),
+          Padrino.root("fixtures/dependencies/circular/g.rb")
+        )
+      end
+
+      assert_equal ["name"], F.fields
+    end
   end
 end


### PR DESCRIPTION
Given a setup like this:

```
# app/models/account.rb
class Account
  include Mongoid::Document

  field :api_key, type: ApiKey
  field :name
end

# app/models/api_key.rb
class ApiKey
end

# app/models/user.rb
class User < Account
end
```

Before this patch, the User model would have no declared fields, because it
inherited from Account before any field declarations could be executed.

Note that this failure is masked in environments where
activesupport/dependencies is required, because AS handles this case already.
You can, however, replicate this in an AS-enabled environment by setting
ENV["NO_RELOAD"].
