### PR TITLE
Prevent logging of health-check requests at log level over :debug

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -403,7 +403,7 @@ module Padrino
         env['rack.logger'] = Padrino.logger
         began_at = Time.now
         status, header, body = @app.call(env)
-        log(env, status, header, began_at)
+        log(env, status, header, began_at) if logger.debug?
         [status, header, body]
       end
 

--- a/padrino-core/test/test_logger.rb
+++ b/padrino-core/test/test_logger.rb
@@ -98,6 +98,35 @@ describe "PadrinoLogger" do
         Padrino.logger.instance_eval{ @log_static = false }
       end
     end
+
+    context "health-check requests logging" do
+      def access_to_mock_app
+        mock_app do
+          enable :logging
+          get("/"){ "Foo" }
+        end
+        get "/"
+      end
+
+      should 'output under debug level' do
+        Padrino.logger.instance_eval{ @level = Padrino::Logger::Levels[:debug] }
+        access_to_mock_app
+        assert_match /\e\[36m  DEBUG\e\[0m/, Padrino.logger.log.string
+
+        Padrino.logger.instance_eval{ @level = Padrino::Logger::Levels[:devel] }
+        access_to_mock_app
+        assert_match /\e\[36m  DEBUG\e\[0m/, Padrino.logger.log.string
+      end
+      should 'not output over debug level' do
+        Padrino.logger.instance_eval{ @level = Padrino::Logger::Levels[:info] }
+        access_to_mock_app
+        assert_equal '', Padrino.logger.log.string
+
+        Padrino.logger.instance_eval{ @level = Padrino::Logger::Levels[:error] }
+        access_to_mock_app
+        assert_equal '', Padrino.logger.log.string
+      end
+    end
   end
 end
 


### PR DESCRIPTION
because, even if specify log level anything, It is always output.
Is this the intended behavior?
