### PR TITLE
Lock nokogiri to 1.5.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
     puts "=> Using sinatra edge"
     gem "sinatra", :git => "git://github.com/sinatra/sinatra.git" # :path => "/Developer/src/Extras/sinatra"
   end
-  gem "nokogiri",  "~> 1.5.9"
+  gem "nokogiri",  "~> 1.5.10"
   gem "json",      ">= 1.5.3"
   gem "rack",      ">= 1.3.0"
   gem "rake",      ">= 0.8.7"


### PR DESCRIPTION
Nokogiri [drops](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc) support for 1.8.7.  
