### PR TITLE
Fix #780. Found that some templates wasn't aware of the user-defined model name in admin generator.

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -109,7 +109,9 @@ module Padrino
           add_project_module model_plural
           require_dependencies('bcrypt-ruby', :require => 'bcrypt')
           gsub_file destination_root("admin/views/#{model_plural}/_form.#{ext}"), "f.text_field :role, :class => :text_field", "f.select :role, :options => access_control.roles"
+          gsub_file destination_root("admin/views/layouts/application.#{ext}"), ":accounts", ":#{model_plural}"
           gsub_file destination_root("admin/controllers/#{model_plural}.rb"), "if #{model_singular}.destroy", "if #{model_singular} != current_account && #{model_singular}.destroy"
+          gsub_file destination_root("admin/controllers/sessions.rb"), "Account.", "#{options[:admin_model]}."
           return if self.behavior == :revoke
 
           instructions = []


### PR DESCRIPTION
Some templates wasn't aware of a custom model name, hopefully this commit fixes all the issues.

After a while using the admin generator I discovered that this same issue was affecting other areas of the code. I corrected all the issues that I found and I've been using the generator for a month now without incidences, so I'm requesting a new pull with my code. :)
