### PR TITLE
preserve the original options when resolving a template (also keeps views path) 

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering.rb
+++ b/padrino-core/lib/padrino-core/application/rendering.rb
@@ -121,7 +121,7 @@ module Padrino
 
           # If data is unassigned then this is a likely a template to be resolved
           # This means that no engine was explicitly defined
-          data, engine = *resolve_template(engine, options) if data.nil?
+          data, engine = *resolve_template(engine, options.dup) if data.nil?
 
           # Setup root
           root = settings.respond_to?(:root) ? settings.root : ""


### PR DESCRIPTION
Padrino's rendering supports passing a `:views => '/path/to/views'` option to locate templates. However, in resolve_template the `views` options gets stripped from the options hash, resulting in a rather strange behavior: Padrinos rendering will find the template and happily hand of to sinatra and tilt, but tilt will trip over the now missing view path and complain about a missing template. This patch clones the options hash before passing it off to resolve_template and thus prevents this behavior.

As as side note: The :views option seems nice at first glance, but only works in simple cases, but any template containing a partial will fail to render. A fix does not seem simple since the underlying issue is that sinatra does not pass the options hash to any template it renders, so the template itself cannot access the :views option and will happily try and find the partial in the app's default views directory.
