### PR TITLE
Add :file option as a new delivery_method for mails

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/templates/mailer.rb.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/mailer.rb.tt
@@ -33,9 +33,8 @@
 # or storing emails locally:
 #
 #   set :delivery_method, :file => {
-#     :location => "emails",
+#     :location => "#{Padrino.root}/tmp/emails",
 #   }
-#   => generated email will be stored in the folder "#{Padrino.root}/email" folder.
 #
 # and then all delivered mail will use these settings unless otherwise specified.
 #


### PR DESCRIPTION
I was searching for all possible options for sending mails and stumbled upon the [edgerails guide](http://edgeguides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration) which mentioned methods which aren't still part of the documentation.

I updated the `mailer.rb.tt` template with an example.

Matthias
