### PR TITLE
Make it possible to pass options to submit_tag when using button_to

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -766,6 +766,8 @@ module Padrino
       #   Instructs ujs handler to handle the submit as ajax.
       # @option options [Symbol] :method
       #   Instructs ujs handler to use different http method (i.e :post, :delete).
+      # @option options [Hash] :submit_options
+      #   Hash of any options, that you want to pass to submit_tag (i.e :id, :class)
       #
       # @return [String] Form and button html with specified +options+.
       #
@@ -782,11 +784,12 @@ module Padrino
         name, url = args[0], args[1]
         options   = args.extract_options!
         options['data-remote'] = 'true' if options.delete(:remote)
+        submit_options = options.delete(:submit_options) || {}
         if block_given?
           form_tag(url, options, &block)
         else
           form_tag(url, options.merge!(:not_concat => true)) do
-            submit_tag(name)
+            submit_tag(name, submit_options)
           end
         end
       end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -968,6 +968,11 @@ describe "FormHelpers" do
       assert_has_tag('form button', :type => 'submit', :content => "My button's content", :title => "My button") { actual_html }
     end
 
+    should "pass options on submit button when submit_options are given" do
+      actual_html = button_to("Fancy button", '/users/1', :submit_options => { :class => :fancy })
+      assert_has_tag('form input', :type => 'submit', :value => 'Fancy button', :class => 'fancy') { actual_html }
+    end
+
     should 'display correct button_to in erb' do
       visit '/erb/button_to'
       assert_have_selector('form', :action => '/foo')


### PR DESCRIPTION
Use case:
I wanted to add simple button with specific class. Turns out I had to pass a block. For such a simple scenario I think it's too much of work. So I propose this change (test included).
