### PR TITLE
Fix Sequel+sqlite3 on windows connection string

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
@@ -32,9 +32,9 @@ def setup_orm
     require_dependencies 'pg'
     'pg'
   else
-    sequel.gsub!(/!DB_DEVELOPMENT!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_development.db\")")
-    sequel.gsub!(/!DB_PRODUCTION!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_production.db\")")
-    sequel.gsub!(/!DB_TEST!/,"\"sqlite://\" + Padrino.root('db', \"#{db}_test.db\")")
+    sequel.gsub!(/!DB_DEVELOPMENT!/,"\"sqlite:///\" + Padrino.root('db', \"#{db}_development.db\")")
+    sequel.gsub!(/!DB_PRODUCTION!/,"\"sqlite:///\" + Padrino.root('db', \"#{db}_production.db\")")
+    sequel.gsub!(/!DB_TEST!/,"\"sqlite:///\" + Padrino.root('db', \"#{db}_test.db\")")
     require_dependencies 'sqlite3'
     'sqlite3'
   end


### PR DESCRIPTION
Fixes #698 by adding an extra "/" to the connection string when using sqlite3 with Sequel.

It doesn't really hurt Linux/Mac since that extra "/" doesn't really count at all.
