### PR TITLE
ORMs use mysql2 instead of mysql

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -3,7 +3,7 @@ AR = (<<-AR) unless defined?(AR)
 # You can use other adapters like:
 #
 #   ActiveRecord::Base.configurations[:development] = {
-#     :adapter   => 'mysql',
+#     :adapter   => 'mysql2',
 #     :encoding  => 'utf8',
 #     :reconnect => true,
 #     :database  => 'your_database',
@@ -95,13 +95,14 @@ SQLITE
 def setup_orm
   ar = AR
   db = @app_name.underscore
+  # We're now defaulting to mysql2 since mysql is deprecated
   case options[:adapter]
-  when 'mysql'
+  when 'mysql-gem'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_test'")
     require_dependencies 'mysql', :version => "~> 2.8.1"
-  when 'mysql2'
+  when 'mysql', 'mysql2'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_test'")

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/mini_record.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/mini_record.rb
@@ -79,12 +79,12 @@ def setup_orm
   ar = MR
   db = @app_name.underscore
   case options[:adapter]
-  when 'mysql'
+  when 'mysql-gem'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL.gsub(/!DB_NAME!/,"'#{db}_test'")
-    require_dependencies 'mysql'
-  when 'mysql2'
+    require_dependencies 'mysql', :version => "~> 2.8.1"
+  when 'mysql', 'mysql2'
     ar.gsub! /!DB_DEVELOPMENT!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_development'")
     ar.gsub! /!DB_PRODUCTION!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_production'")
     ar.gsub! /!DB_TEST!/, MYSQL2.gsub(/!DB_NAME!/,"'#{db}_test'")

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
@@ -12,21 +12,30 @@ def setup_orm
   sequel = SEQUEL
   db = @app_name.underscore
   require_dependencies 'sequel'
-  require_dependencies case options[:adapter]
+  case options[:adapter]
+  when 'mysql-gem'
+    sequel.gsub!(/!DB_DEVELOPMENT!/, "\"mysql://localhost/#{db}_development\"")
+    sequel.gsub!(/!DB_PRODUCTION!/, "\"mysql://localhost/#{db}_production\"")
+    sequel.gsub!(/!DB_TEST!/,"\"mysql://localhost/#{db}_test\"")
+    require_dependencies 'mysql', :version => "~> 2.8.1"
+    'mysql'
   when 'mysql', 'mysql2'
-    sequel.gsub!(/!DB_DEVELOPMENT!/, "\"#{options[:adapter]}://localhost/#{db}_development\"")
-    sequel.gsub!(/!DB_PRODUCTION!/, "\"#{options[:adapter]}://localhost/#{db}_production\"")
-    sequel.gsub!(/!DB_TEST!/,"\"#{options[:adapter]}://localhost/#{db}_test\"")
-    options[:adapter]
+    sequel.gsub!(/!DB_DEVELOPMENT!/, "\"mysql2://localhost/#{db}_development\"")
+    sequel.gsub!(/!DB_PRODUCTION!/, "\"mysql2://localhost/#{db}_production\"")
+    sequel.gsub!(/!DB_TEST!/,"\"mysql2://localhost/#{db}_test\"")
+    require_dependencies 'mysql2'
+    'mysql2'
   when 'postgres'
     sequel.gsub!(/!DB_DEVELOPMENT!/, "\"postgres://localhost/#{db}_development\"")
     sequel.gsub!(/!DB_PRODUCTION!/, "\"postgres://localhost/#{db}_production\"")
     sequel.gsub!(/!DB_TEST!/,"\"postgres://localhost/#{db}_test\"")
+    require_dependencies 'pg'
     'pg'
   else
     sequel.gsub!(/!DB_DEVELOPMENT!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_development.db\")")
     sequel.gsub!(/!DB_PRODUCTION!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_production.db\")")
     sequel.gsub!(/!DB_TEST!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_test.db\")")
+    require_dependencies 'sqlite3'
     'sqlite3'
   end
   create_file("config/database.rb", sequel)

