### PR TITLE
Fix mismatch between sinatra and padrino in arguement size of method

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -493,6 +493,13 @@ module Padrino
         route('HEAD', path, *args, &block)
       end
 
+      # Fix mismatch in verb method arguement size between Sinatra and Padrino
+      def post(path, *args, &block)    route('POST', path, *args, &block)    end
+      def put(path, *args, &block)     route('PUT', path, *args, &block)     end
+      def delete(path, *args, &block)  route('DELETE', path, *args, &block)  end
+      def patch(path, *args, &block)   route('PATCH', path, *args, &block)   end
+      def options(path, *args, &block) route('OPTIONS', path, *args, &block) end
+
       private
         # Parse params from the url method
         def value_to_param(value)

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -786,7 +786,7 @@ describe "Routing" do
     assert_equal "wacky 1-2", body
   end
 
-  should 'apply maps when given path is kind of hash' do
+  should 'apply maps when given path is kind of string' do
     mock_app do
       controllers :admin do
         get(:foobar, "/foo/bar"){ "foobar" }
@@ -794,6 +794,25 @@ describe "Routing" do
     end
     get "/foo/bar"
     assert_equal "foobar", body
+  end
+
+  should 'pass route definition when 3 arguements given' do
+    mock_app do
+      controllers :admin do
+        get(:foobar, "/foo/bar", :provides => [:json]){ "GET it" }
+        post(:foobar2, "/foo/bar", :provides => [:json]){ "POST it" }
+        put(:foobar3, "/foo/bar", :provides => [:json]){ "PUT it" }
+        delete(:foobar4, "/foo/bar", :provides => [:json]){ "DELETE it" }
+      end
+    end
+    get "/foo/bar.json"
+    assert_equal "GET it", body
+    post "/foo/bar.json"
+    assert_equal "POST it", body
+    put "/foo/bar.json"
+    assert_equal "PUT it", body
+    delete "/foo/bar.json"
+    assert_equal "DELETE it", body
   end
 
   should "apply parent to route" do


### PR DESCRIPTION
Currently, DSL like below

``` ruby
App.controller :users do
  post :create, '/users/create', provides: [:json] do
    #... create it
  end
end
```

raises ArgumentError.

Because Sinatra::Base's `post`(and her company) can accept just 2 args.
