### PR TITLE
Add status messages to common padrino logger

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -318,11 +318,17 @@ module Padrino
               env["PATH_INFO"],
               env["QUERY_STRING"].empty? ? "" : "?" + env["QUERY_STRING"],
               ' - ',
-              status.to_s[0..3].bold
+              status.to_s[0..3].bold,
+              ' ',
+              code_to_name(status)
             ] * '',
             :debug,
             :magenta
           )
+        end
+        
+        def code_to_name(status)
+          ::Rack::Utils::HTTP_STATUS_CODES[status.to_i] || ''
         end
     end # Rack
   end # Logger

--- a/padrino-core/test/test_logger.rb
+++ b/padrino-core/test/test_logger.rb
@@ -64,6 +64,15 @@ describe "PadrinoLogger" do
       assert_match /GET/, Padrino.logger.log.string
     end
 
+    should 'log an application\'s status code' do
+      mock_app do
+        enable :logging
+        get("/"){ "Foo" }
+      end
+      get "/"
+      assert_match /\e\[1m200\e\[0m OK/, Padrino.logger.log.string
+    end
+
     context "static asset logging" do
       should 'not log static assets by default' do
         mock_app do


### PR DESCRIPTION
Hi, team

I like new Padrino::Logger's output very much.

Now, I think it's more useful for log's format to show a "status message" in addition to a status code.
Especially in case between status codes 301 & 302, and so on...

I'll be very happy when this small feature will be accepted!

sample is below.

![http://gyazo.udzura.jp/84700c6e3a73e5f7cedce84ceedeea24.png](http://gyazo.udzura.jp/84700c6e3a73e5f7cedce84ceedeea24.png)
