### PR TITLE
Fix for padrino & libxml-ruby gem

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -98,7 +98,7 @@ module Padrino
       # We lock dependencies sets to prevent reloading of protected constants
       #
       def lock!
-        klasses = ObjectSpace.classes.map { |klass| klass.to_s.split("::")[0] }.uniq
+        klasses = ObjectSpace.classes.map { |klass| klass.name.to_s.split("::")[0] }.uniq
         klasses = klasses | Padrino.mounted_apps.map { |app| app.app_class }
         Padrino::Reloader.exclude_constants.concat(klasses)
       end


### PR DESCRIPTION
Fixes the following issue:

```
% padrino console
=> Loading development console (Padrino v.0.10.1)
/Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/reloader.rb:101:in `to_s': wrong number of arguments(0 for 1) (ArgumentError)
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/reloader.rb:101:in `block in lock!'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/reloader.rb:101:in `map'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/reloader.rb:101:in `lock!'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/loader.rb:54:in `load!'
    from /Users/farcaller/Developer/Active/TapDeploy/config/boot.rb:29:in `<top (required)>'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/cli/base.rb:68:in `require'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/lib/padrino-core/cli/base.rb:68:in `console'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/gems/padrino-core-0.10.1/bin/padrino:9:in `<top (required)>'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/bin/padrino:19:in `load'
    from /Users/farcaller/.rvm/gems/ruby-1.9.2-p290@padrino/bin/padrino:19:in `<main>'
```
