### PR TITLE
An ability to place not ActiveRecord models in the "models" folder

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -304,6 +304,9 @@ if defined?(ActiveRecord)
           # Get the model class
           klass = m.camelize.constantize
 
+          # Avoid non ActiveRecord models
+          next unless klass.ancestors.include?(ActiveRecord::Base)
+
           # Init the processing
           print "Processing #{m.humanize}: "
           FileUtils.mkdir_p("#{Padrino.root}/app/locale/models/#{m}")


### PR DESCRIPTION
It gives an ability to place not ActiveRecord models in the "models" folder and use ar:translate task without the problems
