### PR TITLE
Fix warning message on VALID_HTTP_VERBS

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -64,7 +64,7 @@ class HttpRouter
 
   # @private
   class Route
-    VALID_HTTP_VERBS.replace %w{GET POST PUT PATCH DELETE HEAD OPTIONS LINK UNLINK}
+    VALID_HTTP_VERBS.replace %w[GET POST PUT PATCH DELETE HEAD OPTIONS LINK UNLINK]
 
     attr_accessor :use_layout, :controller, :action, :cache, :cache_key, :cache_expires_in, :parent
 


### PR DESCRIPTION
Replace constant instead of redefining it so that we don't get an ugly warning. Thanks @skade https://github.com/padrino/padrino-framework/pull/1181#issuecomment-15458360.

Fixes the warning issue in #1181.
