### PR TITLE
ability for cache_key to be a block

### DIFF
--- a/padrino-cache/lib/padrino-cache/helpers/page.rb
+++ b/padrino-cache/lib/padrino-cache/helpers/page.rb
@@ -121,7 +121,7 @@ module Padrino
                   settings.cache.set(resolve_cache_key || env['PATH_INFO'], content, :expires_in => @_last_expires_in)
                   @_last_expires_in = nil
                 else
-                  settings.cache.set(resolved_key || env['PATH_INFO'], content)
+                  settings.cache.set(resolve_cache_key || env['PATH_INFO'], content)
                 end
 
                 logger.debug "SET Cache", began_at, @route.cache_key || env['PATH_INFO'] if defined?(logger)

--- a/padrino-cache/test/test_padrino_cache.rb
+++ b/padrino-cache/test/test_padrino_cache.rb
@@ -292,4 +292,18 @@ describe "PadrinoCache" do
 
     assert_equal 3, call_count
   end
+
+  should 'raise an error if providing both a cache_key and block' do
+    mock_app do 
+      register Padrino::Cache
+      enable :caching
+
+      get '/foo', :cache => true do
+        cache_key(:some_key) { "key #{params[:id]}" }
+      end
+    end
+
+    assert_raises(RuntimeError) { get '/foo' }
+  end
+
 end


### PR DESCRIPTION
Ref #1064
- Allows cache_key to be block and get re-evaluated each request.
- API:

``` ruby
  get '/foo', :cache => true do
     cache_key { param[:id] }
     "my id is #{param[:id}"
  end
```
