### PR TITLE
Fix error of routing when using provides :any and Accept contains */*

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -813,7 +813,7 @@ module Padrino
         def provides(*types)
           @_use_format = true
           condition do
-            mime_types        = types.map { |t| mime_type(t) }
+            mime_types        = types.map { |t| mime_type(t) }.compact
             url_format        = params[:format].to_sym if params[:format]
             accepts           = request.accept.map { |a| a.to_str }
 
@@ -821,11 +821,14 @@ module Padrino
             # Assume */* if no ACCEPT header is given.
             catch_all = (accepts.delete "*/*" || accepts.empty?)
             matching_types = accepts.empty? ? mime_types.slice(0,1) : (accepts & mime_types)
+            if matching_types.empty? && types.include?(:any)
+              matching_types = accepts
+            end
 
             if !url_format && matching_types.first
               type = ::Rack::Mime::MIME_TYPES.find { |k, v| v == matching_types.first }[0].sub(/\./,'').to_sym
               accept_format = CONTENT_TYPE_ALIASES[type] || type
-            elsif catch_all
+            elsif catch_all && !types.include?(:any)
               type = types.first
               accept_format = CONTENT_TYPE_ALIASES[type] || type
             end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -1122,6 +1122,24 @@ describe "Routing" do
     assert_equal 'js', body
   end
 
+  should "set content_type to :html if Accept */* and provides of :any" do
+    mock_app do
+      get("/foo", :provides => :any) { content_type.to_s }
+    end
+
+    get '/foo', {}, { 'HTTP_ACCEPT' => '*/*' }
+    assert_equal 'html', body
+  end
+
+  should "set content_type to :js if Accept includes both application/javascript, */*;q=0.5 and provides of :any" do
+    mock_app do
+      get("/foo", :provides => :any) { content_type.to_s }
+    end
+
+    get '/foo', {}, { 'HTTP_ACCEPT' => 'application/javascript, */*;q=0.5' }
+    assert_equal 'js', body
+  end
+
   should 'allows custom route-conditions to be set via route options and halt' do
     protector = Module.new do
       def protect(*args)


### PR DESCRIPTION
Routing raises Runtime Error when provides option includes :any and ACCEPT header includes "_/_".

```
RuntimeError - Unknown media type: :any:
```
