### PR TITLE
Use a simpler syntax to refer to Padrino edge on Github in the Gemfile

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -22,7 +22,7 @@ gem 'rake'
 <% if options.dev? %># <% end %>gem 'padrino', '<%= Padrino.version %>'
 
 # Or Padrino Edge
-# gem 'padrino', github: 'padrino/padrino-framework'
+# gem 'padrino', :github => 'padrino/padrino-framework'
 
 # Or Individual Gems
 <% unless options.dev? %># <% end %>%w(core gen helpers cache mailer admin).each do |g|


### PR DESCRIPTION
Use a simpler syntax to refer to Padrino edge on Github in the Gemfile `gem 'padrino', github: 'padrino/padrino-framework'`. It reads so much better :)
