### PR TITLE
Patched to fix rake use in padrino templates. 

### DIFF
--- a/padrino-core/lib/padrino-core/cli/rake.rb
+++ b/padrino-core/lib/padrino-core/cli/rake.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../tasks', __FILE__)
 require 'rake'
+require 'rake/dsl_definition'
 require 'thor'
 require 'securerandom' unless defined?(SecureRandom)
 


### PR DESCRIPTION
Just adding the 'rake/dsl_definition' requirement to allow rake to be run by project templates.
