### PR TITLE
Skip padrino cache test if can not connect to cache server

### DIFF
--- a/padrino-cache/test/test_stores.rb
+++ b/padrino-cache/test/test_stores.rb
@@ -118,6 +118,11 @@ end
 begin
   require 'mongo'
   Padrino::Cache::Store::Mongo.new(::Mongo::Connection.new('127.0.0.1', 27017).db('padrino-cache_test'))
+rescue LoadError
+  warn "Skipping Mongo tests with Mongo library tests"
+rescue Mongo::ConnectionFailure
+  warn "Skipping Mongo Mongo with Mongo server tests"
+else
   describe "MongoStore" do
     def setup
       Padrino.cache = Padrino::Cache::Store::Mongo.new(::Mongo::Connection.new('127.0.0.1', 27017).db('padrino-cache_test'), {:size => 10, :collection => 'cache'})
@@ -131,8 +136,6 @@ begin
 
     eval COMMON_TESTS
   end
-rescue LoadError, Mongo::ConnectionFailure
-  warn "Skipping Mongo tests"
 end
 
 describe "FileStore" do


### PR DESCRIPTION
- if can not connect to memcached, redis, mongo server,  which  skip those tests (padrino-cache/test/test_stores.rb)
- use memcached gem
  - because [memcache-client is already deprecated](https://github.com/mperham/memcache-client#memcache-client-is-deprecated-as-of-august-2010--it-will-be-supported-through-2010-but-new-code-should-use-dalli-instead) and already memcached gem in Gemfile
