### PR TITLE
Patch to make asset_timestamp respect public_folder setting

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -366,9 +366,9 @@ module Padrino
         source = source.to_s.gsub(/\s/, '%20')
         ignore_extension = (asset_folder.to_s == kind.to_s) # don't append an extension
         source << ".#{kind}" unless ignore_extension or source =~ /\.#{kind}/
-        timestamp_path = is_absolute ? source : File.join(self.class.public_folder, asset_folder, source)
-        timestamp = asset_timestamp(timestamp_path, is_absolute)
-        result_path = is_absolute ? source : uri_root_path(asset_folder, source)
+        source = File.join(asset_folder, source) unless is_absolute
+        timestamp = asset_timestamp(source, is_absolute)
+        result_path = is_absolute ? source : uri_root_path(source)
         "#{result_path}#{timestamp}"
       end
 
@@ -394,7 +394,11 @@ module Padrino
       #
       def asset_timestamp(file_path, absolute=false)
         return nil if file_path =~ /\?/ || (self.class.respond_to?(:asset_stamp) && !self.class.asset_stamp)
-        stamp = File.mtime(file_path).to_i if file_path && File.exist?(file_path)
+        public_default = Padrino.root("public") if Padrino.respond_to?(:root)
+        public_folder = (!self.class.respond_to?(:public_folder) or absolute) ? public_default : self.class.public_folder
+        # TODO: use the mounter to figure out the correct folder for absolute files
+        public_file_path = File.join(absolute ? public_default : public_folder, file_path)
+        stamp = File.mtime(public_file_path).to_i if File.exist?(public_file_path)
         stamp ||= Time.now.to_i unless absolute
         "?#{stamp}" if stamp
       end


### PR DESCRIPTION
Currently asset_timestamp just uses Padrino.root + "public" + appname as the asset folder. Normally this is equal to the public_folder setting, unless someone overrides it in their app.rb. This fixes that issue by combining the source path with public_folder instead.

NOTE: This fixes the asset_folder bug in my previous pull request. I am aware this fails some tests which it shouldn't. Could someone please look into that for me, I am short on time.
