### PR TITLE
Adding an options attribute to ProjectModule

### DIFF
--- a/padrino-admin/lib/padrino-admin/access_control.rb
+++ b/padrino-admin/lib/padrino-admin/access_control.rb
@@ -145,9 +145,9 @@ module Padrino
         ##
         # Create a project module
         #
-        def project_module(name, path)
+        def project_module(name, path, options={})
           allow(path)
-          @project_modules << ProjectModule.new(name, path)
+          @project_modules << ProjectModule.new(name, path, options)
         end
       end # Authorization
 
@@ -155,10 +155,10 @@ module Padrino
       # Project Module class
       #
       class ProjectModule
-        attr_reader :name
+        attr_reader :name, :options
 
-        def initialize(name, path) # @private
-          @name, @path = name, path
+        def initialize(name, path, options={}) # @private
+          @name, @path, @options = name, path, options
         end
 
         ##


### PR DESCRIPTION
Hi,

Here is a patch to add an `options` attribute to the `ProjectModule` class in admin.
The cost is pretty lightweight but it allows to do some nice things in admin.

Using this patch I was able to make this:

``` ruby
# admin/app.rb
class Admin < Padrino::Application
  # ...

  access_control.roles_for :admin do |role|
    role.project_module :thing_1,  '/thing_1', :group => :things
    role.project_module :thing_2,  '/thing_2', :group => :things
    role.project_module :stuff,    '/stuff'
    role.project_module :other,    '/other'
    role.project_module :accounts, '/accounts'
  end
end
```

``` erb
<%# admin/views/layouts/application.erb %>
<div id="main-navigation">
  <ul class="wat-cf">
    <% project_modules.group_by { |pm| pm.options[:group] }.each do |group, modules| %>
      <% if group %>
        <li class="dropdown">
          <%= mt group %>
          <ul>
            <%= partial "shared/admin_menu_item", collection: modules %>
          </ul>
        </li>
      <% else %>
        <%= partial "shared/admin_menu_item", collection: modules %>
      <% end %>
  </ul>
</div>
```

And now I have dropdown tabs in my admin :)

I know it's not the prettiest code in the world but it was just an example of what could be possible with just this very light addition :)
