### PR TITLE
deleting :require => "postgres" when using AR with pg gem

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -103,7 +103,7 @@ def setup_orm
     ar.gsub! /!DB_DEVELOPMENT!/, POSTGRES.gsub(/!DB_NAME!/,"\"#{db}_development\"")
     ar.gsub! /!DB_PRODUCTION!/, POSTGRES.gsub(/!DB_NAME!/,"\"#{db}_production\"")
     ar.gsub! /!DB_TEST!/, POSTGRES.gsub(/!DB_NAME!/,"\"#{db}_test\"")
-    require_dependencies 'pg', :require => 'postgres'
+    require_dependencies 'pg'
   else
     ar.gsub! /!DB_DEVELOPMENT!/, SQLITE.gsub(/!DB_NAME!/,"Padrino.root('db', \"#{db}_development.db\")")
     ar.gsub! /!DB_PRODUCTION!/, SQLITE.gsub(/!DB_NAME!/,"Padrino.root('db', \"#{db}_production.db\")")

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -240,7 +240,7 @@ describe "ProjectGenerator" do
 
       should "properly generate postgres" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=activerecord', '--adapter=postgres') }
-        assert_match_in_file(/gem 'pg', :require => "postgres"/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(/gem 'pg'$/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
         assert_match_in_file(%r{:adapter   => 'postgresql'}, "#{@apptmp}/sample_project/config/database.rb")
       end


### PR DESCRIPTION
Dear Team,

I found generated Gemfile might cause trouble when passing the option `-d activerecord` with `-a postgres` ...

Now Gemfile might say `gem "pg", :require => "postgres"` ,but I think it won't works. (It would be a trouble especially in developments with Heroku.)

So I fixed generator... Could you look into this?
