### PR TITLE
Use tilt 1.4.0+ (fixes haml & UTF-8 issue #519)

### DIFF
--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   # s.post_install_message << " as shown here:\e[0m https://gist.github.com/1d36a35794dbbd664ea4"
   # s.post_install_message << "\n\e[32m" + ("*" * 20) + "\n\e[0m"
 
-  s.add_dependency("tilt", "~> 1.3.7")
+  s.add_dependency("tilt", "~> 1.4.0")
   if ENV["SINATRA_EDGE"]
     s.add_dependency("sinatra")
   else


### PR DESCRIPTION
Today, when I tried Padrino it failed to render haml page with my native characters in UTF-8 format.
I tried Sinatra and it didn't have problem.

I soon found issue #519. While this https://github.com/padrino/padrino-framework/issues/519#issuecomment-4750542 comment worked for rendering, it broke rspec.

Looking at Gemspec.lock of my projects with Sinatra and Padrino I noticed that Sinatra had newer tilt.
So I tried updating tilt for Padrino. It worked - I could render the page that failed previously.

I ran tests and they all passes. Hope you'll merge this one.
