### PR TITLE
Enable bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development do
   gem "webrat",    ">= 0.5.1"
   gem "haml",      ">= 2.2.22"
   gem "erubis",    ">= 2.7.0"
-  gem "slim",      ">= 1.3.0"
+  gem "slim",      ">= 2.0.0.pre"
   gem "uuid",      ">= 2.3.1"
   gem "builder",   ">= 2.1.2"
   gem "bcrypt-ruby", :require => "bcrypt"


### PR DESCRIPTION
`slim` 1.3.8 requires `tilt` ~> 1.3.3, this butts against another dependancies with `tilt`,
(this is `bundler` bug???) so update `slim` obviously.

Another (temporary) solution:

```
diff --git a/Gemfile b/Gemfile
index a615d4e..04691bb 100644
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   gem "haml",      ">= 2.2.22"
   gem "erubis",    ">= 2.7.0"
   gem "slim",      ">= 1.3.0"
+  gem "tilt",      "~> 1.3.3"
```
