### PR TITLE
Pin memcached down to 1.3.7, since >= 1.4.1 fail to install.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :cache do
   platforms :mri do
     gem "bson_ext",  ">= 1.3.1"
     gem 'dalli',     ">= 1.0.2"
-    gem "memcached", ">= 0.20.1"
+    gem "memcached", "~> 1.3.7"
   end
   platform :rbx do
     gem 'dalli',  ">= 1.0.2"


### PR DESCRIPTION
- https://github.com/evan/memcached/issues/113
