### PR TITLE
Fixed :grouped_options of select_tag.

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -833,9 +833,7 @@ module Padrino
               # {:first => [[1,2,3], {:disabled => true}], :second => [4,5,6]}
               attributes_hash = value.last.is_a?(Hash) ? value.pop : nil
               disabled ||=  attributes_hash && attributes_hash.include?(:disabled) ? attributes_hash[:disabled] : false
-              content_tag :optgroup, :label => key, :disabled => disabled do
-                options_for_select(value, selected)
-              end
+              content_tag :optgroup, options_for_select(value, selected), :label => key, :disabled => disabled
             end
           elsif collection.is_a?(Array)
             # Array format:
@@ -845,9 +843,7 @@ module Padrino
             # the last item tells if it is disabled or not. This is keeps it backwards compatible.
             collection.map do |optgroup|
               disabled ||= optgroup.count > 2 ? optgroup.pop : false
-              content_tag :optgroup, :label => optgroup.first, :disabled => disabled do
-                options_for_select(optgroup.last, selected)
-              end
+              content_tag :optgroup, options_for_select(optgroup.last, selected), :label => optgroup.first, :disabled => disabled
             end
           end
         end

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -19,6 +19,7 @@
     <%= label_tag :gender %>
     <%= label_tag :color %>
     <%= select_tag :color, :options => ['green', 'orange', 'purple'] %>
+    <%= select_tag :type, :grouped_options => { 'foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar'] } %>
     <%= radio_button_tag :gender, :value => 'male' %>
     <%= radio_button_tag :gender, :value => 'female' %>
     <%= submit_tag %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -18,6 +18,7 @@
     = search_field_tag :search
     = label_tag  :color
     = select_tag :color, :options => ['green', 'orange', 'purple']
+    = select_tag :type, :grouped_options => { 'foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar'] }
     = label_tag  :gender
     = radio_button_tag :gender, :value => 'male'
     = radio_button_tag :gender, :value => 'female'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -18,6 +18,7 @@
     = search_field_tag :search
     = label_tag  :color
     = select_tag :color, :options => ['green', 'orange', 'purple']
+    = select_tag :type, :grouped_options => { 'foo' => ['foo', 'bar'], 'bar' => ['foo', 'bar'] }
     = label_tag  :gender
     = radio_button_tag :gender, :value => 'male'
     = radio_button_tag :gender, :value => 'female'

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -787,6 +787,7 @@ describe "FormHelpers" do
       assert_have_selector('select option', :content => 'green',  :value => '1')
       assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
       assert_have_selector('select option', :content => 'purple', :value => '3')
+      assert_have_selector('select optgroup', :label => 'foo')
     end
 
     should "display select tag in haml" do
@@ -799,6 +800,7 @@ describe "FormHelpers" do
       assert_have_selector('select option', :content => 'green',  :value => '1')
       assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
       assert_have_selector('select option', :content => 'purple', :value => '3')
+      assert_have_selector('select optgroup', :label => 'foo')
     end
 
     should "display select tag in slim" do
@@ -811,6 +813,7 @@ describe "FormHelpers" do
       assert_have_selector('select option', :content => 'green',  :value => '1')
       assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
       assert_have_selector('select option', :content => 'purple', :value => '3')
+      assert_have_selector('select optgroup', :label => 'foo')
     end
   end
 


### PR DESCRIPTION
Reference to issue #1294.
When using content_tag and other tag helpers in template of erb or slim, `__erb_in_template` is always defined.
So, I thought that concat_content(output) is executed in #content_tag, against my own will.
This pull request is way of solving without using block in #grouped_options_for_select.
