### PR TITLE
Lazily load the mail gem without autoload

### DIFF
--- a/padrino-mailer/lib/padrino-mailer.rb
+++ b/padrino-mailer/lib/padrino-mailer.rb
@@ -41,15 +41,15 @@ module Padrino
       #
       # @api public
       def registered(app)
-        # lazily autoload heavy mail and it's padrino extension if ruby is MRI19
-        if RUBY_VERSION =~ /^1\.9/ && RUBY_ENGINE == 'ruby'
-          autoload :Mail, 'padrino-mailer/ext'
-        else
-          require 'padrino-mailer/ext'
-        end
         require 'padrino-mailer/base'
         require 'padrino-mailer/helpers'
         require 'padrino-mailer/mime'
+        # This lazily loads the mail gem, due to its long require time.
+        app.set :_padrino_mailer, proc {
+          require 'mail'
+          require 'padrino-mailer/ext'
+          app._padrino_mailer = Mail
+        }
         app.helpers Padrino::Mailer::Helpers
       end
       alias :included :registered

--- a/padrino-mailer/lib/padrino-mailer/base.rb
+++ b/padrino-mailer/lib/padrino-mailer/base.rb
@@ -86,7 +86,7 @@ module Padrino
       def email(name, &block)
         raise "The email '#{name}' is already defined" if self.messages[name].present?
         self.messages[name] = Proc.new { |*attrs|
-          message = Mail::Message.new(self.app)
+          message = app.settings._padrino_mailer::Message.new(self.app)
           message.defaults = self.defaults if self.defaults.any?
           message.delivery_method(*delivery_settings)
           message.instance_exec(*attrs, &block)

--- a/padrino-mailer/lib/padrino-mailer/ext.rb
+++ b/padrino-mailer/lib/padrino-mailer/ext.rb
@@ -1,5 +1,3 @@
-require 'mail'
-
 module Mail # @private
   class Message # @private
     include Sinatra::Templates

--- a/padrino-mailer/lib/padrino-mailer/helpers.rb
+++ b/padrino-mailer/lib/padrino-mailer/helpers.rb
@@ -136,7 +136,7 @@ module Padrino
         #
         # @api public
         def email(mail_attributes={}, &block)
-          message = Mail::Message.new(self)
+          message = _padrino_mailer::Message.new(self)
           message.delivery_method(*delivery_settings)
           message.instance_eval(&block) if block_given?
           mail_attributes.reverse_merge(mailer_defaults) if respond_to?(:mailer_defaults)


### PR DESCRIPTION
This implementation uses the lazy sinatra settings system instead.

At worst, it can lead to _padrino_mailer being set twice.

The lazy load function removes itself after execution.
