### PR TITLE
Added layout option for controllers

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/controller.rb
+++ b/padrino-gen/lib/padrino-gen/generators/controller.rb
@@ -26,6 +26,7 @@ module Padrino
       class_option :app,       :desc => 'The application destination path',       :aliases => '-a', :default => '/app', :type => :string
       class_option :destroy,                                                      :aliases => '-d', :default => false,  :type => :boolean
       class_option :namespace, :desc => 'The name space of your padrino project', :aliases => '-n', :default => '',     :type => :string
+      class_option :layout,    :desc => 'The layout for the controller',          :aliases => '-l', :default => '',     :type => :string
 
       # Show help if no argv given
       require_arguments!
@@ -43,6 +44,7 @@ module Padrino
           @app_name     = fetch_app_name(app)
           @actions      = controller_actions(fields)
           @controller   = name.to_s.underscore
+          @layout       = options[:layout] if options[:layout] && !options[:layout].empty?
           self.behavior = :revoke if options[:destroy]
           template 'templates/controller.rb.tt', destination_root(app, 'controllers', "#{name.to_s.underscore}.rb")
           template 'templates/helper.rb.tt',     destination_root(app, 'helpers', "#{name.to_s.underscore}_helper.rb")

--- a/padrino-gen/lib/padrino-gen/generators/templates/controller.rb.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/controller.rb.tt
@@ -1,4 +1,5 @@
 <%= @project_name %>::<%= @app_name %>.controllers <%= ":#{@controller}" if @controller %> do
+  <%= "layout :#{@layout}" if @layout %>
   # get :index, :map => '/foo/bar' do
   #   session[:foo] = 'bar'
   #   render 'index'

--- a/padrino-gen/test/test_controller_generator.rb
+++ b/padrino-gen/test/test_controller_generator.rb
@@ -46,6 +46,18 @@ describe "ControllerGenerator" do
       assert_match_in_file(/describe "DemoItemsController" do/m, @controller_test_path.gsub('app','subby'))
     end
 
+    should "generate controller with specified layout" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-l=xyzlayout') }
+      assert_match_in_file(/layout :xyzlayout/m, @controller_path)
+    end
+
+    should "generate controller with-out specified layout if empty" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-l=') }
+      assert_no_match_in_file(/layout/m, @controller_path)
+    end
+
     should 'not fail if we don\'t have test component' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--test=none') }
       capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project") }


### PR DESCRIPTION
(ref #1096) 

Added the -l option for controllers, so you can specify the layout :xzy string while creating.

example:

```
padrino generate controller users -l=global
```
