### PR TITLE
Some auto-detection for authenticity_token & form_tag

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -79,11 +79,15 @@ module Padrino
       def form_tag(url, options={}, &block)
         desired_method = options[:method].to_s
         options.delete(:method) unless desired_method =~ /get|post/i
-        options.reverse_merge!(:method => 'post', :action => url)
+        options.reverse_merge!(:method => 'post', 
+                               :action => url,
+                               :protect_from_csrf => is_protected_from_csrf? )
         options[:enctype] = 'multipart/form-data' if options.delete(:multipart)
         options['accept-charset'] ||= 'UTF-8'
         inner_form_html = hidden_form_method_field(desired_method)
-        inner_form_html << csrf_token_field unless desired_method =~ /get/i
+        if options[:protect_from_csrf] == true && !(desired_method =~ /get/i)
+          inner_form_html << csrf_token_field
+        end
         inner_form_html << mark_safe(capture_html(&block))
         concat_content content_tag(:form, inner_form_html, options)
       end
@@ -884,6 +888,16 @@ module Padrino
           Array(selected_values).any? do |selected|
             [value.to_s, caption.to_s].include?(selected.to_s)
           end
+        end
+
+        ##
+        # Returns whether the application is being protected from csrf
+        #
+        def is_protected_from_csrf?
+          return true unless defined? app
+          return true unless app.respond_to?(:protect_from_csrf)
+          return true if app.protect_from_csrf == nil
+          app.protect_from_csrf
         end
     end # FormHelpers
   end # Helpers

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -88,3 +88,6 @@
     <%= image_submit_tag "buttons/submit.png" %>
   <% end %>
 <% end %>
+
+<% form_tag '/dontprotect', :class => 'no-protection', :protect_from_csrf => false do %>
+<% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -71,3 +71,6 @@
     = submit_tag "Login"
     = button_tag "Cancel"
     = image_submit_tag "buttons/submit.png"
+
+- form_tag '/dontprotect', :class => 'no-protection', :protect_from_csrf => false do
+  = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -72,3 +72,6 @@
     = submit_tag "Login"
     = button_tag "Cancel"
     = image_submit_tag "buttons/submit.png"
+    
+= form_tag '/dontprotect', :class => 'no-protection', :protect_from_csrf => false do
+  = submit_tag "Login"

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -9,6 +9,8 @@ describe "FormHelpers" do
   end
 
   context 'for #form_tag method' do
+    after(:each) { app.set :protect_from_csrf, true }
+    
     should "display correct forms in ruby" do
       actual_html = form_tag('/register', :"accept-charset" => "UTF-8", :class => 'test', :method => "post") { "Demo" }
       assert_has_tag(:form, :"accept-charset" => "UTF-8", :class => "test") { actual_html }
@@ -66,25 +68,50 @@ describe "FormHelpers" do
       assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
     end
 
+    should "have an authenticity_token by default" do
+      actual_html = form_tag('/superadmindelete') { "Demo" }
+      assert_has_tag(:input, :name => 'authenticity_token') { actual_html }
+    end
+
+    should "not have an authenticity_token if passing protect_from_csrf: false" do
+      actual_html = form_tag('/superadmindelete', :protect_from_csrf => false) { "Demo" }
+      assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
+    end
+
+    should "have an authenticity_token if protect_from_csrf is not set on app settings" do
+      app.set :protect_from_csrf, nil
+      actual_html = form_tag('/superadmindelete') { "Demo" }
+      assert_has_tag(:input, :name => 'authenticity_token') { actual_html }
+    end
+
+    should "not have an authenticity_token if protect_from_csrf is false on app settings" do
+      app.set :protect_from_csrf, false
+      actual_html = form_tag('/superadmindelete') { "Demo" }
+      assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
+    end
+
     should "display correct forms in erb" do
       visit '/erb/form_tag'
       assert_have_selector 'form.simple-form', :action => '/simple'
       assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
+      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
     end
 
     should "display correct forms in haml" do
       visit '/haml/form_tag'
       assert_have_selector 'form.simple-form', :action => '/simple'
       assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
+      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
     end
 
     should "display correct forms in slim" do
       visit '/slim/form_tag'
       assert_have_selector 'form.simple-form', :action => '/simple'
       assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
+      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
     end
   end
 


### PR DESCRIPTION
- if the application has protect_from_csrf set to false, do not include authenticity_token
- if :protect_from_csrf => false option is passed to #form_tag, do not include authenticity_token
- defaults to stricter :protect_from_csrf if protection is unknown for safety

Closes #1266
