### PR TITLE
Fixed broken link in HAML version of the admin layout

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/haml/app/layouts/application.haml.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/haml/app/layouts/application.haml.tt
@@ -27,5 +27,5 @@
                 Copyright &copy;
                 =Time.now.year
                 Your Site - Powered by
-                =link_to "Padrino v.#{Padrino.version}", "http://www.padrinorb.com/", :target => :_blank
+                =link_to "Padrino v.#{Padrino.version}", "https://github.com/padrino/padrino-framework", :target => :_blank
         #sidebar=yield_content :sidebar


### PR DESCRIPTION
The HAML version of the footer pointed to an incorrect link on github, resulting in 404. Changed the link to match the ERB version and to link to the padrino/padrino-framework repository.
