### PR TITLE
Use haml ugly syntax by default on production env

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -181,6 +181,11 @@ module Padrino
         set :views, Proc.new { File.join(root,   "views") }
         set :images_path, Proc.new { File.join(public, "images") }
         set :protection, false
+        # haml engine
+        if Padrino.env == :production && defined?(Haml)
+          set :haml, {:ugly => true}
+        end
+
         # Padrino specific
         set :uri_root, '/'
         set :app_name, settings.to_s.underscore.to_sym


### PR DESCRIPTION
With this change rendering haml on production is faster and will take
less bandwidth since the generated document is smaller.
