### PR TITLE
Add Mizuno and Trinidad support

### DIFF
--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -17,7 +17,7 @@ module Padrino
   #
   class Server < Rack::Server
     # Server Handlers
-    Handlers = [:thin, :mongrel, :mizuno, :trinidad, :webrick]
+    Handlers = [:thin, :mongrel, :trinidad, :webrick]
 
     # Starts the application on the available server with specified options.
     def self.start(app, opts={})

--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source :rubygems
 
 # Server requirements
 # gem 'thin' # or mongrel
-# gem 'mizuno', :platform => 'jruby' # or trinidad on JRuby
+# gem 'trinidad', :platform => 'jruby'
 
 # Project requirements
 gem 'rake'


### PR DESCRIPTION
Server now automatically picks them up if
they register a proper Rack::Handler.

Also suggest them in the Gemfile.

This is a preliminary request for testing, _please_ do not merge yet, especially as Trinidad has not released their Rack support yet.

In the end, I found Mizuno the better experience, especially since it does not rely on jruby-rack.
