### PR TITLE
Fix module name including dashes in project generator

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/templates/gem/README.md.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/gem/README.md.tt
@@ -1,4 +1,4 @@
-# <%=name.camelcase%>
+# <%= @project_name %>
 
 A padrino gem
 
@@ -13,7 +13,7 @@ gem '<%=name%>'
 and mount the app in your `apps.rb`:
 
 ```ruby
-Padrino.mount("<%=name.camelcase%>::App").to("/<%=name%>")
+Padrino.mount("<%= @project_name %>::App").to("/<%=name%>")
 ```
 
 ## Development

--- a/padrino-gen/lib/padrino-gen/generators/templates/gem/gemspec.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/gem/gemspec.tt
@@ -11,9 +11,9 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = <%=name.underscore.inspect%>
+  gem.name          = <%= name.downcase.inspect %>
   gem.require_paths = ["lib", "app"]
-  gem.version       = <%=name.camelcase%>::VERSION
+  gem.version       = <%= @project_name %>::VERSION
 
   gem.add_dependency "padrino-core"
 end

--- a/padrino-gen/lib/padrino-gen/generators/templates/gem/lib/libname.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/gem/lib/libname.tt
@@ -1,6 +1,6 @@
 require 'padrino-core'
 
-module <%=name.camelcase%>
+module <%= @project_name %>
   extend Padrino::Module
-  gem! <%=name.downcase.inspect%>
+  gem! <%= name.downcase.inspect %>
 end

--- a/padrino-gen/lib/padrino-gen/generators/templates/gem/lib/libname/version.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/gem/lib/libname/version.tt
@@ -1,3 +1,3 @@
-module <%=name.camelcase%>
+module <%= @project_name %>
   VERSION = '0.0.1'
 end

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -41,6 +41,19 @@ describe "ProjectGenerator" do
       assert_match_in_file("Padrino.mount('ProjectCom::WsDci2011', :app_file => Padrino.root('ws_dci_2011/app.rb')).to('/ws_dci_2011')", "#{@apptmp}/project.com/config/apps.rb")
     end
 
+    should "generate nested path with dashes in name" do
+      capture_io { generate(:project, 'sample-project', "--root=#{@apptmp}") }
+      assert_file_exists("#{@apptmp}/sample-project")
+      assert_match_in_file(/module SampleProject/,  "#{@apptmp}/sample-project/app/app.rb")
+      assert_match_in_file(/class App < Padrino::Application/,  "#{@apptmp}/sample-project/app/app.rb")
+      assert_match_in_file("Padrino.mount('SampleProject::App', :app_file => Padrino.root('app/app.rb')).to('/')", "#{@apptmp}/sample-project/config/apps.rb")
+      capture_io { generate(:app, 'ws-dci-2011', "--root=#{@apptmp}/sample-project") }
+      assert_file_exists("#{@apptmp}/sample-project/ws_dci_2011")
+      assert_match_in_file(/module SampleProject/,  "#{@apptmp}/sample-project/ws_dci_2011/app.rb")
+      assert_match_in_file(/class WsDci2011 < Padrino::Application/,  "#{@apptmp}/sample-project/ws_dci_2011/app.rb")
+      assert_match_in_file("Padrino.mount('SampleProject::WsDci2011', :app_file => Padrino.root('ws_dci_2011/app.rb')).to('/ws_dci_2011')", "#{@apptmp}/sample-project/config/apps.rb")
+    end
+
     should "raise an Error when given invalid constant names" do
       assert_raises(::NameError) { capture_io { generate(:project, "123asdf", "--root=#{@apptmp}") } }
       assert_raises(::NameError) { capture_io { generate(:project, "./sample_project", "--root=#{@apptmp}") } }
@@ -94,6 +107,22 @@ describe "ProjectGenerator" do
       assert_match_in_file(/^module SampleGem/,"#{@apptmp}/sample_gem/app/app.rb")
       assert_match_in_file(/class App/,"#{@apptmp}/sample_gem/app/app.rb")
       assert_file_exists("#{@apptmp}/sample_gem/README.md")
+    end
+
+    should "generate gemspec and special files with dashes in name" do
+      capture_io { generate(:project,'sample-gem', '--gem', "--root=#{@apptmp}") }
+      assert_file_exists("#{@apptmp}/sample-gem/sample-gem.gemspec")
+      assert_file_exists("#{@apptmp}/sample-gem/README.md")
+      assert_match_in_file(/\/lib\/sample-gem\/version/,"#{@apptmp}/sample-gem/sample-gem.gemspec")
+      assert_match_in_file(/"sample-gem"/,"#{@apptmp}/sample-gem/sample-gem.gemspec")
+      assert_match_in_file(/SampleGem::VERSION/,"#{@apptmp}/sample-gem/sample-gem.gemspec")
+      assert_match_in_file(/^# SampleGem/,"#{@apptmp}/sample-gem/README.md")
+      assert_match_in_file(/SampleGem::App/,"#{@apptmp}/sample-gem/README.md")
+      assert_match_in_file(/^module SampleGem/,"#{@apptmp}/sample-gem/lib/sample-gem.rb")
+      assert_match_in_file(/gem! "sample-gem"/,"#{@apptmp}/sample-gem/lib/sample-gem.rb")
+      assert_match_in_file(/^module SampleGem/,"#{@apptmp}/sample-gem/lib/sample-gem/version.rb")
+      assert_match_in_file(/^module SampleGem/,"#{@apptmp}/sample-gem/app/app.rb")
+      assert_match_in_file(/class App/,"#{@apptmp}/sample-gem/app/app.rb")
     end
 
     should "not create models folder if no orm is chosen" do


### PR DESCRIPTION
ref #1242

```
$ padrino g project my-project -g
$ cat my-project/lib/my-project/version.rb
module MyProject
  VERSION = '0.0.1'
end
```
