### PR TITLE
Fix French translation

### DIFF
--- a/padrino-core/lib/padrino-core/locale/fr.yml
+++ b/padrino-core/lib/padrino-core/locale/fr.yml
@@ -10,7 +10,7 @@ fr:
       only_day: "%e"
 
     day_names: [Dimanche, Lundi, Mardi, Mercredi, Jeudi, Vendredi, Samedi]
-    abbr_day_names: [Lun, Mar, Mer, Jeu, Ven, Sam, Dim]
+    abbr_day_names: [Dim, Lun, Mar, Mer, Jeu, Ven, Sam]
     month_names: [~, Janvier, Février, Mars, Avril, Mai, Juin, Juillet, Août, Septembre, Octobre, Novembre, Décembre]
     abbr_month_names: [~, Jan, Fev, Mar, Avr, Mai, Jun, Jul, Aou, Sep, Oct, Nov, Dec]
     order: 


### PR DESCRIPTION
The French translation for `abbr_day_names` is in the wrong order, `Dim` should be first.
