### PR TITLE
introduce case insensitive authentication by email, closes #1261

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
@@ -19,7 +19,7 @@ class <%= @model_name %> < ActiveRecord::Base
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = first(:conditions => { :email => email }) if email.present?
+    account = first(:conditions => ["lower(email) = lower(?)", email]) if email.present?
     account && account.has_password?(password) ? account : nil
   end
 

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/datamapper.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/datamapper.rb.tt
@@ -29,7 +29,7 @@ class <%= @model_name %>
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = first(:conditions => { :email => email }) if email.present?
+    account = first(:conditions => ["lower(email) = lower(?)", email]) if email.present?
     account && account.has_password?(password) ? account : nil
   end
 

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/minirecord.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/minirecord.rb.tt
@@ -22,7 +22,7 @@ class <%= @model_name %> < ActiveRecord::Base
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = first(:conditions => { :email => email }) if email.present?
+    account = first(:conditions => ["lower(email) = lower(?)", email]) if email.present?
     account && account.has_password?(password) ? account : nil
   end
 

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/mongoid.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/mongoid.rb.tt
@@ -27,7 +27,7 @@ class <%= @model_name %>
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = where(:email => email).first if email.present?
+    account = where(:email => /#{Regexp.escape(email)}/i).first if email.present?
     account && account.has_password?(password) ? account : nil
   end
 

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/mongomapper.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/mongomapper.rb.tt
@@ -27,7 +27,7 @@ class <%= @model_name %>
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = first(:email => email) if email.present?
+    account = first(:email => /#{Regexp.escape(email)}/i) if email.present?
     account && account.has_password?(password) ? account : nil
   end
 

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/sequel.rb.tt
@@ -26,7 +26,7 @@ class <%= @model_name %> < Sequel::Model
   # This method is for authentication purpose
   #
   def self.authenticate(email, password)
-    account = filter(:email => email).first
+    account = filter(Sequel.function(:lower, :email) => Sequel.function(:lower, email)).first
     account && account.has_password?(password) ? account : nil
   end
 


### PR DESCRIPTION
Supported ORMS: activerecord, datamapper, minirecord, mongoid, mongomapper, sequel
ORMs not supporting case insensitive search: ohm
Cryptic ORMS: couchrest
