### PR TITLE
Fix invalid markup in mail_to (ampersand not escaped)

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -166,7 +166,7 @@ module Padrino
       # @api public
       def mail_to(email, caption=nil, mail_options={})
         html_options = mail_options.slice!(:cc, :bcc, :subject, :body)
-        mail_query = Rack::Utils.build_query(mail_options).gsub(/\+/, '%20').gsub('%40', '@')
+        mail_query = Rack::Utils.build_query(mail_options).gsub(/\+/, '%20').gsub('%40', '@').gsub('&', '&amp;')
         mail_href = "mailto:#{email}"; mail_href << "?#{mail_query}" if mail_query.present?
         link_to((caption || email), mail_href, html_options)
       end


### PR DESCRIPTION
Escape ampersands for validation.

It looks like this should probably be handled in the link_to helper, but I am not familiar enough with standards to know if `&` is supposed to be escaped in html tags in general.

Less hacky/more general solutions welcome to whoever knows more about the standards specs!
