### PR TITLE
Loading json gem for rendering.rb

### DIFF
--- a/padrino-core/lib/padrino-core/support_lite.rb
+++ b/padrino-core/lib/padrino-core/support_lite.rb
@@ -11,6 +11,7 @@ require 'active_support/inflector/methods'                  # constantize
 require 'active_support/inflector/inflections'              # pluralize
 require 'active_support/inflections'                        # load default inflections
 require 'yaml' unless defined?(YAML)                        # load yaml for i18n
+require 'json'                                              # load json for rendering
 require 'win32console' if RUBY_PLATFORM =~ /(win|m)32/      # ruby color support for win
 
 ##


### PR DESCRIPTION
fixes #1023 (Duplicated issue by mistake sorry :( )

is given with the example from padrino-core/application/rendering.rb :
--Use render { :a => 1, :b => 2, :c => 3 } # => return a json string

Gist of controller/Error: https://gist.github.com/4639694

The controller and rendering work fine if using the .json extension explicitly.
