### PR TITLE
Support keys as symbols when expiring cache

### DIFF
--- a/padrino-cache/lib/padrino-cache/helpers/cache_store.rb
+++ b/padrino-cache/lib/padrino-cache/helpers/cache_store.rb
@@ -5,7 +5,7 @@ module Padrino
 
         # @api private
         def expire(*key)
-          if key.size == 1 and key.first.is_a?(String)
+          if key.size == 1 and (key.first.is_a?(String) or key.first.is_a?(Symbol))
             settings.cache.delete(key.first)
           else
             settings.cache.delete(self.class.url(*key))


### PR DESCRIPTION
Correct me if I'm wrong but a cached value can be set using either a String and a Symbol. In other words:

  cache(:something, 'some value')

is the same as:

  cache ('something', 'some value')

I don't know if there's a particular reason not to use Symbols but if you're trying to expire a cached value created using a Symbol key you get an error unless there's an URL on the controller that matches that key, in which case it's even worse since that's not what you're trying to achieve when deleting that key.

I'm attaching a simple patch to support both Symbols and Strings.

Let me know if it should be like that or I'm just missing something.

Thanks
