### PR TITLE
Partial Implementation of Relative Routes

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -626,6 +626,12 @@ module Padrino
           # We need check if path is a symbol, if that it's a named route
           map = options.delete(:map)
 
+          relative_path = false
+          if map == :index
+            map = '/'
+            relative_path = true
+          end
+
           if path.kind_of?(Symbol) # path i.e :index or :show
             name = path                                                # The route name
             path = map ? map.dup : (path == :index ? '/' : path.to_s)  # The route path
@@ -654,7 +660,7 @@ module Padrino
 
             unless controller.empty?
               # Now we need to add our controller path only if not mapped directly
-              if !absolute_map
+              if !absolute_map or relative_path
                 controller_path = controller.join("/")
                 path.gsub!(%r{^\(/\)|/\?}, "")
                 path = File.join(controller_path, path)


### PR DESCRIPTION
Since I've come across Padrino, the main issue I've come across is named routes leading to redundant `map` requests. I saw issue #747, and decided to see what it would take to implement this right now. I know it's slated for release for milestone 0.11.0, but I did it now anyway (seeing as 0.10.8 missed the slated release by 3 months already). I know the tests fail, so I know this probably won't be merged now, especially before 0.10.8.

Here's an example use that shows some of the possible uses:

``` ruby
# app/controllers/users.rb
MyApp.controllers :users do
  get :sign_up, '/sign_up' do
    'sign up'
  end

  get :sign_in, '/sign_in' do
    'sign in'
  end

  get :list, :index do
    'listing all users'
  end

  get :show, ':id' do
    "showing user with id #{params[:id]}"
  end
end
```

```
# $ padrino rake routes
=> Executing Rake routes ...

Application: MyApp
    URL                     REQUEST  PATH
    (:users, :sign, :up)      GET    /sign_up
    (:users, :sign, :in)      GET    /sign_in
    (:users, :list)           GET    /users
    (:users, :show)           GET    /users/:id
```
