### PR TITLE
Fix compat with 1.8.7

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -207,13 +207,8 @@ module Padrino
 
     include Extensions
 
-    attr_accessor :level
-    attr_accessor :auto_flush
-    attr_reader   :buffer
-    attr_reader   :log
-    attr_reader   :init_args
-    attr_accessor :log_static
-    attr_reader   :colorize_logging
+    attr_accessor :auto_flush, :level, :log_static
+    attr_reader   :buffer, :colorize_logging, :init_args, :log
 
     ##
     # Configuration for a given environment, possible options are:


### PR DESCRIPTION
The behavior of Module#const_defined? is different in the 1.8.7 and 1.9.x.
