### PR TITLE
Set default id attribute on form helper elements

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -357,17 +357,17 @@ module Padrino
       #
       # @example
       #   text_field_tag :first_name, :maxlength => 40, :required => true
-      #   # => <input name="first_name" maxlength="40" required type="text" />
+      #   # => <input id="first_name" name="first_name" maxlength="40" required type="text" />
       #
       #   text_field_tag :last_name, :class => 'string', :size => 40
-      #   # => <input name="last_name" class="string" size="40" type="text" />
+      #   # => <input id="last_name" name="last_name" class="string" size="40" type="text" />
       #
       #   text_field_tag :username, :placeholder => 'Your Username'
-      #   # => <input name="username" placeholder="Your Username" type="text" />
+      #   # => <input id="username" name="username" placeholder="Your Username" type="text" />
       #
       # @api public
       def text_field_tag(name, options={})
-        input_tag(:text, options.reverse_merge!(:name => name))
+        input_tag(:text, options.reverse_merge!(:name => name, :id => name))
       end
 
       ##
@@ -419,20 +419,20 @@ module Padrino
       #
       # @example
       #   number_field_tag :quanity, :class => 'numeric'
-      #   # => <input name="quanity" class="numeric" type="number" />
+      #   # => <input id="quantity" name="quanity" class="numeric" type="number" />
       #
       #   number_field_tag :zip_code, :pattern => /[0-9]{5}/
-      #   # => <input name="zip_code" pattern="[0-9]{5}" type="number" />
+      #   # => <input id="zip_code" name="zip_code" pattern="[0-9]{5}" type="number" />
       #
       #   number_field_tag :credit_card, :autocomplete => :off
-      #   # => <input name="credit_card" autocomplete="off" type="number" />
+      #   # => <input id="credit_card" name="credit_card" autocomplete="off" type="number" />
       #
       #   number_field_tag :age, :min => 18, :max => 120, :step => 1
-      #   # => <input name="age" min="18" max="120" step="1" type="number" />
+      #   # => <input id="age" name="age" min="18" max="120" step="1" type="number" />
       #
       # @api public
       def number_field_tag(name, options={})
-        input_tag(:number, options.reverse_merge(:name => name))
+        input_tag(:number, options.reverse_merge(:name => name, :id => name))
       end
 
       ##
@@ -448,13 +448,13 @@ module Padrino
       #  telephone_field_tag :work_phone, :tabindex => 2
       #  telephone_field_tag :home_phone, :tabindex => 3
       #
-      #  # => <input name="cell_phone" tabindex="1" type="tel" />
-      #  # => <input name="work_phone" tabindex="2" type="tel" />
-      #  # => <input name="home_phone" tabindex="3" type="tel" />
+      #  # => <input id="cell_phone" name="cell_phone" tabindex="1" type="tel" />
+      #  # => <input id="work_phone" name="work_phone" tabindex="2" type="tel" />
+      #  # => <input id="home_phone" name="home_phone" tabindex="3" type="tel" />
       #
       # @api public
       def telephone_field_tag(name, options={})
-        input_tag(:tel, options.reverse_merge(:name => name))
+        input_tag(:tel, options.reverse_merge(:name => name, :id => name))
       end
       alias_method :phone_field_tag, :telephone_field_tag
 
@@ -465,14 +465,14 @@ module Padrino
       #
       # @example
       #   email_field_tag :email, :placeholder => 'you@example.com'
-      #   # => <input name="email" placeholder="you@example.com" type="email" />
+      #   # => <input id="email" name="email" placeholder="you@example.com" type="email" />
       #
       #   email_field_tag :email, :value => 'padrinorb@gmail.com', :readonly => true
-      #   # => <input name="email" value="padrinorb@gmail.com" readonly type="email" />
+      #   # => <input id="email" name="email" value="padrinorb@gmail.com" readonly type="email" />
       #
       # @api public
       def email_field_tag(name, options={})
-        input_tag(:email, options.reverse_merge(:name => name))
+        input_tag(:email, options.reverse_merge(:name => name, :id => name))
       end
 
       ##
@@ -482,20 +482,20 @@ module Padrino
       #
       # @example
       #  search_field_tag :search, :placeholder => 'Search this website...'
-      #  # => <input name="search" placeholder="Search this website..." type="search" />
+      #  # => <input id="search" name="search" placeholder="Search this website..." type="search" />
       #
       #  search_field_tag :search, :maxlength => 15, :class => ['search', 'string']
-      #  # => <input name="search" maxlength="15" class="search string" />
+      #  # => <input id="search" name="search" maxlength="15" class="search string" />
       #
       #  search_field_tag :search, :id => 'search'
       #  # => <input name="search" id="search" type="search" />
       #
       #  search_field_tag :search, :autofocus => true
-      #  # => <input name="search" autofocus type="search" />
+      #  # => <input id="search" name="search" autofocus type="search" />
       #
       # @api public
       def search_field_tag(name, options={})
-        input_tag(:search, options.reverse_merge(:name => name))
+        input_tag(:search, options.reverse_merge(:name => name, :id => name))
       end
 
       ##
