### PR TITLE
thor complains about missing task descriptions

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -11,6 +11,7 @@ module Padrino
       class_option :help, :type => :boolean, :desc => "Show help usage"
 
       desc "start", "Starts the Padrino application (alternatively use 's')."
+      map "s" => :start
       method_option :server,    :type => :string,  :aliases => "-a", :desc => "Rack Handler (default: autodetect)"
       method_option :host,      :type => :string,  :aliases => "-h", :required => true, :default => "0.0.0.0", :desc => "Bind to HOST address."
       method_option :port,      :type => :numeric, :aliases => "-p", :required => true, :default => 3000, :desc => "Use PORT."
@@ -24,20 +25,13 @@ module Padrino
         Padrino::Cli::Adapter.start(options)
       end
 
-      def s
-        invoke :start
-      end
-
       desc "stop", "Stops the Padrino application (alternatively use 'st')."
+      map "st" => :stop
       method_option :pid, :type => :string,  :aliases => "-p", :desc => "File to store pid", :default => 'tmp/pids/server.pid'
       def stop
         prepare :stop
         require File.expand_path("../adapter", __FILE__)
         Padrino::Cli::Adapter.stop(options)
-      end
-
-      def st
-        invoke :stop
       end
 
       desc "rake", "Execute rake tasks."
@@ -59,7 +53,8 @@ module Padrino
       end
 
       desc "console", "Boots up the Padrino application irb console (alternatively use 'c')."
-      def console
+      map "c" => :console
+      def console(*args)
         prepare :console
         require File.expand_path("../../version", __FILE__)
         ARGV.clear
@@ -71,11 +66,8 @@ module Padrino
         IRB.start
       end
 
-      def c(*args)
-        invoke(:console, args)
-      end
-
       desc "generate", "Executes the Padrino generator with given options (alternatively use 'gen' or 'g')."
+      map ["gen", "g"] => :generate
       def generate(*args)
         # Build Padrino g as an alias of padrino-gen
         begin
@@ -92,16 +84,8 @@ module Padrino
         end
       end
 
-      def gen(*args)
-        invoke(:generate, args)
-      end
-
-      def g(*args)
-        invoke(:generate, args)
-      end
-
       desc "version", "Show current Padrino version."
-      map "-v" => :version, "--version" => :version
+      map ["-v", "--version"] => :version
       def version
         require 'padrino-core/version'
         puts "Padrino v. #{Padrino.version}"


### PR DESCRIPTION
Most padrino tasks with a shortcut (`s` => `start`, `g` => `generate`, etc...) don't have an associated usage or description. Thor puts a warning like this:

```
[WARNING] Attempted to create task "g" without usage or description. Call desc if you want this method to be available as task or declare it inside a no_tasks{} block. Invoked from "/home/vagrant/.rvm/gems/ruby-1.9.3-p194/bundler/gems/padrino-framework-c400f66fba6e/padrino-core/lib/padrino-core/cli/base.rb:99:in `<class:Base>'".
```

Instead of defining a new task and invoking the other, wouldn't be thor's `map` a better alternative (eg. `map ["gen", "g"] => :generate`)? 
