### PR TITLE
Changed checking of settings.sessions to checking of existence of a rack session.

### DIFF
--- a/padrino-core/lib/padrino-core/application/flash.rb
+++ b/padrino-core/lib/padrino-core/application/flash.rb
@@ -222,7 +222,7 @@ module Padrino
       # @since 0.10.8
       # @api public
       def flash
-        @_flash ||= Storage.new(settings.sessions ? session[:_flash] : {})
+        @_flash ||= Storage.new(env['rack.session'] ? session[:_flash] : {})
       end
     end # Helpers
   end # Flash


### PR DESCRIPTION
This enables Padrino-Flash to be used with any Rack Sessions, instead
of just Rack::Session::Cookie.
