### PR TITLE
fix flash_tag() with multiple attributes.

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -32,7 +32,7 @@ module Padrino
         bootstrap = options.delete(:bootstrap) if options[:bootstrap]
         args.inject(''.html_safe) do |html,kind|
           flash_text = flash[kind]
-          next if flash_text.blank?
+          next html if flash_text.blank?
           flash_text << safe_content_tag(:button, "&times;", {:type => :button, :class => :close, :'data-dismiss' => :alert}) if bootstrap
           html << safe_content_tag(:div, flash_text, options.reverse_merge(:class => kind))
         end

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -23,7 +23,7 @@ describe "AssetTagHelpers" do
     should "display multiple flash tags with given attributes" do
       flash[:error] = 'wrong'
       flash[:success] = 'okey'
-      actual_html = flash_tag(:success, :error, :id => 'area')
+      actual_html = flash_tag(:success, :warning, :error, :id => 'area')
       assert_has_tag('div.success#area', :content => flash[:success]) { actual_html }
       assert_has_tag('div.error#area', :content => flash[:error]) { actual_html }
       assert_has_no_tag('div.notice') { actual_html }


### PR DESCRIPTION
flash_tag() with multiple attributes raises NoMethodError when some attributes are not given.

When flash is set in controller:

```
flash[:error] = 'error message'
flash[:success] = 'success message'
```

and use flash_tag() in view:

```
flash_tag(:error, :warning, :success)
```

Then raise error:

```
NoMethodError: undefined method `<<' for nil:NilClass
```
