### PR TITLE
Patch to make asset_timestamp respect public_folder setting

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -367,7 +367,7 @@ module Padrino
         ignore_extension = (asset_folder.to_s == kind.to_s) # don't append an extension
         source << ".#{kind}" unless ignore_extension or source =~ /\.#{kind}/
         result_path = is_absolute ? source : uri_root_path(asset_folder, source)
-        timestamp = asset_timestamp(result_path, is_absolute)
+        timestamp = asset_timestamp(source, is_absolute)
         "#{result_path}#{timestamp}"
       end
 
@@ -393,7 +393,7 @@ module Padrino
       #
       def asset_timestamp(file_path, absolute=false)
         return nil if file_path =~ /\?/ || (self.class.respond_to?(:asset_stamp) && !self.class.asset_stamp)
-        public_file_path = Padrino.root("public", file_path) if Padrino.respond_to?(:root)
+        public_file_path = File.join(self.class.public_folder, file_path)
         stamp = File.mtime(public_file_path).to_i if public_file_path && File.exist?(public_file_path)
         stamp ||= Time.now.to_i unless absolute
         "?#{stamp}" if stamp


### PR DESCRIPTION
Currently asset_timestamp just uses Padrino.root + "public" + appname as the asset folder. Normally this is equal to the public_folder setting, unless someone overrides it in their app.rb. This fixes that issue by combining the source path with public_folder instead.

EDIT: Slight mistake. I'm submitting a new one.
