### PR TITLE
app.app_name is not set error at /padrino-cache/lib/padrino-cache.rb

### DIFF
--- a/padrino-cache/lib/padrino-cache.rb
+++ b/padrino-cache/lib/padrino-cache.rb
@@ -91,7 +91,7 @@ module Padrino
         app.helpers Padrino::Cache::Helpers::CacheStore
         app.helpers Padrino::Cache::Helpers::Fragment
         app.helpers Padrino::Cache::Helpers::Page
-        app.set :cache, Padrino::Cache::Store::File.new(Padrino.root('tmp', app.app_name.to_s ,'cache'))
+        app.set :cache, Padrino::Cache::Store::File.new(Padrino.root('tmp', defined? app.app_name ? app.app_name.to_s : 'app_name' ,'cache'))
         app.disable :caching
       end
       alias :included :registered


### PR DESCRIPTION
when I use Padrino::Cache,app.app_name is not set error at Padrino::registered.
please check.
