### PR TITLE
Moved the CSRF authenticity token to be generated on the form_tag helper

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -107,49 +107,6 @@ module Padrino
       end
 
       ##
-      # Creates a form containing a single button that submits to the url.
-      #
-      # @overload button_to(name, url, options={})
-      #   @param [String]  caption  The text caption.
-      #   @param [String]  url      The url href.
-      #   @param [Hash]    options  The html options.
-      # @overload button_to(name, options={}, &block)
-      #   @param [String]  url      The url href.
-      #   @param [Hash]    options  The html options.
-      #   @param [Proc]    block    The button content.
-      #
-      # @option options [Boolean] :multipart
-      #   If true, this form will support multipart encoding.
-      # @option options [String] :remote
-      #   Instructs ujs handler to handle the submit as ajax.
-      # @option options [Symbol] :method
-      #   Instructs ujs handler to use different http method (i.e :post, :delete).
-      #
-      # @return [String] Form and button html with specified +options+.
-      #
-      # @example
-      #   button_to 'Delete', url(:accounts_destroy, :id => account), :method => :delete, :class => :form
-      #   # Generates:
-      #   # <form class="form" action="/admin/accounts/destroy/2" method="post">
-      #   #   <input type="hidden" value="delete" name="_method" />
-      #   #   <input type="submit" value="Delete" />
-      #   # </form>
-      #
-      # @api public
-      def button_to(*args, &block)
-        name, url = args[0], args[1]
-        options   = args.extract_options!
-        desired_method = options[:method]
-        options.delete(:method) if options[:method].to_s !~ /get|post/i
-        options.reverse_merge!(:method => 'post', :action => url)
-        options[:enctype] = 'multipart/form-data' if options.delete(:multipart)
-        options['data-remote'] = 'true' if options.delete(:remote)
-        inner_form_html  = hidden_form_method_field(desired_method)
-        inner_form_html += block_given? ? capture_html(&block) : submit_tag(name)
-        content_tag('form', inner_form_html, options)
-      end
-
-      ##
       # Creates a link tag that browsers and news readers can use to auto-detect an RSS or ATOM feed.
       #
       # @param [Symbol] mime

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -713,6 +713,49 @@ module Padrino
         hidden_field_tag :authenticity_token, :value => token
       end
 
+      ##
+      # Creates a form containing a single button that submits to the url.
+      #
+      # @overload button_to(name, url, options={})
+      #   @param [String]  caption  The text caption.
+      #   @param [String]  url      The url href.
+      #   @param [Hash]    options  The html options.
+      # @overload button_to(name, options={}, &block)
+      #   @param [String]  url      The url href.
+      #   @param [Hash]    options  The html options.
+      #   @param [Proc]    block    The button content.
+      #
+      # @option options [Boolean] :multipart
+      #   If true, this form will support multipart encoding.
+      # @option options [String] :remote
+      #   Instructs ujs handler to handle the submit as ajax.
+      # @option options [Symbol] :method
+      #   Instructs ujs handler to use different http method (i.e :post, :delete).
+      #
+      # @return [String] Form and button html with specified +options+.
+      #
+      # @example
+      #   button_to 'Delete', url(:accounts_destroy, :id => account), :method => :delete, :class => :form
+      #   # Generates:
+      #   # <form class="form" action="/admin/accounts/destroy/2" method="post">
+      #   #   <input type="hidden" value="delete" name="_method" />
+      #   #   <input type="submit" value="Delete" />
+      #   # </form>
+      #
+      # @api public
+      def button_to(*args, &block)
+        name, url = args[0], args[1]
+        options   = args.extract_options!
+        options['data-remote'] = 'true' if options.delete(:remote)
+        if block_given?
+          form_tag(url, options, &block)
+        else
+          form_tag(url, options) do
+            submit_tag(name)
+          end
+        end
+      end
+
       protected
 
         ##

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -781,4 +781,25 @@ describe "FormHelpers" do
       assert_have_selector 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
     end
   end
+
+  context 'for #button_to method' do
+    should "have a form and set the method properly" do
+      actual_html = button_to('Delete', '/users/1', :method => :delete)
+      assert_has_tag('form', :action => '/users/1') { actual_html }
+      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'delete') { actual_html }
+      assert_has_tag('form input', :type => 'hidden', :name => "authenticity_token") { actual_html }
+    end
+
+    should "add a submit button by default if no content is specified" do
+      actual_html = button_to('My Delete Button', '/users/1', :method => :delete)
+      assert_has_tag('form input', :type => 'submit', :value => 'My Delete Button') { actual_html }
+    end
+
+    should "set specific content inside the form if a block was sent" do
+      actual_html = button_to('My Delete Button', '/users/1', :method => :delete) do
+        content_tag :button, "My button's content", :type => :submit, :title => "My button"
+      end
+      assert_has_tag('form button', :type => 'submit', :content => "My button's content", :title => "My button") { actual_html }
+    end
+  end
 end


### PR DESCRIPTION
Moved the CSRF authenticity token to be generated on the form_tag helper instead of form_for (the latter uses form_tag at the end anyway...). Added tests too.

@padrino/core-members shouldn't we also add tests for the case where csrf is disabled?

Fixes #1113.
