### PR TITLE
Inline attachment helper

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/render_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/render_helpers.rb
@@ -2,6 +2,35 @@ module Padrino
   module Helpers
     module RenderHelpers
       ##
+      # Tell the client that the response includes an inline file attachment.
+      #
+      # @note Inline attachment means the client wont directly download the
+      #   file, just show it inside the browser
+      # @note Sinatra::Base#send_file already supports inline attachment.
+      #   However, it's not always the case the developer wants to read from
+      #   a source path
+      #
+      # @param [optional String] filename
+      #   Filename to represent
+      #
+      # @example
+      #   inline_attachment "my_script.sh"
+      #   send_file "/path/to/my_script.sh"
+      #
+      # @see Sinatra::Base#attachment
+      #
+      # @api public
+      def inline_attachment(filename = nil)
+        value = "Inline"
+
+        if filename
+          value << "; filename=\"#{File.basename filename}\""
+        end
+
+        response["Content-Disposition"] = value
+      end
+
+      ##
       # Render a partials with collections support
       #
       # @param [String] template


### PR DESCRIPTION
This pull request contains a new helper that tells the client that the received data is to be showed inside the browser, discarding the mime-type of the file.

Sinatra already have a send_file method that supports inline disposition, although it only takes a file path as a parameter. It's not always the case you want to read from the filesystem.

Sorry for the lack of tests.
