### PR TITLE
Add missing HTTP verbs to http_router

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -64,6 +64,8 @@ class HttpRouter
 
   # @private
   class Route
+    VALID_HTTP_VERBS = %w{GET POST PUT PATCH DELETE HEAD OPTIONS LINK UNLINK}
+
     attr_accessor :use_layout, :controller, :action, :cache, :cache_key, :cache_expires_in, :parent
 
     def before_filters(&block)


### PR DESCRIPTION
Thanks to @kenkeiter for bringing up the fact that http_router [is missing PATCH](https://github.com/joshbuddy/http_router/blob/master/lib/http_router/route.rb#L5).

This commit overrides it supporting everything that [Sinatra supports as helpers](https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1375-L1382).

I got rid of TRACE since there's no helper for it and route is private
so you can't use it at all :).

See the IRC discussion here: http://irclogger.com/.padrino/2013-03-25.

Fixes #1180.

Before merging... Should we mirror [Sinatra's tests](https://github.com/sinatra/sinatra/blob/master/test/routing_test.rb#L26) on the matter?

I think we should wrap this up and release 0.11.1 with it since it's quite important to support these. Thoughts @padrino/core-members?