--- a/padrino-gen/lib/padrino-gen/generators/project.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project.rb
@@ -31,7 +31,7 @@ module Padrino
       class_option :root,         :desc => 'The root destination',                                  :aliases => '-r', :default => '.',      :type => :string
       class_option :dev,          :desc => 'Use padrino from a git checkout',                                         :default => false,    :type => :boolean
       class_option :tiny,         :desc => 'Generate tiny app skeleton',                            :aliases => '-i', :default => false,    :type => :boolean
-      class_option :adapter,      :desc => 'SQL adapter for ORM (sqlite, mysql, mysql2, postgres)', :aliases => '-a', :default => 'sqlite', :type => :string
+      class_option :adapter,      :desc => 'SQL adapter for ORM (sqlite, mysql, mysql2, mysql-gem, postgres)', :aliases => '-a', :default => 'sqlite', :type => :string
       class_option :template,     :desc => 'Generate project from template',                        :aliases => '-p', :default => nil,      :type => :string
       class_option :gem,          :desc => 'Generate project as a gem',                             :aliases => '-g', :default => false,    :type => :boolean
 

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -198,8 +198,22 @@ describe "ProjectGenerator" do
         assert_match_in_file(%r{project_com}, "#{@apptmp}/project.com/config/database.rb")
       end
 
-      should "properly generate mysql" do
+      should "properly generate mysql (default to mysql2)" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=sequel', '--adapter=mysql') }
+        assert_match_in_file(/gem 'mysql2'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(%r{"mysql2://}, "#{@apptmp}/sample_project/config/database.rb")
+        assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
+      end
+
+      should "properly generate mysql2" do
+        out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=sequel', '--adapter=mysql2') }
+        assert_match_in_file(/gem 'mysql2'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(%r{"mysql2://}, "#{@apptmp}/sample_project/config/database.rb")
+        assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
+      end
+
+      should "properly generate mysql-gem" do
+        out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=sequel', '--adapter=mysql-gem') }
         assert_match_in_file(/gem 'mysql'/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(%r{"mysql://}, "#{@apptmp}/sample_project/config/database.rb")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
@@ -230,11 +244,11 @@ describe "ProjectGenerator" do
         assert_match_in_file(/project_com/, "#{@apptmp}/project.com/config/database.rb")
       end
 
-      should "properly generate mysql" do
+      should "properly generate mysql (default to mysql2)" do
         out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=activerecord','--adapter=mysql') }
-        assert_match_in_file(/gem 'mysql', '~> 2.8.1'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(/gem 'mysql2'/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
-        assert_match_in_file(%r{:adapter   => 'mysql'}, "#{@apptmp}/sample_project/config/database.rb")
+        assert_match_in_file(%r{:adapter   => 'mysql2'}, "#{@apptmp}/sample_project/config/database.rb")
       end
 
       should "properly generate mysql2" do
@@ -242,6 +256,13 @@ describe "ProjectGenerator" do
         assert_match_in_file(/gem 'mysql2'/, "#{@apptmp}/sample_project/Gemfile")
         assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
         assert_match_in_file(%r{:adapter   => 'mysql2'}, "#{@apptmp}/sample_project/config/database.rb")
+      end
+
+      should "properly generate mysql-gem" do
+        out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--orm=activerecord','--adapter=mysql-gem') }
+        assert_match_in_file(/gem 'mysql', '~> 2.8.1'/, "#{@apptmp}/sample_project/Gemfile")
+        assert_match_in_file(/sample_project_development/, "#{@apptmp}/sample_project/config/database.rb")
+        assert_match_in_file(%r{:adapter   => 'mysql'}, "#{@apptmp}/sample_project/config/database.rb")
       end
 
       should "properly generate sqlite3" do


### PR DESCRIPTION
Defaulted all ORMs that used the mysql gem to use mysql2 when the options mysql and mysql2 are used and to force the mysql gem only when mysql-gem is specified in the generator.

Normalised it in AR, MiniRecord and Sequel.
#1104
