### PR TITLE
Fix mocha deprecation warnings with riot and change insert_into_gemfile to allow :require => false

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -307,7 +307,7 @@ WARNING
       def insert_into_gemfile(name, options={})
         after_pattern = options[:group] ? "#{options[:group].to_s.capitalize} requirements\n" : "Component requirements\n"
         version       = options.delete(:version)
-        gem_options   = options.map { |k, v| ":#{k} => '#{v.to_s}'" }.join(", ")
+        gem_options   = options.map { |k, v| k.to_s == 'require' && [true,false].include?(v) ? ":#{k} => #{v}" : ":#{k} => '#{v.to_s}'" }.join(", ")
         write_option  = gem_options.present? ? ", #{gem_options}" : ''
         write_version = version.present? ? ", '#{version.to_s}'" : ''
         include_text  = "gem '#{name}'" << write_version << write_option << "\n"

--- a/padrino-gen/lib/padrino-gen/generators/components/mocks/mocha.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/mocks/mocha.rb
@@ -1,9 +1,10 @@
 def setup_mock
-  require_dependencies 'mocha', :group => 'test'
+  require_dependencies 'mocha', :group => 'test', :require => false
   case options[:test].to_s
     when 'rspec'
       inject_into_file 'spec/spec_helper.rb', "  conf.mock_with :mocha\n", :after => "RSpec.configure do |conf|\n"
     else
+      inject_into_file 'test/test_config.rb', "require 'mocha/api'", :after => "require File.expand_path(File.dirname(__FILE__) + \"/../config/boot\")\n"
       insert_mocking_include "Mocha::API"
   end
 end

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -221,6 +221,13 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'mocha'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/conf.mock_with :mocha/m, "#{@apptmp}/sample_project/spec/spec_helper.rb")
     end
+
+    should "properly generate for mocha and riot" do
+      out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--test=riot', '--mock=mocha', '--script=none') }
+      assert_match(/applying.*?mocha.*?mock/, out)
+      assert_match_in_file(/gem 'mocha'.*require => false/, "#{@apptmp}/sample_project/Gemfile")
+      assert_match_in_file(/require 'mocha\/api'/, "#{@apptmp}/sample_project/test/test_config.rb")
+    end
   end
 
   context "the generator for orm components" do


### PR DESCRIPTION
This commit allows :require => false to be used with insert_into_gemfile (before it would enter it as :require => 'false' and also fixes deprecation warning from mocha when used with riot
