### PR TITLE
Avoide change_table's remove migration's deprecation message in AR

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/actions.rb
@@ -67,6 +67,7 @@ module Padrino
           else
             return if migration_exist?(filename)
             change_format = options[:change_format]
+            remove_format = options[:remove_format]
             migration_scan = filename.underscore.camelize.scan(/(Add|Remove)(?:.*?)(?:To|From)(.*?)$/).flatten
             direction, table_name = migration_scan[0].downcase, migration_scan[1].downcase.pluralize if migration_scan.any?
             tuples = direction ? columns.map { |value| value.split(":") } : []
@@ -74,7 +75,7 @@ module Padrino
             add_columns    = tuples.map(&options[:add]).join("\n    ")
             remove_columns = tuples.map(&options[:remove]).join("\n    ")
             forward_text = change_format.gsub(/!TABLE!/, table_name).gsub(/!COLUMNS!/, add_columns) if tuples.any?
-            back_text    = change_format.gsub(/!TABLE!/, table_name).gsub(/!COLUMNS!/, remove_columns) if tuples.any?
+            back_text    = remove_format.gsub(/!TABLE!/, table_name).gsub(/!COLUMNS!/, remove_columns) if tuples.any?
             contents = options[:base].dup.gsub(/\s{4}!UP!\n/m,   (direction == 'add' ? forward_text.to_s : back_text.to_s))
             contents.gsub!(/\s{4}!DOWN!\n/m, (direction == 'add' ? back_text.to_s : forward_text.to_s))
             contents = contents.gsub(/!FILENAME!/, filename.underscore).gsub(/!FILECLASS!/, filename.underscore.camelize)

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -172,10 +172,14 @@ change_table :!TABLE! do |t|
 end
 MIGRATION
 
+AR_REMOVE_MG = (<<-MIGRATION).gsub(/^/, '    ') unless defined?(AR_REMOVE_MG)
+remove_columns :!TABLE!, !COLUMNS!
+MIGRATION
+
 def create_migration_file(migration_name, name, columns)
   output_migration_file(migration_name, name, columns,
-    :base => AR_MIGRATION, :change_format => AR_CHANGE_MG,
+    :base => AR_MIGRATION, :change_format => AR_CHANGE_MG, :remove_format => AR_REMOVE_MG,
     :add => Proc.new { |field, kind| "t.#{kind.underscore.gsub(/_/, '')} :#{field}" },
-    :remove => Proc.new { |field, kind| "t.remove :#{field}" }
+    :remove => Proc.new { |field, kind| ":#{field}" }
   )
 end


### PR DESCRIPTION
Avoide change_table's remove migration's deprecation message in ActiveRecord:

DEPRECATION WARNING: Passing array to remove_columns is deprecated,
please use multiple arguments, like: `remove_columns(:posts, :foo,
:bar)`.
