### PR TITLE
Fix Mongoid documentation link

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/mongoid.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/mongoid.rb
@@ -22,7 +22,7 @@ Mongoid.database = Mongo::Connection.new(host, port).db(database_name)
 #   ]
 # end
 #
-# More installation and setup notes are on http://mongoid.org/docs/
+# More installation and setup notes are on http://mongoid.org/
 MONGO
 
 MONGOID3YML = (<<-MONGO) unless defined?(MONGOID3YML)


### PR DESCRIPTION
http://mongoid.org/docs/ = 404

URL was moved over time, new official link is http://mongoid.org this one according to https://rubygems.org/gems/mongoid
