### PR TITLE
add support for em_mysql2 adapter in AR rake tasks

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -60,7 +60,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
         end
       rescue
         case config[:adapter]
-        when 'mysql', 'mysql2', 'jdbcmysql'
+        when 'mysql', 'mysql2', 'em_mysql2', 'jdbcmysql'
           @charset   = ENV['CHARSET']   || 'utf8'
           @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
           creation_options = {:charset => (config[:charset] || @charset), :collation => (config[:collation] || @collation)}
@@ -189,7 +189,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
     task :charset => :environment do
       config = ActiveRecord::Base.configurations[Padrino.env || :development]
       case config[:adapter]
-      when 'mysql', 'mysql2', 'jdbcmysql'
+      when 'mysql', 'mysql2', 'em_mysql2', 'jdbcmysql'
         ActiveRecord::Base.establish_connection(config)
         puts ActiveRecord::Base.connection.charset
       when 'postgresql'
@@ -204,7 +204,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
     task :collation => :environment do
       config = ActiveRecord::Base.configurations[Padrino.env || :development]
       case config[:adapter]
-      when 'mysql', 'mysql2', 'jdbcmysql'
+      when 'mysql', 'mysql2', 'em_mysql2', 'jdbcmysql'
         ActiveRecord::Base.establish_connection(config)
         puts ActiveRecord::Base.connection.collation
       else
@@ -261,7 +261,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       task :dump => :environment do
         abcs = ActiveRecord::Base.configurations
         case abcs[Padrino.env][:adapter]
-        when "mysql", "mysql2", "oci", "oracle", 'jdbcmysql'
+        when "mysql", "mysql2", 'em_mysql2', "oci", "oracle", 'jdbcmysql'
           ActiveRecord::Base.establish_connection(abcs[Padrino.env])
           File.open("#{Padrino.root}/db/#{Padrino.env}_structure.sql", "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
         when "postgresql"
@@ -340,7 +340,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
 
   def drop_database(config)
     case config[:adapter]
-    when 'mysql', 'mysql2', 'jdbcmysql'
+    when 'mysql', 'mysql2', 'em_mysql2', 'jdbcmysql'
       ActiveRecord::Base.establish_connection(config)
       ActiveRecord::Base.connection.drop_database config[:database]
     when /^sqlite/


### PR DESCRIPTION
Support for em_mysql2 adapter in ActiveRecord rake tasks. It all works fine since it's essentially the same mysql2 gem.
