### PR TITLE
padrino rake mi:create_indexes can't retrieve directories of mongoid models

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/mongoid.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/mongoid.rb
@@ -67,7 +67,7 @@ if PadrinoTasks.load?(:mongoid, defined?(Mongoid))
     # Helper to retrieve a list of models.
     def get_mongoid_models
       documents = []
-      Dir['{app,.}/models/*.rb'].sort.each do |file|
+      Dir['{app,.}/models/**/*.rb'].sort.each do |file|
         model_path = file[0..-4].split('/')[2..-1]
 
         begin


### PR DESCRIPTION
if create some direcoty in models, this command not work.
so fix it. please merge this commt ;)
