### PR TITLE
Make the logger thread-safe

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -343,7 +343,8 @@ module Padrino
     def flush
       return unless @buffer.size > 0
       @@mutex.synchronize do
-        @log.write(@buffer.slice!(0..-1).join(''))
+        @log.write(@buffer.join(''))
+        @buffer.clear
       end
     end
 


### PR DESCRIPTION
Applied the patch suggested by @yogi in padrino/padrino-framework#815 to make the logger thread-safe. @DAddYE @nesquena 
