### PR TITLE
Also require dm-types

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
@@ -25,6 +25,7 @@ def setup_orm
   db = @app_name.underscore
   %w(
     dm-core
+    dm-types
     dm-aggregates
     dm-constraints
     dm-migrations


### PR DESCRIPTION
It's fairly difficult to write a DataMapper app without using dm-types.
