### PR TITLE
Use ActiveSupport::JSON for dumping json in render

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering.rb
+++ b/padrino-core/lib/padrino-core/application/rendering.rb
@@ -156,7 +156,7 @@ module Padrino
         #
         def render(engine, data=nil, options={}, locals={}, &block)
           # If engine is a hash then render data converted to json
-          content_type(:json, :charset => 'utf-8') and return engine.to_json if engine.is_a?(Hash) || engine.is_a?(Array)
+          content_type(:json, :charset => 'utf-8') and return ActiveSupport::JSON.encode(engine) if engine.is_a?(Hash) || engine.is_a?(Array)
 
           # If engine is nil, ignore engine parameter and shift up all arguments
           # render nil, "index", { :layout => true }, { :localvar => "foo" }

--- a/padrino-core/lib/padrino-core/support_lite.rb
+++ b/padrino-core/lib/padrino-core/support_lite.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/array/extract_options'     # extract_options
 require 'active_support/inflector/methods'                  # constantize
 require 'active_support/inflector/inflections'              # pluralize
 require 'active_support/inflections'                        # load default inflections
+require 'active_support/json'                               # load ActiveSupport json interface
 require 'yaml' unless defined?(YAML)                        # load yaml for i18n
 require 'win32console' if RUBY_PLATFORM =~ /(win|m)32/      # ruby color support for win
 


### PR DESCRIPTION
This relieves us of any extra work that comes with handling JSON engines, etc. and ensures that rendering of json works without extra requires.

Closed #1023 and #1024,
