### PR TITLE
Updating tag & content_tag for better HTML 5 support

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -153,7 +153,7 @@ module Padrino
       # @api public
       def feed_tag(mime, url, options={})
         full_mime = (mime == :atom) ? 'application/atom+xml' : 'application/rss+xml'
-        content_tag(:link, options.reverse_merge(:rel => 'alternate', :type => full_mime, :title => mime, :href => url))
+        tag(:link, options.reverse_merge(:rel => 'alternate', :type => full_mime, :title => mime, :href => url))
       end
 
       ##
@@ -291,9 +291,9 @@ module Padrino
       # @api public
       def javascript_include_tag(*sources)
         options = sources.extract_options!.symbolize_keys
-        options.reverse_merge!(:type => 'text/javascript', :content => "")
+        options.reverse_merge!(:type => 'text/javascript')
         sources.flatten.map { |source|
-          tag(:script, options.reverse_merge(:src => asset_path(:js, source)))
+          content_tag(:script, nil, options.reverse_merge(:src => asset_path(:js, source)))
         }.join("\n")
       end
 

--- a/padrino-helpers/lib/padrino-helpers/format_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/format_helpers.rb
@@ -81,7 +81,7 @@ module Padrino
       # @api public
       def simple_format(text, options={})
         t = options.delete(:tag) || :p
-        start_tag = tag(t, options.merge(:open => true))
+        start_tag = tag(t, options, true)
         text = text.to_s.dup
         text.gsub!(/\r\n?/, "\n")                    # \r\n and \r -> \n
         text.gsub!(/\n\n+/, "</#{t}>\n\n#{start_tag}")  # 2+ newline  -> paragraph

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -21,17 +21,13 @@ describe "TagHelpers" do
       assert_has_tag('option', :selected => 'selected') { actual_html }
     end
 
-    should "support tags with content no attributes" do
-      assert_has_tag(:p, :content => "Demo String") { tag(:p, :content => "Demo String") }
-    end
-
-    should "support tags with content and attributes" do
-      actual_html = tag(:p, :content => "Demo", :class => 'large', :id => 'intro')
-      assert_has_tag('p#intro.large', :content => "Demo") { actual_html }
+    should "support data attributes" do
+      actual_html = tag(:a, :data => { :remote => true, :method => 'post'})
+      assert_has_tag(:a, 'data-remote' => 'true', 'data-method' => 'post') { actual_html }
     end
 
     should "support open tags" do
-      actual_html = tag(:p, :class => 'demo', :open => true)
+      actual_html = tag(:p, { :class => 'demo' }, true)
       assert_equal "<p class=\"demo\">", actual_html
     end
 


### PR DESCRIPTION
I dropped support for `:content` in `tag` but this change had almost no impact on the test coverage and I expect it to have just as little on your average project.
