### PR TITLE
File.read is better than "open".

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -45,7 +45,7 @@ module Padrino
         path = File.expand_path(File.dirname(__FILE__) + "/components/#{component.to_s.pluralize}/#{choice}.rb")
         say_status :apply, "#{component.to_s.pluralize}/#{choice}"
         shell.padding += 1
-        instance_eval(open(path).read)
+        instance_eval(File.read(path))
         shell.padding -= 1
       end
 


### PR DESCRIPTION
File.read is faster than open.

```
require 'benchmark'

Benchmark.bm do |x|
  x.report { 1000.times do ; open("foo.txt").read; end }
  x.report { 1000.times do ; File.read("foo.txt"); end }
end
       user     system      total        real
   0.030000   0.000000   0.030000 (  0.034196)
   0.020000   0.010000   0.030000 (  0.024281)
```
