### PR TITLE
Session id randomization for admin

### DIFF
--- a/padrino-admin/lib/padrino-admin/access_control.rb
+++ b/padrino-admin/lib/padrino-admin/access_control.rb
@@ -13,7 +13,8 @@ module Padrino
       #
       class << self
         def registered(app)
-          app.set :session_id, "_padrino_#{File.basename(Padrino.root)}_#{app.app_name}".to_sym
+          charset = [('a'..'z'),('A'..'Z'),(0..9)].map{|i| i.to_a}.flatten
+          app.set :session_id, "_padrino_#{File.basename(Padrino.root)}_#{app.app_name}_#{(0..16).map{ charset[rand(charset.length)]}.join}".to_sym
           app.helpers Padrino::Admin::Helpers::AuthenticationHelpers
           app.helpers Padrino::Admin::Helpers::ViewHelpers
           app.before { login_required }


### PR DESCRIPTION
I noticed issue [#384](https://github.com/padrino/padrino-framework/issues/384)

Correct me if I'm wrong, but if the session id is simply randomized like this won't that hole be closed?

Tested and works fine for me.
