### PR TITLE
Missing = in the admin generator erb page templates

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/page/edit.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/page/edit.erb.tt
@@ -7,7 +7,7 @@
     </ul>
   </div>
   <div class="content">
-    <h2 class="title"><%%= pat(:edit) %> <%% mt(:<%= @orm.name_singular %>) %></h2>
+    <h2 class="title"><%%= pat(:edit) %> <%%= mt(:<%= @orm.name_singular %>) %></h2>
     <div class="inner">
       <%% form_for :<%= @orm.name_singular %>, url(:<%= @orm.name_plural %>, :update, :id => @<%= @orm.name_singular %>.id), :method => :put, :class => :form do |f| %>
         <%%= partial "<%= @orm.name_plural %>/form", :locals => { :f => f } %>

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/page/index.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/page/index.erb.tt
@@ -6,7 +6,7 @@
     </ul>
   </div>
   <div class="content">
-    <h2 class="title"><%%= pat(:all) %> <%% mt(:<%= @orm.name_plural %>) %></h2>
+    <h2 class="title"><%%= pat(:all) %> <%%= mt(:<%= @orm.name_plural %>) %></h2>
     <div class="inner">
       <table class="table">
         <tr>

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/page/new.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/page/new.erb.tt
@@ -6,7 +6,7 @@
     </ul>
   </div>
   <div class="content">
-    <h2 class="title"><%%= pat(:new) %> <%% mt(:<%= @orm.name_singular %>) %></h2>
+    <h2 class="title"><%%= pat(:new) %> <%%= mt(:<%= @orm.name_singular %>) %></h2>
     <div class="inner">
       <%% form_for :<%= @orm.name_singular %>, url(:<%= @orm.name_plural %>, :create), :class => :form do |f| %>
         <%%= partial "<%= @orm.name_plural %>/form", :locals => { :f => f } %>


### PR DESCRIPTION
The erb templates in the admin generator were missing = from <%%=
mt(:<%= @orm.name_plural %>) %> so the @orm.name_plural value wasn't
being added to the page output.
