### PR TITLE
Add mysql gem version string for activerecord

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -100,7 +100,7 @@ def setup_orm
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_test'")
-    require_dependencies 'mysql'
+    require_dependencies 'mysql', :version => "~> 2.8"
   when 'mysql2'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_production'")

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -218,7 +218,7 @@ describe "ProjectGenerator" do
 
       should "properly generate mysql" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=activerecord','--adapter=mysql') }
-        assert_match_in_file(/gem 'mysql'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(/gem 'mysql', '~> 2.8'/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
         assert_match_in_file(%r{:adapter   => 'mysql'}, "#{@apptmp}/sample_project/config/database.rb")
       end


### PR DESCRIPTION
Not to install gem newer than 2.8.

mysql gem 2.9.0 has been out, so project `bundle` will install mysql 2.9.0.

But ActiveRecord 3.2.x mysql adapter requires mysql gem '~> 2.8'
- https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb

so a Gemfile created by `padrino g project -a mysql` occurs a confusing error... "stack level too deep"

This fix should be reverted when Rails 4 released
- https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb

Thanks!
