### PR TITLE
remove tlsmail dependency - already in mail gem

### DIFF
--- a/padrino-mailer/padrino-mailer.gemspec
+++ b/padrino-mailer/padrino-mailer.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency("padrino-core", Padrino.version)
   s.add_dependency("mail", "~> 2.3.0")
-  s.add_dependency("tlsmail") if RUBY_VERSION == "1.8.6"
 end


### PR DESCRIPTION
mail >= 2.3.0 has:
  gem "tlsmail" if RUBY_VERSION <= '1.8.6'
