### PR TITLE
Padrino's Logger is Confusing and Broken

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -257,13 +257,13 @@ module Padrino
 
     @@mutex = Mutex.new
     def self.logger
-      @@logger || setup!
+      @logger || setup!
     end
 
     def self.logger=(logger)
       logger.extend(Padrino::Logger::Extensions)
 
-      @@logger = logger
+      @logger = logger
     end
 
     ##


### PR DESCRIPTION
Can we please rip out the Padrino Logger and use what the Standard Library gives us?  There have been countless thread-safety bugs, and they exist because the Padrino library is written by people whose day job does not involve any kind of serious threading.  I'm not being derisive -- there's nothing wrong with that.  It just means that threading nuances should be avoided when and where possible.

I am hitting an Open Files limit.  Padrino is opening the log file once for each thread, and it is preventing that log file from being closed (ie, garbage collected) because it is caching the logger in a class-variable (the mutex table).  It also makes no sense why a Mutex table is being kept, when the logger lives in a thread-local.

Either we should have one (and only one) logger, wrapped in a mutex, or there should be many with no mutex.

Patch is coming after I go and get lunch.

Edit: The end result was to simply wrap one logger in a shared mutex.  This is the most sane way to do it.
