### PR TITLE
Implemented #csrf_meta_tags

### DIFF
--- a/padrino-helpers/test/fixtures/markup_app/app.rb
+++ b/padrino-helpers/test/fixtures/markup_app/app.rb
@@ -10,11 +10,15 @@ class MarkupDemo < Sinatra::Base
   register Padrino::Helpers
 
   configure do
+    set :logging, false
+    set :padrino_logging, false
+    set :environment, :test
     set :root, File.dirname(__FILE__)
     set :erb, :engine_class => Padrino::Erubis::SafeBufferTemplate
     set :haml, :escape_html => true
-    set :slim, :generator => Temple::Generators::RailsOutputBuffer,
-               :buffer => "out_buf"
+    set :slim, :generator => Temple::Generators::RailsOutputBuffer, :buffer => "out_buf"
+    set :sessions, true
+    set :protect_from_csrf, true
   end
 
   get '/:engine/:file' do

--- a/padrino-helpers/test/fixtures/render_app/app.rb
+++ b/padrino-helpers/test/fixtures/render_app/app.rb
@@ -16,6 +16,7 @@ class RenderDemo < Padrino::Application
   configure do
     set :logging, false
     set :padrino_logging, false
+    set :environment, :test
     set :erb, :engine_class => Padrino::Erubis::SafeBufferTemplate
     set :haml, :escape_html => true
     set :slim, :generator => Temple::Generators::RailsOutputBuffer

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -5,7 +5,7 @@ describe "AssetTagHelpers" do
   include Padrino::Helpers::AssetTagHelpers
 
   def app
-    MarkupDemo.tap { |app| app.set :environment, :test }
+    MarkupDemo
   end
 
   def flash

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -4,15 +4,15 @@ require File.expand_path(File.dirname(__FILE__) + '/fixtures/markup_app/app')
 describe "FormBuilder" do
   include Padrino::Helpers::FormHelpers
 
+  def app
+    MarkupDemo
+  end
+
   # Dummy form builder for testing
   module Padrino::Helpers::FormBuilder
     class FakeFormBuilder < AbstractFormBuilder
       def foo_field; @template.content_tag(:span, "bar"); end
     end
-  end
-
-  def app
-    MarkupDemo.tap { |app| app.set :environment, :test }
   end
 
   def setup
@@ -49,8 +49,7 @@ describe "FormBuilder" do
     end
 
     should "display form specifying default builder setting" do
-      self.expects(:settings).returns(stub(:default_builder => 'FakeFormBuilder')).once
-      actual_html = ""
+      self.expects(:settings).returns(stub(:default_builder => 'FakeFormBuilder', :protect_from_csrf => false)).at_least_once
       actual_html = form_for(@user, '/register', :id => 'register', :"accept-charset" => "UTF-8", :method => 'post') { |f| f.foo_field }
       assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :method => 'post') { actual_html }
       assert_has_tag('span', :content => "bar") { actual_html }

--- a/padrino-helpers/test/test_format_helpers.rb
+++ b/padrino-helpers/test/test_format_helpers.rb
@@ -2,15 +2,15 @@ require File.expand_path(File.dirname(__FILE__) + '/helper')
 require File.expand_path(File.dirname(__FILE__) + '/fixtures/markup_app/app')
 
 describe "FormatHelpers" do
+  include Padrino::Helpers::FormatHelpers
+
   def app
-    MarkupDemo.tap { |app| app.set :environment, :test }
+    MarkupDemo
   end
 
   def setup
     Time.stubs(:now).returns(Time.utc(1983, 11, 9, 5))
   end
-
-  include Padrino::Helpers::FormatHelpers
 
   context 'for #simple_format method' do
     should "format simple text into html format" do

--- a/padrino-helpers/test/test_number_helpers.rb
+++ b/padrino-helpers/test/test_number_helpers.rb
@@ -4,6 +4,10 @@ require File.expand_path(File.dirname(__FILE__) + '/fixtures/markup_app/app')
 describe "NumberHelpers" do
   include Padrino::Helpers::NumberHelpers
 
+  def app
+    MarkupDemo
+  end
+
   def kilobytes(number)
     number * 1024
   end

--- a/padrino-helpers/test/test_output_helpers.rb
+++ b/padrino-helpers/test/test_output_helpers.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/fixtures/markup_app/app')
 
 describe "OutputHelpers" do
   def app
-    MarkupDemo.tap { |app| app.set :environment, :test }
+    MarkupDemo
   end
 
   context 'for #content_for method' do

--- a/padrino-helpers/test/test_render_helpers.rb
+++ b/padrino-helpers/test/test_render_helpers.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/fixtures/render_app/app')
 
 describe "RenderHelpers" do
   def app
-    RenderDemo.tap { |app| app.set :environment, :test }
+    RenderDemo
   end
 
   context 'for #partial method and object' do

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/fixtures/markup_app/app')
 
 describe "TagHelpers" do
   def app
-    MarkupDemo.tap { |app| app.set :environment, :test }
+    MarkupDemo
   end
 
   context 'for #tag method' do


### PR DESCRIPTION
- Implemented #csrf_meta_tags. It complies with [Rails implementation](https://github.com/padrino/padrino-framework/issues/1127#issuecomment-16068768)
  and will generate two meta tags one with the `csrf-param` your app is
  expecting and the other with the `csrf-token`. Fixes #1127 and #1251.
- Added a csrf_param setting to allow you to tell what your CSRF token's
  field name should be when sent as a form parameter. It defaults to
  `authenticity_token`. `rack-protection` doesn't allow for that param to
  be set, so if you do so and want the middleware to work correctly you'll
  have to patch it or use your own validations for now - [see this](https://github.com/rkh/rack-protection/pull/65).
- Refactored and cleaned up the CSRF helpers' code base and some
  helpers' tests.
