### PR TITLE
fix indent for Extensions

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -357,7 +357,7 @@ WARNING
       # @api public
       def initializer(name, data=nil)
         @_init_name, @_init_data = name, data
-        register = data.present? ? "  register #{name.to_s.underscore.camelize}Initializer\n" : "  register #{name}\n"
+        register = data.present? ? "    register #{name.to_s.underscore.camelize}Initializer\n" : "    register #{name}\n"
         inject_into_file destination_root("/app/app.rb"), register, :after => "Padrino::Application\n"
         template "templates/initializer.rb.tt", destination_root("/lib/#{name}_init.rb") if data.present?
       end

--- a/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
@@ -27,7 +27,7 @@ end
 COMPASS
 
 COMPASS_REGISTER = <<-COMPASSR unless defined?(COMPASS_REGISTER)
-  register CompassInitializer\n
+    register CompassInitializer\n
 COMPASSR
 
 def setup_stylesheet

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -100,7 +100,7 @@ class MiniTest::Spec
     path = File.join(options[:root],'lib',"#{name}_init.rb")
     instance = mock
     instance.expects(:invoke!).at_least_once
-    include_text = "  register #{name.to_s.camelize}Initializer\n"
+    include_text = "    register #{name.to_s.camelize}Initializer\n"
     Thor::Actions::InjectIntoFile.expects(:new).with(anything,anything, include_text, anything).returns(instance)
     Thor::Actions::CreateFile.expects(:new).with(anything, path, kind_of(Proc), anything).returns(instance)
   end


### PR DESCRIPTION
``` sh
$ padrino g project foo -c compass
```

before:

``` ruby
module Foo
  class App < Padrino::Application
    register Padrino::Rendering
    register Padrino::Mailer
    register Padrino::Helpers
  register CompassInitializer

end
```

after

``` ruby
module Foo
  class App < Padrino::Application
    register Padrino::Rendering
    register Padrino::Mailer
    register Padrino::Helpers
    register CompassInitializer

end
```