@@ -505,14 +505,14 @@ module Padrino
       #
       # @example
       #  url_field_tag :favorite_website, :placeholder => 'http://padrinorb.com'
-      #  <input name="favorite_website" placeholder="http://padrinorb.com." type="url" />
+      #  <input id="favorite_website" name="favorite_website" placeholder="http://padrinorb.com." type="url" />
       #
       #  url_field_tag :home_page, :class => 'string url'
-      #  <input name="home_page" class="string url", type="url" />
+      #  <input id="home_page" name="home_page" class="string url", type="url" />
       #
       # @api public
       def url_field_tag(name, options={})
-        input_tag(:url, options.reverse_merge(:name => name))
+        input_tag(:url, options.reverse_merge(:name => name, :id => name))
       end
 
       ##
@@ -525,7 +525,7 @@ module Padrino
       #
       # @api public
       def hidden_field_tag(name, options={})
-        options.reverse_merge!(:name => name)
+        options.reverse_merge!(:name => name, :id => name)
         input_tag(:hidden, options)
       end
 
@@ -539,7 +539,7 @@ module Padrino
       #
       # @api public
       def text_area_tag(name, options={})
-        options.reverse_merge!(:name => name, :rows => "", :cols => "")
+        options.reverse_merge!(:name => name, :rows => "", :cols => "", :id => name)
         content_tag(:textarea, options.delete(:value).to_s, options)
       end
 
@@ -553,7 +553,7 @@ module Padrino
       #
       # @api public
       def password_field_tag(name, options={})
-        options.reverse_merge!(:name => name)
+        options.reverse_merge!(:name => name, :id => name)
         input_tag(:password, options)
       end
 
@@ -567,7 +567,7 @@ module Padrino
       #
       # @api public
       def check_box_tag(name, options={})
-        options.reverse_merge!(:name => name, :value => '1')
+        options.reverse_merge!(:name => name, :value => '1', :id => name)
         input_tag(:checkbox, options)
       end
 
@@ -581,7 +581,8 @@ module Padrino
       #
       # @api public
       def radio_button_tag(name, options={})
-        options.reverse_merge!(:name => name)
+        id = options[:value] ? "#{name}_#{options[:value].parameterize.underscore}" : name
+        options.reverse_merge!(:name => name, :id => id)
         input_tag(:radio, options)
       end
 
@@ -596,7 +597,7 @@ module Padrino
       # @api public
       def file_field_tag(name, options={})
         name = "#{name}[]" if options[:multiple]
-        options.reverse_merge!(:name => name)
+        options.reverse_merge!(:name => name, :id => name)
         input_tag(:file, options)
       end
 
@@ -642,7 +643,7 @@ module Padrino
       #
       # @api public
       def select_tag(name, options={})
-        options.reverse_merge!(:name => name)
+        options.reverse_merge!(:name => name, :id => name)
         collection, fields = options.delete(:collection), options.delete(:fields)
         options[:options] = options_from_collection(collection, fields) if collection
         prompt = options.delete(:include_blank)
@@ -798,7 +799,7 @@ module Padrino
       #
       # @api public
       def range_field_tag(name, options = {})
-        options.reverse_merge!(:name => name)
+        options.reverse_merge!(:name => name, :id => name)
         if range = options.delete(:range)
           options[:min], options[:max] = range.min, range.max
         end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -328,7 +328,7 @@ describe "FormHelpers" do
   context 'for #text_field_tag method' do
     should "display text field in ruby" do
       actual_html = text_field_tag(:username, :class => 'long')
-      assert_has_tag(:input, :type => 'text', :class => "long", :name => 'username') { actual_html }
+      assert_has_tag(:input, :type => 'text', :class => "long", :name => 'username', :id => 'username') { actual_html }
     end
 
     should "display text field in erb" do
@@ -353,7 +353,7 @@ describe "FormHelpers" do
   context 'for #number_field_tag method' do
     should "display number field in ruby" do
       actual_html = number_field_tag(:age, :class => 'numeric')
-      assert_has_tag(:input, :type => 'number', :class => 'numeric', :name => 'age') { actual_html }
+      assert_has_tag(:input, :type => 'number', :class => 'numeric', :name => 'age', :id => 'age') { actual_html }
     end
 
     should "display number field in erb" do
@@ -378,7 +378,7 @@ describe "FormHelpers" do
   context 'for #telephone_field_tag method' do
     should "display number field in ruby" do
       actual_html = telephone_field_tag(:telephone, :class => 'numeric')
-      assert_has_tag(:input, :type => 'tel', :class => 'numeric', :name => 'telephone') { actual_html }
+      assert_has_tag(:input, :type => 'tel', :class => 'numeric', :name => 'telephone', :id => 'telephone') { actual_html }
     end
 
     should "display telephone field in erb" do
@@ -403,7 +403,7 @@ describe "FormHelpers" do
   context 'for #search_field_tag method' do
     should "display search field in ruby" do
       actual_html = search_field_tag(:search, :class => 'string')
