### PR TITLE
write cached css files into the default destination for public stylesheets

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/stylesheets/less.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/stylesheets/less.rb
@@ -6,13 +6,14 @@ LESS_INIT = <<-LESS unless defined?(LESS_INIT)
     # optional - use as necessary
     Rack::Less.configure do |config|
       config.compress = true
+      # config.cache = true
       # other configs ...
     end
     app.use Rack::Less,
-      :root      => app.root,
-      :source    => 'stylesheets/',
-      :public    => 'public/',
-      :hosted_at => '/stylesheets'
+      :root      => Padrino.root,
+      :source    => 'app/stylesheets',
+      :public    => 'public',
+      :hosted_at => 'stylesheets'
 LESS
 
 def setup_stylesheet


### PR DESCRIPTION
Rack-Less' configs are confusing:
When using rack-less' caching feature, the `:hosted_at` config is used as a path suffix to `:public` to get the destination where rack-less will write css files into. 
So the actual cache path is something like `:root/:public/:hosted_at`

To get css files cached into "public/stylesheet", either
- `:root` needs to point to `Padrino.root` and `:public` to `public` or
- `:root` needs to point to `app.root` and `:public` to `../public`

Since Padrino's sass and scss templates are using "app/stylesheets" and "public/stylesheets", I picked the first approach. 
