### PR TITLE
fix file cache fail "invalid byte sequence in UTF-8"

### DIFF
--- a/padrino-cache/lib/padrino-cache/store/file.rb
+++ b/padrino-cache/lib/padrino-cache/store/file.rb
@@ -35,7 +35,7 @@ module Padrino
         def get(key)
           init
           if ::File.exist?(path_for_key(key))
-            contents = ::File.read(path_for_key(key))
+            contents = ::File.read(path_for_key(key)).force_encoding('ASCII-8BIT')
             expires_in, body = contents.split("\n", 2)
             expires_in = expires_in.to_i
             if expires_in == -1 or Time.new.to_i < expires_in


### PR DESCRIPTION
when I use Padrino::Cache with Japanese text,
I faced "invalid byte sequence in UTF-8".
I append force encoding to avoid this error.
please check this change.
