### PR TITLE
Admin generator generates broken session controller

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -55,17 +55,17 @@ module Padrino
           self.behavior = :revoke if options[:destroy]
 
           empty_directory destination_root("admin")
-          directory "templates/app",       destination_root("admin")
-          directory "templates/assets",    destination_root("public", "admin")
-          template  "templates/app.rb.tt", destination_root("admin/app.rb")
-          append_file destination_root("config/apps.rb"),  "\nPadrino.mount(\"Admin\").to(\"/admin\")"
-          insert_middleware 'ActiveRecord::ConnectionAdapters::ConnectionManagement', 'admin' if [:mini_record, :activerecord].include?(orm)
-
 
           # Setup Admin Model
           @model_name     = options[:admin_model].classify
           @model_singular = @model_name.underscore
           @model_plural   = @model_singular.pluralize
+
+          directory "templates/app",       destination_root("admin")
+          directory "templates/assets",    destination_root("public", "admin")
+          template  "templates/app.rb.tt", destination_root("admin/app.rb")
+          append_file destination_root("config/apps.rb"),  "\nPadrino.mount(\"Admin\").to(\"/admin\")"
+          insert_middleware 'ActiveRecord::ConnectionAdapters::ConnectionManagement', 'admin' if [:mini_record, :activerecord].include?(orm)
 
           params = [
             @model_singular, "name:string", "surname:string", "email:string", "crypted_password:string", "role:string",


### PR DESCRIPTION
templates for session controller and `app.rb` need to know about the `@model_name`
