### PR TITLE
Change default source in Gemfiles, use https to access rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 require File.expand_path("../padrino-core/lib/padrino-core/version.rb", __FILE__)
 
-source :rubygems
+source 'https://rubygems.org'
 
 if ENV["AS_VERSION"]
   gem 'activesupport', "~> #{ENV['AS_VERSION']}"

--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Distribute your app as a gem
 <% unless options.gem? %># <% end %>gemspec


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure
