### PR TITLE
Padrino::Server - call expand_path on PID file option

### DIFF
--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -27,7 +27,7 @@ module Padrino
       options[:Port] = options.delete(:port) || 3000
       options[:AccessLog] = []
       if options[:daemonize]
-        options[:pid] = options[:pid].blank? ? File.expand_path('tmp/pids/server.pid') : opts[:pid]
+        options[:pid] = File.expand_path(options[:pid].blank? ? 'tmp/pids/server.pid' : opts[:pid])
         FileUtils.mkdir_p(File.dirname(options[:pid]))
       end
       options[:server] = detect_rack_handler if options[:server].blank?


### PR DESCRIPTION
Normally [Rack::Server would expand the PID (-P) argument](https://github.com/rack/rack/blob/master/lib/rack/server.rb#L184). But with `Padrino::Server`, there is no `ARGV` for `Rack::Server` to parse, so a PID option that's not absolute will cause `Padrino::Server` to silently fail when it daemonizes as it will be [attempting to open the file from the root directory ("/")](https://github.com/rack/rack/blob/master/lib/rack/server.rb#L254)  not the directory from which it was invoked. 

On a related note, why not just mimic the `Rack::Server`/`rackup` options? While it's is a minor issue, standardization is good. For example, this is somewhat confusing:

``` bash
> padrino start -di some/pid/file.pid
> padrino stop -i some/pid/file.pid
padrino stop requires at least 0 argument: "padrino stop".
> padrino stop -p some/pid/file.pid
=> Sending INT to process with pid 57493 wait
```
