### PR TITLE
Correctly report the loaded console environment when set via environment variables

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -60,10 +60,10 @@ module Padrino
         prepare :console
         require File.expand_path("../../version", __FILE__)
         ARGV.clear
-        puts "=> Loading #{options.environment} console (Padrino v.#{Padrino.version})"
         require 'irb'
         require "irb/completion"
         require File.expand_path('config/boot.rb')
+        puts "=> Loading #{Padrino.env} console (Padrino v.#{Padrino.version})"
         require File.expand_path('../console', __FILE__)
         IRB.start
       end


### PR DESCRIPTION
This is a very simple patch that correctly reports which console environment is loading when the environment is set via environment variables.

Currently the environment is always reported as development unless you use "-e production"
