### PR TITLE
set PADRINO_LOG_LEVEL constant by default

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
@@ -1,5 +1,6 @@
 # Defines our constants
 PADRINO_ENV  = ENV["PADRINO_ENV"] ||= ENV["RACK_ENV"] ||= "development"  unless defined?(PADRINO_ENV)
+PADRINO_LOG_LEVEL = PADRINO_ENV unless defined?(PADRINO_LOG_LEVEL)
 PADRINO_ROOT = File.expand_path('../..', __FILE__) unless defined?(PADRINO_ROOT)
 
 # Load our dependencies


### PR DESCRIPTION
This PR comes after this question: 
http://stackoverflow.com/questions/8082848/how-do-i-log-queries-in-a-rake-task-using-datamapper-and-padrino

Basically, I didn't understand why logging was working ok inside the padrino admin but not in a rake file.

I think the PADRINO_LOG_LEVEL constant should be included by default to make it easier to avoid problems like this.
