### PR TITLE
Fragment caching currently disregards block content when caching is turned off

### DIFF
--- a/padrino-cache/lib/padrino-cache/helpers/fragment.rb
+++ b/padrino-cache/lib/padrino-cache/helpers/fragment.rb
@@ -60,6 +60,9 @@ module Padrino
               logger.debug "SET Fragment", began_at, key.to_s if defined?(logger)
               concat_content(value)
             end
+          else
+            value = capture_html(&block)
+            concat_content(value)   
           end
         end
       end # Fragment


### PR DESCRIPTION
see https://gist.github.com/1366727 for credit for the original fix. Seems like it was never pulled.  Right now if you run your site in development say with caching off, all fragment cache blocks are ignored.  It really should just execute them as if it is always a cache miss when caching is off.
