### PR TITLE
Update Travis on Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ notifications:
     - joshbuddy@gmail.com
     - info@daddye.it
     - florian.gilcher@asquera.de
+    - dario@uxtemple.com
+    - ujifgc@gmail.com
 branches:
   only:
     - master
@@ -26,8 +28,13 @@ matrix:
       env: SINATRA_EDGE=true
     - rvm: 1.9.3
       env: AS_VERSION=3.1.0
+    - rvm: 2.0.0
+      env: SINATRA_EDGE=true
+    - rvm: 2.0.0
+      env: AS_VERSION=3.1.0
   allow_failures:
     - rvm: 1.9.3
       env: SINATRA_EDGE=true
     - rvm: 2.0.0
+      env: SINATRA_EDGE=true
     - rvm: rbx-18mode


### PR DESCRIPTION
Since Ruby 2.0.0 is stable now, I've removed it from the allowed failures in Travis. It's only allowed to fail with Sinatra edge as 1.9.3 does.

It is also tested in the same way that 1.9.3 is (see matrix includes) - feel free to remove this if it adds too much overhead to the testing process in Travis.

As a final note, I've also added myself and Igor to the notifications' recipients list.
