### PR TITLE
Default host to localhost when in development mode.

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -13,7 +13,7 @@ module Padrino
       desc "start", "Starts the Padrino application (alternatively use 's')."
       map "s" => :start
       method_option :server,    :type => :string,  :aliases => "-a", :desc => "Rack Handler (default: autodetect)"
-      method_option :host,      :type => :string,  :aliases => "-h", :required => true, :default => "0.0.0.0", :desc => "Bind to HOST address."
+      method_option :host,      :type => :string,  :aliases => "-h", :required => true, :desc => "Bind to HOST address."
       method_option :port,      :type => :numeric, :aliases => "-p", :required => true, :default => 3000, :desc => "Use PORT."
       method_option :daemonize, :type => :boolean, :aliases => "-d", :desc => "Run daemonized in the background."
       method_option :pid,       :type => :string,  :aliases => "-i", :desc => "File to store pid."

--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -21,9 +21,11 @@ module Padrino
 
     # Starts the application on the available server with specified options.
     def self.start(app, opts={})
+      default_host = Padrino.env == 'development' ? 'localhost' : '0.0.0.0'
+
       options = {}.merge(opts) # We use a standard hash instead of Thor::CoreExt::HashWithIndifferentAccess
       options.symbolize_keys!
-      options[:Host] = options.delete(:host) || '0.0.0.0'
+      options[:Host] = options.delete(:host) || default_host
       options[:Port] = options.delete(:port) || 3000
       options[:AccessLog] = []
       if options[:daemonize]


### PR DESCRIPTION
Running Rack apps on `0.0.0.0` in development mode will allow malicious
users on the local network (ex: Coffee Shop) to abuse or potentially
exploit the app. Safer to default host to `localhost` when in development
mode.
