### PR TITLE
Revert Thor dependency to 0.15.2 for TorqueBox 2.2.0 compatibility

### DIFF
--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency("tilt", "~> 1.3.0")
   s.add_dependency("sinatra", "~> 1.3.1")
   s.add_dependency("http_router", "~> 0.10.2")
-  s.add_dependency("thor", "~> 0.15.2")
+  s.add_dependency("thor", ">= 0.15.2")
   s.add_dependency("activesupport", "~> 3.2.0")
 end


### PR DESCRIPTION
When using TorqueBox 2.2, Bundler will not install the latest Padrino from GitHub with the updated Thor dependency. It clashes with TorqueBox's Thor version during `bundle install`.

Since the TB Bundler dependency is in a generated file created by a Maven build, I've reverted the version in padrino-core for testing with TorqueBox 2.2. Quick tests seem to be working, but I haven't generated everything. If Thor 0.16.x isn't required then this makes TB easier to work with.
