### PR TITLE
fix for undefined method crypted_password

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
@@ -38,7 +38,7 @@ class <%= @model_name %> < ::Sequel::Model
   end
 
   def has_password?(password)
-    ::BCrypt::Password.new(crypted_password) == password
+    ::BCrypt::Password.new(self.crypted_password) == password
   end
 
   private
@@ -47,6 +47,6 @@ class <%= @model_name %> < ::Sequel::Model
   end
 
   def password_required
-    crypted_password.blank? || password.present?
+    self.crypted_password.blank? || password.present?
   end
 end


### PR DESCRIPTION
After deploying my app to heroku and trying to log into the admin interface I got the following error:

NameError - undefined local variable or method `crypted_password' for #Account:0x...

This seems to be the same as #322 and occurs only when using Sequel ORM with a Postgresql database. Calling self.crypted_password instead of crypted_password in the Account model resolves this error.
