### PR TITLE
Logging improvements

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -138,6 +138,12 @@ module Padrino
     def self.setup!
       config_level = (PADRINO_LOG_LEVEL || Padrino.env || :test).to_sym # need this for PADRINO_LOG_LEVEL
       config = Config[config_level]
+
+      unless config
+        warn("No logging configuration for :#{config_level} found, falling back to :production")
+        config = Config[:production]
+      end
+
       stream = case config[:stream]
         when :to_file
           FileUtils.mkdir_p(Padrino.root("log")) unless File.exists?(Padrino.root("log"))


### PR DESCRIPTION
Hi,

we just had several problems with logging: one of our gems was calling `logger` ahead of Padrino.load![1] during bundle loading, making it impossible to configure the logger. For such cases, a way of configuring loggers ahead of the boot process might be nice - the patch adds such a possibility.

Also, Logger.setup! would fail hard if there was no configuration for a non-standard environment. This patch includes a simple handling of this situation: it uses the most "secure" logger (:production) and emits a warning instead.

Any comments on the solution?

[1] Especially Padrino apps shipped in their own gems, as loading a Padrino::Application subclass automatically calls #logger.
