### PR TITLE
FIX: If action has :provides and unknown extension is specified, RuntimeError is occurred.

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -861,7 +861,7 @@ module Padrino
 
             if matched_format
               @_content_type = url_format || accept_format || :html
-              content_type(@_content_type, :charset => 'utf-8')
+              content_type(@_content_type, :charset => 'utf-8') rescue halt 404
             end
 
             matched_format

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -208,6 +208,8 @@ describe "Routing" do
     end
     get "/a.js"
     assert_equal "/a.json", body
+    get "/a.unknown"
+    assert_equal 404, status
     get "/b.js"
     assert_equal "/b.js", body
     get "/b.ru"


### PR DESCRIPTION
The action has `:provides=>:any`:

```
get :foo, :provides=>:any do
  "foo"
end
```

and GET with unknown extension:

```
GET /foo.unknown
```

then RuntimeError is occurred.

```
RuntimeError - Unknown media type: :unknown:
```
