### PR TITLE
Add a test to show use case for routing priority

### DIFF
--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -785,6 +785,19 @@ describe "Routing" do
     assert_equal "hello", body
   end
 
+  should 'catch all after controllers' do
+    mock_app do
+      get(:index, :with => :slug, :priority => :low) { "catch all" }
+      controllers :contact do
+        get(:index) { "contact"}
+      end
+    end
+    get "/contact"
+    assert_equal "contact", body
+    get "/foo"
+    assert_equal "catch all", body
+  end
+
   should 'allow optionals' do
     mock_app do
       get(:show, :map => "/stories/:type(/:category)") do


### PR DESCRIPTION
This test shows a (currently failing) use case for routing priority as it worked in 0.10 but seems to be broken in 0.11. 

In my app I have a bunch of urls that related to 'pages' the content of which is stored in a DB. These need to be accessed at /:page_name . I also have some controllers with more 'hard coded' pages (shopping cart/contact form, etc.) The problem is the index route in the app.rb should be the last possible route after all the controllers. As it stands it is about the 3rd route... before all of the controllers and thus catches everything resembling a controller.
