### PR TITLE
Fixed "Still, 303 for destroy_many on admin"

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/orm.rb
+++ b/padrino-admin/lib/padrino-admin/generators/orm.rb
@@ -149,6 +149,14 @@ module Padrino
           end
         end
 
+        def parse_many_ids_on_params
+          base = "params[:#{@name_singular}_ids].strip.split(',')"
+          case orm
+            when :activerecord, :minirecord, :datamapper, :sequel then "#{base}.map(&:to_i)"
+            else base
+          end
+        end
+
         def multiple_destroy(params=nil)
           case orm
             when :ohm then "#{params}.each(&:delete)"

--- a/padrino-admin/lib/padrino-admin/generators/templates/page/controller.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/page/controller.rb.tt
@@ -76,7 +76,7 @@
       flash[:error] = pat(:destroy_many_error, :model => '<%= @orm.name_singular %>')
       redirect(url(:<%= @orm.name_plural %>, :index))
     end
-    ids = params[:<%= @orm.name_singular %>_ids].split(',')
+    ids = <%= @orm.parse_many_ids_on_params %>
     <%= @orm.name_plural %> = <%= @orm.find_by_ids("ids") %>
     <% if @orm.name_singular == @admin_model %>
     if <%= @orm.name_plural %>.include? current_account


### PR DESCRIPTION
Fixed the issue and made numeric-id-based-orms use integers, not strings... which were making datamapper fail to first find the records and afterwards delete them! #755 @DAddYE @nesquena 
