### PR TITLE
Added options:

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/controller.rb
+++ b/padrino-gen/lib/padrino-gen/generators/controller.rb
@@ -27,6 +27,8 @@ module Padrino
       class_option :destroy,                                                      :aliases => '-d', :default => false,  :type => :boolean
       class_option :namespace, :desc => 'The name space of your padrino project', :aliases => '-n', :default => '',     :type => :string
       class_option :layout,    :desc => 'The layout for the controller',          :aliases => '-l', :default => '',     :type => :string
+      class_option :parent,    :desc => 'The parent of the controller',           :aliases => '-p', :default => '',     :type => :string
+      class_option :provides,  :desc => 'the formats provided by the controller', :aliases => '-f', :default => '',     :type => :string
 
       # Show help if no argv given
       require_arguments!
@@ -45,6 +47,12 @@ module Padrino
           @actions      = controller_actions(fields)
           @controller   = name.to_s.underscore
           @layout       = options[:layout] if options[:layout] && !options[:layout].empty?
+          
+          block_opts = []
+          block_opts << ":parent => :#{options[:parent]}" if options[:parent] && !options[:parent].empty?
+          block_opts << ":provides => [#{options[:provides]}]" if options[:provides] && !options[:provides].empty?
+          @block_opts_string = block_opts.join(', ') unless block_opts.empty?
+
           self.behavior = :revoke if options[:destroy]
           template 'templates/controller.rb.tt', destination_root(app, 'controllers', "#{name.to_s.underscore}.rb")
           template 'templates/helper.rb.tt',     destination_root(app, 'helpers', "#{name.to_s.underscore}_helper.rb")

--- a/padrino-gen/lib/padrino-gen/generators/templates/controller.rb.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/controller.rb.tt
@@ -1,4 +1,4 @@
-<%= @project_name %>::<%= @app_name %>.controllers <%= ":#{@controller}" if @controller %> do
+<%= @project_name %>::<%= @app_name %>.controllers <%= ":#{@controller}" if @controller %><%= ", #{@block_opts_string}" if @block_opts_string %> do
   <%= "layout :#{@layout}" if @layout %>
   # get :index, :map => '/foo/bar' do
   #   session[:foo] = 'bar'

--- a/padrino-gen/test/test_controller_generator.rb
+++ b/padrino-gen/test/test_controller_generator.rb
@@ -52,13 +52,37 @@ describe "ControllerGenerator" do
       assert_match_in_file(/layout :xyzlayout/m, @controller_path)
     end
 
-    should "generate controller with-out specified layout if empty" do
+    should "generate controller without specified layout if empty" do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
       capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-l=') }
       assert_no_match_in_file(/layout/m, @controller_path)
     end
 
-    should 'not fail if we don\'t have test component' do
+    should "generate controller with specified parent" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-p=user') }
+      assert_match_in_file(/SampleProject::App.controllers :demo_items, :parent => :user do/m, @controller_path)
+    end
+
+    should "generate controller without specified parent" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-p=') }
+      assert_match_in_file(/SampleProject::App.controllers :demo_items do/m, @controller_path)
+    end
+
+    should "generate controller with specified providers" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-f=:html, :js') }
+      assert_match_in_file(/SampleProject::App.controllers :demo_items, :provides => \[:html, :js\] do/m, @controller_path)
+    end
+
+    should "generate controller without specified providers" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon') }
+      capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '-f=') }
+      assert_match_in_file(/SampleProject::App.controllers :demo_items do/m, @controller_path)
+    end
+
+    should "not fail if we don't have test component" do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--test=none') }
       capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project") }
       assert_match_in_file(/SampleProject::App.controllers :demo_items do/m, @controller_path)


### PR DESCRIPTION
(ref #1096)

This is more of the same going along with #1209, and should close out #1096.

options added to controller generator
- -f(--provides)
- -p(--parent)

examples:

```
padrino generate controller main -f :html,:js
```

```
padrino generate controller main -p users
```

```
padrino generate controller main -l global -p users -f :html,:js
```

``` ruby
TestPadrino::App.controllers :main, :parent => :users, :provides => [:html,:js] do
  layout :global
end
```