-      assert_has_tag(:input, :type => 'search', :class => 'string', :name => 'search') { actual_html }
+      assert_has_tag(:input, :type => 'search', :class => 'string', :name => 'search', :id => 'search') { actual_html }
     end
 
     should "display search field in erb" do
@@ -428,7 +428,7 @@ describe "FormHelpers" do
   context 'for #email_field_tag method' do
     should "display email field in ruby" do
       actual_html = email_field_tag(:email, :class => 'string')
-      assert_has_tag(:input, :type => 'email', :class => 'string', :name => 'email') { actual_html }
+      assert_has_tag(:input, :type => 'email', :class => 'string', :name => 'email', :id => 'email') { actual_html }
     end
 
     should "display email field in erb" do
@@ -453,7 +453,7 @@ describe "FormHelpers" do
   context 'for #url_field_tag method' do
     should "display url field in ruby" do
       actual_html = url_field_tag(:webpage, :class => 'string')
-      assert_has_tag(:input, :type => 'url', :class => 'string', :name => 'webpage') { actual_html }
+      assert_has_tag(:input, :type => 'url', :class => 'string', :name => 'webpage', :id => 'webpage') { actual_html }
     end
 
     should "display url field in erb" do
@@ -478,7 +478,7 @@ describe "FormHelpers" do
   context 'for #text_area_tag method' do
     should "display text area in ruby" do
       actual_html = text_area_tag(:about, :class => 'long')
-      assert_has_tag(:textarea, :class => "long", :name => 'about') { actual_html }
+      assert_has_tag(:textarea, :class => "long", :name => 'about', :id => 'about') { actual_html }
     end
 
     should "display text area in ruby with specified content" do
@@ -505,7 +505,7 @@ describe "FormHelpers" do
   context 'for #password_field_tag method' do
     should "display password field in ruby" do
       actual_html = password_field_tag(:password, :class => 'long')
-      assert_has_tag(:input, :type => 'password', :class => "long", :name => 'password') { actual_html }
+      assert_has_tag(:input, :type => 'password', :class => "long", :name => 'password', :id => 'password') { actual_html }
     end
 
     should "display password field in erb" do
@@ -530,7 +530,7 @@ describe "FormHelpers" do
   context 'for #file_field_tag method' do
     should "display file field in ruby" do
       actual_html = file_field_tag(:photo, :class => 'photo')
-      assert_has_tag(:input, :type => 'file', :class => "photo", :name => 'photo') { actual_html }
+      assert_has_tag(:input, :type => 'file', :class => "photo", :name => 'photo', :id => 'photo') { actual_html }
     end
 
     should "have an array name with multiple option" do
@@ -557,7 +557,7 @@ describe "FormHelpers" do
   context "for #check_box_tag method" do
     should "display check_box tag in ruby" do
       actual_html = check_box_tag("clear_session")
-      assert_has_tag(:input, :type => 'checkbox', :value => '1', :name => 'clear_session') { actual_html }
+      assert_has_tag(:input, :type => 'checkbox', :value => '1', :name => 'clear_session', :id => 'clear_session') { actual_html }
       assert_has_no_tag(:input, :type => 'hidden') { actual_html }
     end
 
@@ -586,9 +586,15 @@ describe "FormHelpers" do
   end
 
   context "for #radio_button_tag method" do
+
+    should "display radio_button tag without a value in ruby" do
+      actual_html = radio_button_tag("gender")
+      assert_has_tag(:input, :type => 'radio', :name => 'gender', :id => 'gender') { actual_html }
+    end
+
     should "display radio_button tag in ruby" do
       actual_html = radio_button_tag("gender", :value => 'male')
-      assert_has_tag(:input, :type => 'radio', :value => 'male', :name => 'gender') { actual_html }
+      assert_has_tag(:input, :type => 'radio', :value => 'male', :name => 'gender', :id => 'gender_male') { actual_html }
     end
 
     should "display radio_button tag in ruby with extended attributes" do
@@ -624,7 +630,7 @@ describe "FormHelpers" do
   context "for #select_tag method" do
     should "display select tag in ruby" do
       actual_html = select_tag(:favorite_color, :options => ['green', 'blue', 'black'], :include_blank => true)
-      assert_has_tag(:select, :name => 'favorite_color') { actual_html }
+      assert_has_tag(:select, :name => 'favorite_color', :id => 'favorite_color') { actual_html }
       assert_has_tag('select option:first-child', :content => '') { actual_html }
       assert_has_tag('select option', :content => 'green', :value => 'green') { actual_html }
       assert_has_tag('select option', :content => 'blue',  :value => 'blue')  { actual_html }


### PR DESCRIPTION
Setting a default id on elements created by form helpers makes creating
input/tag pairs easier. For example:

```
<%= label_tag :first_name %>
<%= text_field_tag :first_name %>
```

results in:

```
<label for="first_name">First name: </label>
<input type="text" id="first_name" name="first_name" />
```

Radio buttons are handled a bit differently. The default id will be
generated from the name and value. If no value exists the name alone
will be used.
