### PR TITLE
Improved german translations.

### DIFF
--- a/padrino-core/lib/padrino-core/locale/de.yml
+++ b/padrino-core/lib/padrino-core/locale/de.yml
@@ -5,8 +5,8 @@ de:
       # Wenn keine Formate angegeben werden, wird "default" benutzt.
       # Du kannst auch weitere Formate hinzufügen, wenn Du möchtest.
       default: "&d.&m.%Y"
-      short: "%b %d"
-      long: "%B %d, %Y"
+      short: "%d. %b"
+      long: "%d. %B %Y"
       only_day: "%e"
 
     day_names: [Sonntag, Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag]
@@ -20,9 +20,9 @@ de:
 
   time:
     formats:
-      default: "%a, %d %b %Y %H:%M:%S %z"
-      short: "%d %b %H:%M"
-      long: "%B %d, %Y %H:%M"
+      default: "%a, %d. %b %Y %H:%M:%S %z"
+      short: "%d. %b %H:%M"
+      long: "%d. %B %Y %H:%M"
     am: "am"
     pm: "pm"
 
@@ -31,4 +31,4 @@ de:
     array:
       words_connector: ", "
       two_words_connector: " und "
-      last_word_connector: ", und "
+      last_word_connector: " und "


### PR DESCRIPTION
Date formats fixed; no "," before an "und" as last word connector.
