### PR TITLE
Allow users to override admin templates on a file by file basis

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -21,7 +21,11 @@ module Padrino
       
       # Look for custom template files in a generators folder under the project root
       def source_paths
-        ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
+        if File.exists? destination_root('generators', 'templates')
+          ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
+        else
+          [File.expand_path(File.dirname(__FILE__))]
+        end
       end
 
       desc "Description:\n\n\tpadrino-gen admin generates a new Padrino Admin application"

--- a/padrino-admin/lib/padrino-admin/generators/admin_page.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_page.rb
@@ -22,7 +22,11 @@ module Padrino
 
       # Look for custom template files in a generators folder under the project root
       def source_paths
-        ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
+        if File.exists? destination_root('generators')
+          ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
+        else
+          [File.expand_path(File.dirname(__FILE__))]
+        end
       end
 
       desc "Description:\n\n\tpadrino-gen admin_page model(s)"

--- a/padrino-admin/test/generators/test_admin_app_generator.rb
+++ b/padrino-admin/test/generators/test_admin_app_generator.rb
@@ -53,6 +53,15 @@ describe "AdminAppGenerator" do
       assert_match_in_file 'role.project_module :accounts, \'/accounts\'', "#{@apptmp}/sample_project/admin/app.rb"
     end
 
+    # users can override certain templates from a generators/templates folder in the destination_root
+    it "should use custom generator templates from the project root, if they exist" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '-d=activerecord') }
+      custom_template_path = "#{@apptmp}/sample_project/generators/templates/slim/app/layouts/"
+      `mkdir -p #{custom_template_path} && echo "h1 = 'Hello, custom generator' " > #{custom_template_path}application.slim.tt`
+      capture_io { generate(:admin_app, "--root=#{@apptmp}/sample_project") }
+      assert_match_in_file(/Hello, custom generator/, "#{@apptmp}/sample_project/admin/views/layouts/application.slim")
+    end
+
     it "should generate the admin app under a different folder" do
       # TODO FIXME Implement option --admin_root or something. See https://github.com/padrino/padrino-framework/issues/854#issuecomment-14749356
       skip

--- a/padrino-admin/test/generators/test_admin_page_generator.rb
+++ b/padrino-admin/test/generators/test_admin_page_generator.rb
@@ -46,6 +46,17 @@ describe "AdminPageGenerator" do
       assert_match_in_file "elsif Padrino.env == :development && params[:bypass]", "#{@apptmp}/sample_project/admin/controllers/sessions.rb"
     end
 
+    # users can override certain templates from a generators/templates folder in the destination_root
+    it "should use custom generator templates from the project root, if they exist" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '-d=datamapper','-e=haml') }
+      custom_template_path = "#{@apptmp}/sample_project/generators/templates/haml/page/"
+      `mkdir -p #{custom_template_path} && echo "%h1= 'Hello, custom generator' " > #{custom_template_path}index.haml.tt`
+      capture_io { generate(:admin_app, "--root=#{@apptmp}/sample_project") }
+      capture_io { generate(:model, 'person', "name:string", "age:integer", "email:string", "--root=#{@apptmp}/sample_project") }
+      capture_io { generate(:admin_page, 'person', "--root=#{@apptmp}/sample_project") }
+      assert_match_in_file(/Hello, custom generator/, "#{@apptmp}/sample_project/admin/views/people/index.haml")
+    end
+
     describe "renderers" do
       it 'should correctly generate a new page with haml' do
         capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '-d=datamapper','-e=haml') }


### PR DESCRIPTION
This change lets users override single templates by including them in a `generators/templates` folder in the project root. It only uses the files that are there and falls back to the gem otherwise.

For example, if I want to include my company logo in every edit page I can add a file like so:

```
.
├── Gemfile
├── Gemfile.lock
├── Rakefile
├── admin
├── app
... other files in project
├── generators
│   ├── admin_extensions.rb
│   └── templates
│       └── haml
│           └── page
│               └── edit.haml.tt
├── lib
├── models
├── public
...etc
```

The admin generator will use my custom thor template for every edit page and fall back to the gem for everything else.

My use case for this has been when I'd like the admin generator to include image uploads by for models with a field name containing '_img' or a position widget for a field called 'position'.  Being able to tweak the admin page generator to do this speeds up development when you have lots of models.

If the folder isn't there it doesn't complain and the generator works as standard. I've added tests for both the admin app and page generator.

What do people think?
