### PR TITLE
Added missing comma to spec_helper.rb when generated using the -t command

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
@@ -15,7 +15,7 @@ end
 #     set :foo, :bar
 #   end
 #
-def app(app = nil &blk)
+def app(app = nil, &blk)
   @app ||= block_given? ? app.instance_eval(&blk) : app
   @app ||= Padrino.application
 end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
@@ -14,7 +14,7 @@ class MiniTest::Unit::TestCase
   #     set :foo, :bar
   #   end
   #
-  def app(app = nil &blk)
+  def app(app = nil, &blk)
     @app ||= block_given? ? app.instance_eval(&blk) : app
     @app ||= Padrino.application
   end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
@@ -19,7 +19,7 @@ class Riot::Situation
   #     set :foo, :bar
   #   end
   #
-  def app(app = nil &blk)
+  def app(app = nil, &blk)
     @app ||= block_given? ? app.instance_eval(&blk) : app
     @app ||= Padrino.application
   end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -15,7 +15,7 @@ end
 #     set :foo, :bar
 #   end
 #
-def app(app = nil &blk)
+def app(app = nil, &blk)
   @app ||= block_given? ? app.instance_eval(&blk) : app
   @app ||= Padrino.application
 end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
@@ -16,7 +16,7 @@ class Test::Unit::TestCase
   #     set :foo, :bar
   #   end
   #
-  def app(app = nil &blk)
+  def app(app = nil, &blk)
     @app ||= block_given? ? app.instance_eval(&blk) : app
     @app ||= Padrino.application
   end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/testspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/testspec.rb
@@ -14,7 +14,7 @@ class Test::Unit::TestCase
   #     set :foo, :bar
   #   end
   #
-  def app(app = nil &blk)
+  def app(app = nil, &blk)
     @app ||= block_given? ? app.instance_eval(&blk) : app
     @app ||= Padrino.application
   end


### PR DESCRIPTION
This fixes the first issue described here:
https://github.com/padrino/padrino-framework/issues/1296

where the spec_helper.rb generated by the command:

> padrino generate project test -b true -t rspec -e erb

creates a spec_helper.rb that is missing a comma at this line:

> def app(app = nil &blk)

The only change made is making the above line this:

> def app(app = nil, &blk)

in the files located at padrino-gen/lib/padrino-gen/generators/components/tests/
