### PR TITLE
Create table migration should be also timestamped if configured 

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/actions.rb
@@ -33,9 +33,9 @@ module Padrino
             contents = options[:base].dup.gsub(/\s{4}!UP!\n/m, options[:up]).gsub(/!DOWN!\n/m, options[:down])
             contents = contents.gsub(/!NAME!/, model_name.underscore.camelize).gsub(/!TABLE!/, model_name.underscore)
             contents = contents.gsub(/!FILENAME!/, filename.underscore).gsub(/!FILECLASS!/, filename.underscore.camelize)
-            current_migration_number = return_last_migration_number
-            contents = contents.gsub(/!FIELDS!/, column_declarations).gsub(/!VERSION!/, (current_migration_number + 1).to_s)
-            migration_filename = "#{format("%03d", current_migration_number+1)}_#{filename.underscore}.rb"
+            migration_number = current_migration_number
+            contents = contents.gsub(/!FIELDS!/, column_declarations).gsub(/!VERSION!/, migration_number)
+            migration_filename = "#{format("%03d", migration_number)}_#{filename.underscore}.rb"
             create_file(destination_root('db/migrate/', migration_filename), contents, :skip => true)
           end
         end
@@ -98,7 +98,7 @@ module Padrino
         # For migration files
         # returns the number of the migration that is being created
         # returna timestamp instead if :migration_format: in .components is "timestamp"
-				#
+        #
         # @api private
         def current_migration_number
           if fetch_component_choice(:migration_format).to_s == 'timestamp'

--- a/padrino-gen/test/test_model_generator.rb
+++ b/padrino-gen/test/test_model_generator.rb
@@ -67,13 +67,22 @@ describe "ModelGenerator" do
     end
 
     should "generate migration file versions properly" do
-      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=activerecord') }
+      capture_io { generate(:project, 'sample_project', "--migration_format=number", "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=activerecord') }
       capture_io { generate(:model, 'user', "-r=#{@apptmp}/sample_project") }
       capture_io { generate(:model, 'account', "-r=#{@apptmp}/sample_project") }
       capture_io { generate(:model, 'bank', "-r=#{@apptmp}/sample_project") }
       assert_file_exists("#{@apptmp}/sample_project/db/migrate/001_create_users.rb")
       assert_file_exists("#{@apptmp}/sample_project/db/migrate/002_create_accounts.rb")
       assert_file_exists("#{@apptmp}/sample_project/db/migrate/003_create_banks.rb")
+    end
+
+    should "generate migration file versions properly when timestamped" do
+      capture_io { generate(:project, 'sample_project', "--migration_format=timestamp", "--root=#{@apptmp}", '--script=none', '-t=bacon', '-d=activerecord') }
+
+      time = stop_time_for_test.utc.strftime("%Y%m%d%H%M%S")
+
+      capture_io { generate(:model, 'user', "-r=#{@apptmp}/sample_project") }
+      assert_file_exists("#{@apptmp}/sample_project/db/migrate/#{time}_create_users.rb")
     end
 
     should "generate a default type value for fields" do


### PR DESCRIPTION
Congrats release 0.11.1!

But I was confused that `padrino g model FooBar` created a sequentially-numbered file when I had set `:migration_format: timestamp`

Creating model migration with timestamped file seems to be a proper way.
