### PR TITLE
Reverted mongoid generator to use config/database.rb instead of yml file.

### DIFF
--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -333,8 +333,7 @@ describe "ProjectGenerator" do
       assert_match(/applying.*?mongoid.*?orm/, out)
       if RUBY_VERSION >= '1.9'
         assert_match_in_file(/gem 'mongoid', '~>3.0.0'/, "#{@apptmp}/project.com/Gemfile")
-        assert_match_in_file(/Mongoid.load!/, "#{@apptmp}/project.com/config/database.rb")
-        assert_match_in_file(/production:/, "#{@apptmp}/project.com/config/database.yml")
+        assert_match_in_file(/Mongoid::Config.sessions =/, "#{@apptmp}/project.com/config/database.rb")
       else
         assert_match_in_file(/gem 'mongoid', '~>2.0'/, "#{@apptmp}/project.com/Gemfile")
         assert_match_in_file(/Mongoid.database/, "#{@apptmp}/project.com/config/database.rb")


### PR DESCRIPTION
Reverted mongoid generator for to use `config/database.rb` instead of `config/database.yml`.

However, I left the indications on how to use that on the generated `config/database.rb`.

Also implemented `ENV['MONGO_URI']` as @j15e's suggested. It will default to it if set.
#985.
