### PR TITLE
Fix failing jruby test

### DIFF
--- a/padrino-core/test/test_support_lite.rb
+++ b/padrino-core/test/test_support_lite.rb
@@ -20,7 +20,7 @@ describe "ObjectSpace" do
 
     should "be able to process a the class name given a block" do
       klasses = ObjectSpace.classes do |klass|
-        if klass.to_s =~ /^Padrino::/
+        if klass.name =~ /^Padrino::/
           klass
         end
       end


### PR DESCRIPTION
`klass.to_s` sometimes fails in jruby, if the klass is defined in java world

So I suggest to use `Class#name` in this test
