### PR TITLE
Revert to using stable bundler since 1.3 is out :)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 lang: ruby
-before_install: gem install bundler --pre
 install:
   - gem update --system
   - bundle update


### PR DESCRIPTION
That was a short patch :) Looks like bundler 1.3 has been [released](https://rubygems.org/gems/bun...dler/versions/1.3.0), let's try again. @nesquena if the tests on this one passes (I wasn't getting 1.3 on my laptop yet) would you merge? thx
