### PR TITLE
Fail if class names are using a dangerous name

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -215,6 +215,21 @@ module Padrino
         results.empty? ? nil : results
       end
 
+      # Returns the class with an unacceptable name(if it matches any existent constant) else returns nil.
+      #
+      # @param [Array<String>] fields
+      #   Class names for generators
+      #
+      # @return [Array<String>] array of invalid classes 
+      #
+      # @example
+      #   invalid_classes ['Proc', 'String']
+      #
+      # @api semipublic
+      def invalid_class(klass)
+        Object.constants.include?(klass.capitalize.to_sym)
+      end
+
       # Apply default field types.
       #
       # @param [Array<String>] fields

--- a/padrino-gen/lib/padrino-gen/generators/migration.rb
+++ b/padrino-gen/lib/padrino-gen/generators/migration.rb
@@ -34,6 +34,11 @@ module Padrino
         if in_app_root?
           self.behavior = :revoke if options[:destroy]
           if include_component_module_for(:orm)
+            if invalid_class(name)
+              say 'Invalid migration name:', :red
+              say name.capitalize
+              return
+            end
             create_migration_file(name, name, columns)
           else
             say '<= You need an ORM adapter for run this generator. Sorry!'

--- a/padrino-gen/lib/padrino-gen/generators/model.rb
+++ b/padrino-gen/lib/padrino-gen/generators/model.rb
@@ -39,6 +39,11 @@ module Padrino
           app = options[:app]
           check_app_existence(app)
           self.behavior = :revoke if options[:destroy]
+          if invalid_class(name)
+            say 'Invalid model name:', :red
+            say name.capitalize
+            return
+          end
           if invalids = invalid_fields(fields)
             say 'Invalid field name:', :red
             say " #{invalids.join(", ")}"

--- a/padrino-gen/lib/padrino-gen/generators/project.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project.rb
@@ -51,6 +51,12 @@ module Padrino
       def setup_project
         valid_constant?(options[:app] || name)
         @app_name = (options[:app] || name).gsub(/\W/, '_').underscore.camelize
+
+        if invalid_class(@app_name)
+          say 'Invalid app name:', :red
+          say @app_name 
+          return
+        end
         self.destination_root = File.join(options[:root], name)
         if options[:template] # Run the template to create project
           execute_runner(:template, options[:template])

--- a/padrino-gen/test/test_migration_generator.rb
+++ b/padrino-gen/test/test_migration_generator.rb
@@ -22,6 +22,14 @@ describe "MigrationGenerator" do
       assert_raises(SystemExit) { capture_io { generate(:migration, 'AddEmailToUsers', "-r=#{@apptmp}/sample_project") } }
     end
 
+    should "fail if migration name is not acceptable" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '-d=activerecord') }
+      out, err = capture_io { generate(:migration, 'Proc', "name:string") }
+      assert_match(/Invalid migration name:/, out)
+      assert_match(/Proc/, out)
+      assert_no_file_exists("#{@apptmp}/sample_project/db/migrate/001_proc.rb")
+    end
+
     should "generate migration inside app root" do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=activerecord') }
       response_success = capture_io { generate(:migration, 'AddEmailToUsers', "-r=#{@apptmp}/sample_project") }

--- a/padrino-gen/test/test_model_generator.rb
+++ b/padrino-gen/test/test_model_generator.rb
@@ -23,6 +23,14 @@ describe "ModelGenerator" do
       assert_file_exists("#{@apptmp}/sample_project/models/demo_item.rb")
     end
 
+    should "fail if model name is not acceptable" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=couchrest') }
+      out, err = capture_io { generate(:model, 'Proc', "name:string", "age", "email:string", "-r=#{@apptmp}/sample_project") }
+      assert_match(/Invalid model name:/, out)
+      assert_match(/Proc/, out)
+      assert_no_file_exists("#{@apptmp}/sample_project/models/proc.rb")
+    end
+
     should "fail if field name is not acceptable" do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=couchrest') }
       out, err = capture_io { generate(:model, 'DemoItem', "re@l$ly:string","display-name:string", "age&year:datetime", "email_two:string", "-r=#{@apptmp}/sample_project") }

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -38,6 +38,12 @@ describe "ProjectGenerator" do
       assert_match_in_file(/Padrino.mount\('WsDci2011'\).to\('\/ws_dci_2011'\)/, "#{@apptmp}/project.com/config/apps.rb")
     end
 
+    # FIXME Perhaps this should be merged with the test above? And that method valid_constant? used everwhere?
+    should "fail if app name is not acceptable" do
+      capture_io { generate(:project, 'proc', "--root=#{@apptmp}") }
+      assert_no_file_exists("#{@apptmp}/proc")
+    end
+
     should "raise an Error when given invalid constant names" do
       assert_raises(::NameError) { capture_io { generate(:project, "123asdf", "--root=#{@apptmp}") } }
       assert_raises(::NameError) { capture_io { generate(:project, "./sample_project", "--root=#{@apptmp}") } }


### PR DESCRIPTION
Fail if class names are using a dangerous name (in projects, models and migrations). Tests for migrations and project are failing though. Need to check that. #957.

@ujifgc this is a more agressive approach than #1008 as it fails. It could just warn too or perhaps we add a --force-name flag? It also takes into account project and migrations names.
