### PR TITLE
`render [:some, "array"]` renders JSON

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering.rb
+++ b/padrino-core/lib/padrino-core/application/rendering.rb
@@ -156,7 +156,7 @@ module Padrino
         #
         def render(engine, data=nil, options={}, locals={}, &block)
           # If engine is a hash then render data converted to json
-          content_type(:json, :charset => 'utf-8') and return engine.to_json if engine.is_a?(Hash)
+          content_type(:json, :charset => 'utf-8') and return engine.to_json if engine.is_a?(Hash) || engine.is_a?(Array)
 
           # If engine is nil, ignore engine parameter and shift up all arguments
           # render nil, "index", { :layout => true }, { :localvar => "foo" }

--- a/padrino-core/test/test_rendering.rb
+++ b/padrino-core/test/test_rendering.rb
@@ -457,5 +457,23 @@ describe "Rendering" do
       assert ok?
       assert_equal 'THIS. IS. SPARTA!', body
     end
+
+    should 'renders hashes and arrays as json' do
+      mock_app do
+        get '/hash' do
+          render({:a => 1, :b => 2})
+        end
+
+        get '/array' do
+          render [:a, 1, :b, 2]
+        end
+      end
+      get '/hash'
+      assert ok?
+      assert_equal '{"a":1,"b":2}', body
+      get '/array'
+      assert ok?
+      assert_equal '["a",1,"b",2]', body
+    end
   end
 end


### PR DESCRIPTION
Previously `render` would `to_s` the array and look for a template by that name...
