### PR TITLE
Remove ree and 1.9.2 from testing, add rbx instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby
-  - rbx
+  - rbx-18mode
 notifications:
   irc: 'irc.freenode.org#padrino'
   recipients:
@@ -30,4 +30,4 @@ matrix:
     - rvm: 1.9.3
       env: SINATRA_EDGE=true
     - rvm: 2.0.0
-    - rvm: rbx
+    - rvm: rbx-18mode


### PR DESCRIPTION
Given that most providers have switched for Ruby 1.9.3 and 1.9.2 is really out of style, I switched off the build for it. Same goes for ree - I think testing 1.8.7 is currently enough to keep compatibility.

I took the liberty of activating optional testing on rbx.

This helps save resources on travis.
