### PR TITLE
Fixed a Padrino::Admin bug.

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/application.js
+++ b/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/application.js
@@ -111,6 +111,24 @@
       });
     }
 
+    // Store default values.
+    var defaultValues = {}, xlargeInputs = $('.input-xlarge:not(input[type="checkbox"])');
+    xlargeInputs.each(function() {
+      var input = $(this);
+      defaultValues[input.attr('name')] = input.val();
+    });
+
+    // Remove unnecessary parameters.
+    function removeUnnecessaryAttributes() {
+      xlargeInputs.each(function() {
+        var input = $(this);
+        if(defaultValues[input.attr('name')] === input.val()){
+          input.removeAttr('name');
+        }
+      });
+    }
+    $('.form-actions input').on('click', removeUnnecessaryAttributes);
+
     // Autofocus first field with an error. (usability)
     $('.has-error :input').first().focus();
   });


### PR DESCRIPTION
Hi.
I'm using Mysql, ActiveRecord and Padrino::Admin.
When update a record in the edit page, convert NULL into empty string against my own will.
Therefore, I fixed a javascript `padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/application.js`.

Thanks.
