### PR TITLE
Add request.action to implement #843

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -11,6 +11,9 @@ class Sinatra::Request
   def controller
     route_obj && route_obj.controller
   end
+  def action
+    route_obj && route_obj.action
+  end
 end
 
 ##
@@ -62,7 +65,7 @@ class HttpRouter
 
   # @private
   class Route
-    attr_accessor :use_layout, :controller, :cache, :cache_key, :cache_expires_in
+    attr_accessor :use_layout, :controller, :action, :cache, :cache_key, :cache_expires_in
 
     def before_filters(&block)
       @_before_filters ||= []
@@ -557,6 +560,7 @@ module Padrino
           route_options = options.dup
           route_options[:provides] = @_provides if @_provides
           path, *route_options[:with] = path if path.is_a?(Array)
+          action = path
           path, name, options, route_options = *parse_route(path, route_options, verb)
           options.reverse_merge!(@_conditions) if @_conditions
 
@@ -573,6 +577,7 @@ module Padrino
           # HTTPRouter route construction
           route = router.add(path, route_options)
           route.name(name) if name
+          route.action = action
           priority_name = options.delete(:priority) || :normal
           priority = ROUTE_PRIORITY[priority_name] or raise("Priority #{priority_name} not recognized, try #{ROUTE_PRIORITY.keys.join(', ')}")
           route.cache = options.key?(:cache) ? options.delete(:cache) : @_cache

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -371,6 +371,21 @@ describe "Routing" do
     assert_equal "mini", body
   end
 
+  should "should inject the action name into the request" do
+    mock_app do
+      controller :posts do
+        get('/omnomnom(/:id)') { request.action.inspect }
+        controller :mini do
+          get([:a, :b, :c]) { request.action.inspect }
+        end
+      end
+    end
+    get "/posts/omnomnom"
+    assert_equal "\"/omnomnom(/:id)\"", body
+    get "/mini/a/b/c"
+    assert_equal ":a", body
+  end
+
   should "support not_found" do
     mock_app do
       not_found do


### PR DESCRIPTION
Add request.action which shows the exact first parameter used to register the route

For `get :index` it will be `:index`
For `get '/post(/:id)'` it will be `'/post(/:id)'`
It can be called an action name, but it's not an action exactly
