### PR TITLE
Make sure params inside an action are encoded in UTF-8

### DIFF
--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -110,6 +110,8 @@ describe "Routing" do
   end
 
   should 'encode params using UTF-8' do
+    skip unless ''.respond_to?(:encoding) # for 1.8.7
+
     mock_app do 
       get('/:foo') { params[:foo].encoding.name }
     end


### PR DESCRIPTION
Added a test to ensure that params inside an action are properly encoded in UTF-8. This fixes #210 if all tests pass.
