### PR TITLE
Adds UTF8 encoding to ORMs Components

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 AR = (<<-AR) unless defined?(AR)
 ##
 # You can use other adapters like:

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/couchrest.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/couchrest.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 COUCHREST = (<<-COUCHREST) unless defined?(COUCHREST)
 case Padrino.env
   when :development then db_name = '!NAME!_development'

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 DM = (<<-DM) unless defined?(DM)
 ##
 # A MySQL connection:

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/minirecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/minirecord.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 MR = (<<-MR) unless defined?(MR)
 ActiveRecord::Base.configurations[:development] = {
 !DB_DEVELOPMENT!

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/mongoid.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/mongoid.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 MONGOID = (<<-MONGO) unless defined?(MONGOID)
 # Connection.new takes host, port
 host = 'localhost'

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/mongomapper.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/mongomapper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 MONGO = (<<-MONGO) unless defined?(MONGO)
 MongoMapper.connection = Mongo::Connection.new('localhost', nil, :logger => logger)
 

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/mongomatic.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/mongomatic.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 MONGOMATIC = (<<-MONGO) unless defined?(MONGOMATIC)
 
 case Padrino.env


### PR DESCRIPTION
Adds UTF8 encoding to ORMs Components to ensure good parsing on instance_eval on padrino-gen/generators/actions.rb:48
