### PR TITLE
padrino-perf: watch out for problematic conditions in your app

### DIFF
--- a/padrino-perf/LICENSE.txt
+++ b/padrino-perf/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2011 Padrino
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/padrino-perf/README.rdoc
+++ b/padrino-perf/README.rdoc
@@ -1,0 +1,1 @@
+= Padrino Perf - Perfomance tools for padrino

--- a/padrino-perf/Rakefile
+++ b/padrino-perf/Rakefile
@@ -1,0 +1,5 @@
+# coding:utf-8
+RAKE_ROOT = __FILE__
+
+require 'rubygems'
+require File.expand_path(File.dirname(__FILE__) + '/../gem_rake_helper')

--- a/padrino-perf/bin/padrino-perf
+++ b/padrino-perf/bin/padrino-perf
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require 'optparse'
+require 'rbconfig'
+
+padrino_perf_path = File.expand_path('../../lib', __FILE__)
+
+argv = []
+OptionParser.new do |opts|
+  opts.banner = "Usage: padrino-perf [options]"
+
+  opts.on("-j", "--json", "Check for multiple loaded json libraries") do |v|
+    argv << '-r' + File.expand_path(File.join(padrino_perf_path, "suites", "json"))
+  end
+end.parse!
+
+# This little gem is stolen from Rake, thanks Jim!
+RUBY = File.join(
+  RbConfig::CONFIG['bindir'],
+  RbConfig::CONFIG['ruby_install_name'] + RbConfig::CONFIG['EXEEXT']).
+  sub(/.*\s.*/m, '"\&"')
+
+exec *[RUBY, *argv, "-S", *ARGV]

--- a/padrino-perf/lib/padrino-perf/version.rb
+++ b/padrino-perf/lib/padrino-perf/version.rb
@@ -1,0 +1,5 @@
+module PadrinoPerf
+  def self.version
+    '0.10.7'
+  end
+end

--- a/padrino-perf/lib/suites/json.rb
+++ b/padrino-perf/lib/suites/json.rb
@@ -1,0 +1,58 @@
+module PadrinoPerf
+  module JSON
+    def self.registered_libs
+      @registered_libs ||= {}
+    end
+
+    def self.loaded_libs
+      @loaded_libs ||= {}
+    end
+
+    def self.setup_capture!(lib)
+      suite_path = File.dirname(__FILE__)
+      registered_libs[lib] = File.join(suite_path, lib)
+      $LOAD_PATH.unshift registered_libs[lib]
+    end
+
+    def self.setup_captures!(*libs)
+      libs.map { |l| setup_capture!(l) }
+    end
+
+    def self.loaded_lib!(lib)
+      #remove our shim from the load_path before requiring again
+      $LOAD_PATH.delete(registered_libs[lib])
+      require lib
+
+      loaded_libs[lib] = caller
+
+      if loaded_libs.size >= 2
+        warn <<-WARN
+Concurring json libraries have been loaded. This incurs an
+unneccessary memory overhead at should be avoided. Consult the
+following call stacks to see who loaded the offending libraries
+and contact the authors if necessary:"
+WARN
+        loaded_libs.each do |name, stack|
+          $stderr.puts "============"
+          $stderr.puts "libname: " + name
+          $stderr.puts "============"
+          $stderr.puts caller
+        end
+      end
+    end
+
+    def self.infect_load_path!
+      def $LOAD_PATH.unshift(arg = nil, recurse = true)
+        return super(arg) unless recurse
+        return self unless arg
+        mine = self.grep(/padrino-perf/)
+        mine.each { |m| self.delete(m) }
+        super(arg)
+        mine.each { |m| self.unshift(m, false) }
+      end
+    end
+
+    infect_load_path!
+    setup_captures!("json", "yajl")
+  end
+end

--- a/padrino-perf/lib/suites/json/json.rb
+++ b/padrino-perf/lib/suites/json/json.rb
@@ -1,0 +1,1 @@
+PadrinoPerf::JSON.loaded_lib!('json')

--- a/padrino-perf/lib/suites/yajl/yajl.rb
+++ b/padrino-perf/lib/suites/yajl/yajl.rb
@@ -1,0 +1,1 @@
+PadrinoPerf::JSON.loaded_lib!('yajl')

--- a/padrino-perf/padrino-perf.gemspec
+++ b/padrino-perf/padrino-perf.gemspec
@@ -1,0 +1,24 @@
+# #!/usr/bin/env gem build
+# encoding: utf-8
+
+require File.expand_path("../lib/padrino-perf/version.rb", __FILE__)
+
+Gem::Specification.new do |s|
+  s.name = "padrino-perf"
+  s.rubyforge_project = "padrino-perf"
+  s.authors = ["Padrino Team", "Nathan Esquenazi", "Davide D'Agostino", "Arthur Chiu"]
+  s.email = "padrinorb@gmail.com"
+  s.summary = "A gem for finding performance problems in padrino"
+  s.homepage = "http://www.padrinorb.com"
+  s.description = "A gem for finding performance problems in padrino by tracking loads and memory consumption."
+  s.required_rubygems_version = ">= 1.3.6"
+  s.version = PadrinoPerf.version
+  s.date = Time.now.strftime("%Y-%m-%d")
+
+  s.extra_rdoc_files = Dir["*.rdoc"]
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = ["padrino-perf"]
+  s.require_paths = ["lib"]
+  s.rdoc_options  = ["--charset=UTF-8"]
+end


### PR DESCRIPTION
First of all: this is alpha, ugly and just a proof of concept that I wanted to show you.

This adds a small binary that allows to watch for know error conditions
and hook into certain aspects at startup time of a padrino application
to gather info.

Currently implemented is suite to detect json and yajl being loaded at the same time and tracking _who_ loaded it.

Also, there is a _horrible_ hack to ensure that load_paths added by padrino-perf are always in front of the `$LOAD_PATH`.

To try a sample run: add `padrino-perf`, `json` and `yajl` to your Gemfile. Run:

```
bundle exec padrino-perf -j -- padrino console
```

This is basically a nice alias for:

```
$ruby -r$PADRINO_PERF_SUITES/json -S padrino console
```

where $ruby is the ruby that called padrino-perf.

Then require `json` and `yajl` in any order:

```
.9.3-p125 :001 > require 'json'
 => true 
1.9.3-p125 :002 > require 'yajl'
Concurring json libraries have been loaded. This incurs an
unneccessary memory overhead at should be avoided. Consult the
following call stacks to see who loaded the offending libraries
and contact the authors if necessary:"

============
libname: json
============
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/json.rb:35:in `each'
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/json.rb:35:in `loaded_lib!'
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/yajl/yajl.rb:1:in `<top (required)>'
(irb):2:in `require'
(irb):2:in `irb_binding'
... cont
============
libname: yajl
============
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/json.rb:35:in `each'
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/json.rb:35:in `loaded_lib!'
/Users/skade/padrino/padrino-framework/padrino-framework/padrino-perf/lib/suites/yajl/yajl.rb:1:in `<top (required)>'
(irb):2:in `require'
(irb):2:in `irb_binding'
```

Its not really there yet and the implementation is very straigth-forward and generalized, but the technique can be used to built suites that track memory consumption during loading etc.

Its main strength is that it is not a library that you have to put in your Gemfile, but instead 'just' an extended Runtime.
