### PR TITLE
Pry support instead of IRB.

### DIFF
--- a/padrino-core/README.rdoc
+++ b/padrino-core/README.rdoc
@@ -265,7 +265,7 @@ check out the {Padrino Development Guide}[http://www.padrinorb.com/guides/develo
 === Terminal Commands
 
 Padrino also comes equipped with multiple useful terminal commands which can be activated to perform
-common tasks such as starting / stopping the application, executing the unit tests or activating an irb session.
+common tasks such as starting / stopping the application, executing the unit tests or activating an pry session.
 
 The following commands are available:
 
@@ -277,7 +277,7 @@ The following commands are available:
   # Stops a daemonized app server
   $ padrino stop
 
-  # Bootup the Padrino console (irb)
+  # Bootup the Padrino console (pry)
   $ padrino console
 
   # Run/List tasks

--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -57,17 +57,16 @@ module Padrino
         PadrinoTasks.init(true)
       end
 
-      desc "console", "Boots up the Padrino application irb console"
+      desc "console", "Boots up the Padrino application pry console"
       def console
         prepare :console
         require File.expand_path("../../version", __FILE__)
         ARGV.clear
         puts "=> Loading #{options.environment} console (Padrino v.#{Padrino.version})"
-        require 'irb'
-        require "irb/completion"
+        require 'pry'
         require File.expand_path('config/boot.rb')
         require File.expand_path('../console', __FILE__)
-        IRB.start
+        Pry.start
       end
 
       desc "generate", "Executes the Padrino generator with given options."

--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -11,6 +11,11 @@ gem 'rack-flash'
 
 # Test requirements
 
+# Pry
+group :development do
+  gem 'pry'
+  gem 'gist'
+end
 
 <%- if options.dev? -%>
 # Padrino


### PR DESCRIPTION
Hey guys,

I've been playing around with PRY and it looks really really good!.. So I thought in integrating it into Padrino's console itself by default and here it is.

Now on the app itself we can put bindings.pry or SomeObject.method.pry and it will break there for both the console and the running server.

Hope you like it too! I think that the possibility of inspecting the code in realtime is of great value! :)

Cheers!
