### PR TITLE
Add database files (db/*.db) to .gitignore

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/project/.gitignore
+++ b/padrino-gen/lib/padrino-gen/generators/project/.gitignore
@@ -5,3 +5,4 @@ bin/*
 vendor/gems/*
 !vendor/gems/cache/
 .sass-cache/*
+db/*.db


### PR DESCRIPTION
Added `db/*.db` to the project `.gitignore`. I don't understand why anyone would want to commit their databases by default.
