### PR TITLE
Remove duplicated command-line and new shortcut for stop 

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -6,17 +6,17 @@ module Padrino
     class Base < Thor
       include Thor::Actions
 
-      class_option :chdir, :type => :string, :aliases => "-c", :desc => "Change to dir before starting"
-      class_option :environment, :type => :string,  :aliases => "-e", :required => true, :default => :development, :desc => "Padrino Environment"
+      class_option :chdir, :type => :string, :aliases => "-c", :desc => "Change to dir before starting."
+      class_option :environment, :type => :string,  :aliases => "-e", :required => true, :default => :development, :desc => "Padrino Environment."
       class_option :help, :type => :boolean, :desc => "Show help usage"
 
-      desc "start", "Starts the Padrino application (alternatively use 's')"
+      desc "start", "Starts the Padrino application (alternatively use 's')."
       method_option :server,    :type => :string,  :aliases => "-a", :desc => "Rack Handler (default: autodetect)"
-      method_option :host,      :type => :string,  :aliases => "-h", :required => true, :default => "0.0.0.0", :desc => "Bind to HOST address"
-      method_option :port,      :type => :numeric, :aliases => "-p", :required => true, :default => 3000, :desc => "Use PORT"
-      method_option :daemonize, :type => :boolean, :aliases => "-d", :desc => "Run daemonized in the background"
-      method_option :pid,       :type => :string,  :aliases => "-i", :desc => "File to store pid"
-      method_option :debug,     :type => :boolean,                   :desc => "Set debugging flags"
+      method_option :host,      :type => :string,  :aliases => "-h", :required => true, :default => "0.0.0.0", :desc => "Bind to HOST address."
+      method_option :port,      :type => :numeric, :aliases => "-p", :required => true, :default => 3000, :desc => "Use PORT."
+      method_option :daemonize, :type => :boolean, :aliases => "-d", :desc => "Run daemonized in the background."
+      method_option :pid,       :type => :string,  :aliases => "-i", :desc => "File to store pid."
+      method_option :debug,     :type => :boolean,                   :desc => "Set debugging flags."
       def start
         prepare :start
         require File.expand_path("../adapter", __FILE__)
@@ -28,7 +28,7 @@ module Padrino
         invoke :start
       end
 
-      desc "stop", "Stops the Padrino application (alternatively use 'st')"
+      desc "stop", "Stops the Padrino application (alternatively use 'st')."
       method_option :pid, :type => :string,  :aliases => "-p", :desc => "File to store pid", :default => 'tmp/pids/server.pid'
       def stop
         prepare :stop
@@ -40,7 +40,7 @@ module Padrino
         invoke :stop
       end
 
-      desc "rake", "Execute rake tasks"
+      desc "rake", "Execute rake tasks."
       method_option :environment, :type => :string,  :aliases => "-e", :required => true, :default => :development
       method_option :list,        :type => :string,  :aliases => "-T", :desc => "Display the tasks (matching optional PATTERN) with descriptions, then exit."
       method_option :trace,       :type => :boolean, :aliases => "-t", :desc => "Turn on invoke/execute tracing, enable full backtrace."
@@ -58,7 +58,7 @@ module Padrino
         PadrinoTasks.init(true)
       end
 
-      desc "console", "Boots up the Padrino application irb console (alternatively use 'c')"
+      desc "console", "Boots up the Padrino application irb console (alternatively use 'c')."
       def console
         prepare :console
         require File.expand_path("../../version", __FILE__)
@@ -75,7 +75,7 @@ module Padrino
         invoke(:console, args)
       end
 
-      desc "generate", "Executes the Padrino generator with given options (alternatively use 'gen' or 'g')"
+      desc "generate", "Executes the Padrino generator with given options (alternatively use 'gen' or 'g')."
       def generate(*args)
         # Build Padrino g as an alias of padrino-gen
         begin
@@ -92,15 +92,15 @@ module Padrino
         end
       end
 
-      def g(*args)
-        invoke(:generate, args)
-      end
-
       def gen(*args)
         invoke(:generate, args)
       end
 
-      desc "version", "Show current Padrino Version"
+      def g(*args)
+        invoke(:generate, args)
+      end
+
+      desc "version", "Show current Padrino version."
       map "-v" => :version, "--version" => :version
       def version
         require 'padrino-core/version'


### PR DESCRIPTION
When running `$ padrino` I see a lot of repeating options in the description of the commands:

```
$ padrino
Tasks:
  padrino c         # Boots up the Padrino application irb console
  padrino console   # Boots up the Padrino application irb console
  padrino g         # Executes the Padrino generator with given options.
  padrino gen       # Executes the Padrino generator with given options.
  padrino generate  # Executes the Padrino generator with given options.
  padrino help      # Describe available tasks or one specific task
  padrino rake      # Execute rake tasks
  padrino s         # Starts the Padrino application
  padrino start     # Starts the Padrino application
  padrino stop      # Stops the Padrino application
  padrino version   # Show current Padrino Version
```

It would be nice to sum up the different commands with a different description:

```
padrino console   # Boots up the Padrino application irb console (alternatively use 'c').
padrino generate  # Executes the Padrino generator with given options (alternatively use 'gen' or 'g').
padrino start     # Starts the Padrino application (alternatively use 's') 
padrino stop      # Stops the Padrino application (alternatively use 'st')
```
