### PR TITLE
add require ActiveSupport::TimeWithZone class at padrino-helpers #858

### DIFF
--- a/padrino-helpers/lib/padrino-helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers.rb
@@ -2,6 +2,7 @@ require 'padrino-core/support_lite' unless defined?(SupportLite)
 require 'cgi'
 require 'i18n'
 require 'enumerator'
+require 'active_support/time_with_zone'               # next extension depends on this
 require 'active_support/core_ext/string/conversions'  # to_date
 require 'active_support/core_ext/float/rounding'      # round
 require 'active_support/option_merger'                # with_options


### PR DESCRIPTION
See Also: #858
I tried to fix broken padrino-helpers dependenies, and here is the solution for it.
All tests succeed at ruby 1.9.3-p194 and 1.8.7-p358 version.

Incidentally, gems version which I used is following .

``` sh
|--[namai][mbp][±][bug_fix ✗][1.8.7][~/workspace/prog/ruby/padrino_test]
+---> gem list

*** LOCAL GEMS ***

activesupport (3.2.5)
addressable (2.2.8)
bcrypt-ruby (3.0.1)
bson (1.6.3)
bson_ext (1.6.3)
builder (3.0.0)
bundler (1.1.4)
dalli (2.0.5)
data_objects (0.10.8)
diff-lcs (1.1.3)
dm-aggregates (1.2.0)
dm-core (1.2.0)
dm-do-adapter (1.2.0)
dm-migrations (1.2.0)
dm-sqlite-adapter (1.2.0)
dm-validations (1.2.0)
do_sqlite3 (0.10.8)
erubis (2.7.0)
fakeweb (1.3.0)
grit (2.5.0)
haml (3.1.6)
http_router (0.10.2)
i18n (0.6.0)
json (1.7.3)
lumberjack (1.0.2)
macaddr (1.6.1)
mail (2.3.3)
memcached (1.4.1)
metaclass (0.0.1)
mime-types (1.18)
minitest (2.6.2)
mocha (0.10.5)
mongo (1.6.3)
multi_json (1.3.6)
nokogiri (1.5.3)
polyglot (0.3.3)
posix-spawn (0.3.6)
rack (1.4.1)
rack-protection (1.2.0)
rack-test (0.6.1)
rake (0.9.2.2, 0.8.7)
redis (3.0.1)
sinatra (1.3.2)
slim (1.2.1)
system_timer (1.2.4)
systemu (2.5.1)
temple (0.4.0)
thor (0.14.6)
tilt (1.3.3)
treetop (1.4.10)
url_mount (0.2.1)
uuid (2.3.5)
webrat (0.7.3)
yard (0.8.1)
```
