### PR TITLE
Added Puma as a server handler

### DIFF
--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -17,7 +17,7 @@ module Padrino
   #
   class Server < Rack::Server
     # Server Handlers
-    Handlers = [:thin, :mongrel, :trinidad, :webrick]
+    Handlers = [:thin, :puma, :mongrel, :trinidad, :webrick]
 
     # Starts the application on the available server with specified options.
     def self.start(app, opts={})


### PR DESCRIPTION
[Puma](http://puma.io) is, as defined on the official repo: "a simple, fast, and highly concurrent HTTP 1.1 server for Ruby web applications".

It's screamingly fast and consumes way less memory than other alternatives.

I thought it would be nice to include it in the list of handlers so that if it appears on the gems for your project Padrino would pick it up straight away.
