### PR TITLE
Add CLI console shortcut with just 'c'

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -68,6 +68,11 @@ module Padrino
         IRB.start
       end
 
+      desc "c", "Boots up the Padrino application irb console"
+      def c(*args)
+        invoke(:console, args)
+      end
+
       desc "generate", "Executes the Padrino generator with given options."
       def generate(*args)
         # Build Padrino g as an alias of padrino-gen


### PR DESCRIPTION
This just adds support for "padrino c" to open up the console just as "rails c" does
## 

I'm nearly always going on the console to test out some model code, and so I added this small change to make my life a little easier. 
