### PR TITLE
Fix prioritized routes don't work in rbx.

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -497,7 +497,7 @@ module Padrino
 
       # Returns all routes that were deferred based on their priority.
       def deferred_routes
-        @deferred_routes ||= ROUTE_PRIORITY.keys.map{[]}
+        @deferred_routes ||= ROUTE_PRIORITY.map{[]}
       end
 
       ##


### PR DESCRIPTION
ref #1362

Seems not guaranteed order of hash.
Therefore, I changed deferred_routes from hash to array.
