### PR TITLE
Make mysql2 a alias of mysql when DataMapper is selected

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
@@ -32,7 +32,7 @@ def setup_orm
     dm-validations
   ).each { |dep| require_dependencies dep }
   require_dependencies case options[:adapter]
-    when 'mysql'
+    when 'mysql', 'mysql2'
       dm.gsub!(/!DB_DEVELOPMENT!/,"\"mysql://root@localhost/#{db}_development\"")
       dm.gsub!(/!DB_PRODUCTION!/,"\"mysql://root@localhost/#{db}_production\"")
       dm.gsub!(/!DB_TEST!/,"\"mysql://root@localhost/#{db}_test\"")

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -263,6 +263,14 @@ describe "ProjectGenerator" do
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
       end
 
+      # DataMapper has do_mysql that is the version of MySQL driver.
+      should "properly generate for mysql2" do
+        out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=datamapper', '--adapter=mysql2') }
+        assert_match_in_file(/gem 'dm-mysql-adapter'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(%r{"mysql://}, "#{@apptmp}/sample_project/config/database.rb")
+        assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
+      end
+
       should "properly generate for sqlite" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=datamapper', '--adapter=sqlite') }
         assert_match_in_file(/gem 'dm-sqlite-adapter'/, "#{@apptmp}/sample_project/Gemfile")


### PR DESCRIPTION
DataMapper has `do_mysql' that is the version of MySQL driver.
So`mysql2' should be considered as a alias of `mysql' adapter.
