### PR TITLE
Fixed bug in breadcrumbs del method.

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/breadcrumb_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/breadcrumb_helpers.rb
@@ -105,7 +105,7 @@ module Padrino
       #
       # @api public
       def del(name)
-        items.each{ |item| item.delete if item[:name] == name.to_sym }
+        items.each{ |item| items.delete(item) if item[:name] == name.to_sym }
       end
 
     end # Breadcrumb


### PR DESCRIPTION
This addresses a couple bugs in the breadcrumbs del method.  One being a typo of `item.delete` to being `items.delete`, and the second being the `delete` method needing a single parameter of the item to delete (`items.delete(item)`).
