### PR TITLE
still some issues with reloader and jruby

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -183,8 +183,8 @@ module Padrino
       # Removes the specified class and constant.
       #
       def remove_constant(const)
-        return if exclude_constants.compact.uniq.any? { |c| const.name.index(c) == 0 } &&
-                 !include_constants.compact.uniq.any? { |c| const.name.index(c) == 0 }
+        return if exclude_constants.compact.uniq.any? { |c| const._orig_klass_name.index(c) == 0 } &&
+                 !include_constants.compact.uniq.any? { |c| const._orig_klass_name.index(c) == 0 }
         begin
           parts  = const.to_s.sub(/^::(Object)?/, 'Object::').split('::')
           object = parts.pop


### PR DESCRIPTION
if you create a new project with jruby and sequel using sqlite you'll get the following error:

``` ruby
ArgumentError: Java package `java.name.name.name.name.name.name.name.name' does not have a method `index'
        method_missing at /home/erubboli/.rvm/rubies/jruby-1.6.7/lib/ruby/site_ruby/shared/builtin/javasupport/java.rb:50
       remove_constant at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/reloader.rb:186
                  any? at org/jruby/RubyEnumerable.java:1355
       remove_constant at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/reloader.rb:186
             safe_load at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/reloader.rb:164
                  each at org/jruby/RubyArray.java:1615
             safe_load at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/reloader.rb:164
  require_dependencies at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/loader.rb:163
                  each at org/jruby/RubyArray.java:1615
  require_dependencies at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/loader.rb:161
                 load! at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/loader.rb:70
                  each at org/jruby/RubyArray.java:1615
                 load! at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/lib/padrino-core/loader.rb:70
                (root) at /home/erubboli/projects/elc/vfdb-api/config/boot.rb:29
               require at org/jruby/RubyKernel.java:1042
                  rake at /home/erubboli/projects/elc/vfdb-api/config/boot.rb:54
              __send__ at org/jruby/RubyBasicObject.java:1698
                  send at org/jruby/RubyKernel.java:2097
                   run at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/gems/thor-0.14.6/lib/thor/task.rb:21
           invoke_task at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/gems/thor-0.14.6/lib/thor/invocation.rb:118
              dispatch at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/gems/thor-0.14.6/lib/thor.rb:263
                 start at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/gems/thor-0.14.6/lib/thor/base.rb:389
                (root) at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bundler/gems/padrino-framework-78329337e6bc/padrino-core/bin/padrino:9
                  load at org/jruby/RubyKernel.java:1068
                (root) at /home/erubboli/.rvm/gems/jruby-1.6.7@vfdb-api/bin/padrino:19
```

this fixes the issue using the same logic used in https://github.com/padrino/padrino-framework/commit/865d67c414290aa6a596cd1f478b205996abae08
