### PR TITLE
Graceful rake task loading

### DIFF
--- a/padrino-core/lib/padrino-core/cli/rake_tasks.rb
+++ b/padrino-core/lib/padrino-core/cli/rake_tasks.rb
@@ -1,5 +1,11 @@
 # Load rake tasks from common rake task definition locations
-Dir["{lib/tasks/**,tasks/**,test,spec}/*.rake"].each  { |rake| load(rake) }
+Dir["{lib/tasks/**,tasks/**,test,spec}/*.rake"].each do |file|
+  begin
+    load(file)
+  rescue LoadError => e
+    warn "#{file}: #{e.message}"
+  end
+end
 
 # Loads the Padrino applications mounted within the project
 # setting up the required environment for Padrino


### PR DESCRIPTION
When loading the various `.rake` files, if one cannot be loaded simply print a warning message and carry on. This will allow a developer to run `padrino rake dm:migrate` in production where the development/test dependencies were not bundled (`bundle install --deployment --without development test`; thus `spec/spec.rake` cannot be loaded due to rspec not being bundled).
