### PR TITLE
Forcing the mysql gem to stay in 2.8.x.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -100,7 +100,7 @@ def setup_orm
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_test'")
-    require_dependencies 'mysql', :version => "~> 2.8"
+    require_dependencies 'mysql', :version => "~> 2.8.1"
   when 'mysql2'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_production'")

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -232,7 +232,7 @@ describe "ProjectGenerator" do
 
       should "properly generate mysql" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=activerecord','--adapter=mysql') }
-        assert_match_in_file(/gem 'mysql', '~> 2.8'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(/gem 'mysql', '~> 2.8.1'/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
         assert_match_in_file(%r{:adapter   => 'mysql'}, "#{@apptmp}/sample_project/config/database.rb")
       end


### PR DESCRIPTION
Forcing the mysql gem to stay in 2.8.x since 2.9 is out and break things for existing users.

In response to #1092.
