### PR TITLE
simple_format - Prevent too much escaped html

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/format_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/format_helpers.rb
@@ -77,9 +77,8 @@ module Padrino
       #
       def simple_format(text, options={})
         t = options.delete(:tag) || :p
-        s = options.delete(:sanitize)
         start_tag = tag(t, options, true)
-        text = escape_html(text.to_s.dup) unless s == false
+        text = escape_html(text.to_s.dup) unless text.html_safe?
         text.gsub!(/\r\n?/, "\n")                      # \r\n and \r -> \n
         text.gsub!(/\n\n+/, "</#{t}>\n\n#{start_tag}") # 2+ newline  -> paragraph
         text.gsub!(/([^\n]\n)(?=[^\n])/, '\1<br />')   # 1 newline   -> br

--- a/padrino-helpers/test/test_format_helpers.rb
+++ b/padrino-helpers/test/test_format_helpers.rb
@@ -35,7 +35,7 @@ describe "FormatHelpers" do
     end
 
     should "support already sanitized text" do
-      actual_text = simple_format("Don't try to escape <b>me</b>!", :sanitize => false)
+      actual_text = simple_format("Don't try to escape <b>me</b>!".html_safe)
       assert_equal "<p>Don't try to escape <b>me</b>!</p>", actual_text
     end
 


### PR DESCRIPTION
Hi,
# simple_format always escape html, but in some case this is too much.

Let us the choice about escaping or not !
