### PR TITLE
fix reloader issue with some gems that redefine Class#name (like pry)

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -103,7 +103,7 @@ module Padrino
       # We lock dependencies sets to prevent reloading of protected constants
       #
       def lock!
-        klasses = ObjectSpace.classes.map { |klass| klass.to_s.split('::')[0] }.uniq
+        klasses = ObjectSpace.classes.map { |klass| klass._orig_name.split('::')[0] }.uniq
         klasses = klasses | Padrino.mounted_apps.map { |app| app.app_class }
         Padrino::Reloader.exclude_constants.concat(klasses)
       end
@@ -252,3 +252,4 @@ module Padrino
     end
   end # Reloader
 end # Padrino
+

--- a/padrino-core/lib/padrino-core/support_lite.rb
+++ b/padrino-core/lib/padrino-core/support_lite.rb
@@ -194,6 +194,13 @@ end
 I18n.load_path += Dir["#{File.dirname(__FILE__)}/locale/*.yml"] if defined?(I18n)
 
 ##
+# Make sure we can always use the class name
+#
+class Module
+  alias :_orig_name :to_s
+end
+
+##
 # Used to determine if this file has already been required
 #
 module SupportLite; end


### PR DESCRIPTION
`padrino start` doesn't work when using 'pry'
