### PR TITLE
error_message_on should check for empty Array

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -244,11 +244,12 @@ module Padrino
       def error_message_on(object, field, options={})
         object = object.is_a?(Symbol) ? instance_variable_get("@#{object}") : object
         error  = object.errors[field] rescue nil
+        # Array(error).first is necessary because some ORMs give us an array others directly a value
+        error  = Array(error).first
         if error
           options.reverse_merge!(:tag => :span, :class => :error)
           tag   = options.delete(:tag)
-          # Array(error).first is necessary because some orm give us an array others directly a value
-          error = [options.delete(:prepend), Array(error).first, options.delete(:append)].compact.join(" ")
+          error = [options.delete(:prepend), error, options.delete(:append)].compact.join(" ")
           content_tag(tag, error, options)
         else
           ''

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -177,6 +177,12 @@ describe "FormHelpers" do
       actual_html = error_message_on(:user, :fake, :prepend => "foo", :append => "bar")
       assert actual_html.blank?
     end
+
+    should "display no message when error isn't present in an Array" do
+      @user = mock_model("User", :errors => { :a => [], :b => "2" }, :blank? => false)
+      actual_html = error_message_on(:user, :a, :prepend => "foo", :append => "bar")
+      assert actual_html.blank?
+    end
   end
 
   context 'for #label_tag method' do


### PR DESCRIPTION
`ActiveModel::Validations` will return an empty array if there are no errors.

Currently `error_message_on` checks for a non-nil value before rendering an error message:
https://github.com/padrino/padrino-framework/blob/master/padrino-helpers/lib/padrino-helpers/form_helpers.rb#L247

Empty arrays will cause the error HTML to be generated.
