### PR TITLE
Fix default type for model generation from frozen String issue.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -224,7 +224,7 @@ module Padrino
       #
       # @api semipublic
       def apply_default_fields(fields)
-        fields.each { |field| field << ":string" unless field =~ /:/ }
+        fields.map! { |field| field =~ /:/ ? field : "#{field}:string" }
       end
 
       # Returns the app_name for the application at root.


### PR DESCRIPTION
`fields.each { |field| field << ":string" unless field =~ /:/ }`

was throwing a frozen string issue, see:

```
@daris.local➜  issue_924  bundle exec padrino g model test_model test_field:boolean super_field_string_default
       apply  orms/activerecord
/Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/lib/padrino-gen/generators/actions.rb:227:in `block in apply_default_fields': can't modify frozen String (RuntimeError)
  from /Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/lib/padrino-gen/generators/actions.rb:227:in `map'
  from /Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/lib/padrino-gen/generators/actions.rb:227:in `apply_default_fields'
  from /Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/lib/padrino-gen/generators/model.rb:53:in `create_model'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `block in invoke_all'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `each'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `map'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `invoke_all'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/group.rb:238:in `dispatch'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/base.rb:425:in `start'
  from /Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/lib/padrino-gen/generators/cli.rb:51:in `setup'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `block in invoke_all'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `each'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `map'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `invoke_all'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/group.rb:238:in `dispatch'
  from /Users/daris/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/thor-0.16.0/lib/thor/base.rb:425:in `start'
  from /Users/daris/Documents/uxtemple/opensource/padrino-framework/padrino-gen/bin/padrino-gen:16:in `<main>'
```

@achiu #924.
