### PR TITLE
ActiveRecord - Downcases emails for login and corrects email used in authenticate method

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
@@ -14,13 +14,19 @@ class <%= @model_name %> < ActiveRecord::Base
 
   # Callbacks
   before_save :encrypt_password, :if => :password_required
+  before_save :downcase_email
 
   ##
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
+    email = email.downcase rescue nil
     account = first(:conditions => { :email => email }) if email.present?
     account && account.has_password?(password) ? account : nil
+  end
+
+  def downcase_email
+    self.email = self.email.downcase rescue nil
   end
 
   def has_password?(password)


### PR DESCRIPTION
Fix for issue 1261: https://github.com/padrino/padrino-framework/issues/1261

All sorts of problems happen if Account emails are not stored downcased or someone tries to login expecting their KevinZAbel@example.com to work.

I force the Account model to callback to downcase the email and then also changed the authenticate model to set the incoming email from params to downcase for comparison.
