### PR TITLE
Add task generator.

### DIFF
--- a/padrino-gen/lib/padrino-gen.rb
+++ b/padrino-gen/lib/padrino-gen.rb
@@ -68,7 +68,7 @@ module Padrino
 end
 
 # Add our generators to Padrino::Generators.
-Padrino::Generators.load_paths << Dir[File.dirname(__FILE__) + '/padrino-gen/generators/{project,app,mailer,controller,model,migration,plugin,component}.rb']
+Padrino::Generators.load_paths << Dir[File.dirname(__FILE__) + '/padrino-gen/generators/{project,app,mailer,controller,model,migration,plugin,component,task}.rb']
 
 # Add our tasks to padrino-core.
 Padrino::Tasks.files << Dir[File.dirname(__FILE__) + "/padrino-gen/padrino-tasks/**/*.rb"]

--- a/padrino-gen/lib/padrino-gen/generators/task.rb
+++ b/padrino-gen/lib/padrino-gen/generators/task.rb
@@ -1,0 +1,45 @@
+module Padrino
+  module Generators
+    ##
+    # Responsible for generating new task file for Padrino application.
+    #
+    class Task < Thor::Group
+      include Thor::Actions
+      include Padrino::Generators::Actions
+      include Padrino::Generators::Components::Actions
+
+      Padrino::Generators.add_generator(:task, self)
+
+      class << self
+        def source_root; File.expand_path(File.dirname(__FILE__)); end
+        def banner; "padrino-gen task [name]"; end
+      end
+
+      desc "Description:\n\n\tpadrino-gen task generates a new task file."
+
+      argument     :name,        :desc => 'The name of your application task'
+      class_option :root,        :desc => 'The root destination',                     :aliases => '-r', :default => '.', :type => :string
+      class_option :description, :desc => 'The description of your application task', :aliases => '-d', :default => nil, :type => :string
+      class_option :namespace,   :desc => 'The namespace of your application task',   :aliases => '-n', :default => nil, :type => :string
+
+      # Show help if no ARGV given
+      require_arguments!
+
+      def create_task
+        self.destination_root = options[:root]
+        if in_app_root?
+          app        = options[:app]
+          @task_name = name.to_s.underscore
+          @namespace = options[:namespace].underscore if options[:namespace]
+          @desc      = options[:description]
+          filename   = @task_name + ".rake"
+          filename   = "#{@namespace}_#{filename}" if @namespace
+
+          template 'templates/task.rb.tt', destination_root('tasks', filename)
+        else
+          say 'You are not at the root of a Padrino application! (config/boot.rb not found)'
+        end
+      end
+    end
+  end
+end

--- a/padrino-gen/lib/padrino-gen/generators/templates/task.rb.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/task.rb.tt
@@ -1,0 +1,7 @@
+<%= "namespace :#{@namespace} do" if @namespace %>
+  <%= "desc \"#{@desc}\"" if @desc %>
+  task :<%= @task_name %> => :environment do
+    # This is a custom task.
+  end
+<%= "end" if @namespace %>
+

--- a/padrino-gen/test/test_generator.rb
+++ b/padrino-gen/test/test_generator.rb
@@ -4,7 +4,7 @@ describe "Generator" do
 
   context "the generator" do
     should "have default generators" do
-      %w{controller mailer migration model app plugin component}.each do |gen|
+      %w{controller mailer migration model app plugin component task}.each do |gen|
         assert Padrino::Generators.mappings.has_key?(gen.to_sym)
         assert_equal "Padrino::Generators::#{gen.camelize}", Padrino::Generators.mappings[gen.to_sym].name
         assert Padrino::Generators.mappings[gen.to_sym].respond_to?(:start)

--- a/padrino-gen/test/test_task_generator.rb
+++ b/padrino-gen/test/test_task_generator.rb
@@ -1,0 +1,53 @@
+require File.expand_path(File.dirname(__FILE__) + '/helper')
+
+describe "TaskGenerator" do
+  def setup
+    @apptmp = "#{Dir.tmpdir}/padrino-tests/#{UUID.new.generate}"
+    `mkdir -p #{@apptmp}`
+  end
+
+  def teardown
+    `rm -rf #{@apptmp}`
+  end
+
+  context 'the task generator' do
+    should "fail outside app root" do
+      out, err = capture_io { generate(:task, 'foo', "-r=#{@apptmp}") }
+      assert_match(/not at the root/, out)
+      assert_no_file_exists('/tmp/tasks/foo.rake')
+    end
+
+    should "generate filename properly" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      capture_io { generate(:task, 'DemoTask', "--namespace=Sample", "--description='This is a sample'", "-r=#{@apptmp}/sample_project") }
+      assert_file_exists("#{@apptmp}/sample_project/tasks/sample_demo_task.rake")
+    end
+
+    should "generate task file with description" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      capture_io { generate(:task, 'foo', "--description=This is a sample", "-r=#{@apptmp}/sample_project") }
+      file_path = "#{@apptmp}/sample_project/tasks/foo.rake"
+      assert_no_match_in_file(/namespace/, file_path)
+      assert_match_in_file(/desc "This is a sample"/, file_path)
+      assert_match_in_file(/task :foo => :environment do/, file_path)
+    end
+
+    should "generate task file with namespace" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      capture_io { generate(:task, 'foo', "--namespace=Sample", "-r=#{@apptmp}/sample_project") }
+      file_path = "#{@apptmp}/sample_project/tasks/sample_foo.rake"
+      assert_match_in_file(/namespace :sample do/, file_path)
+      assert_match_in_file(/task :foo => :environment do/, file_path)
+      assert_no_match_in_file(/desc/, file_path)
+    end
+
+    should "generate task file with snake case name when using camelized name" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      capture_io { generate(:task, 'DemoTask', "--namespace=Sample", "--description=This is a sample", "-r=#{@apptmp}/sample_project") }
+      file_path = "#{@apptmp}/sample_project/tasks/sample_demo_task.rake"
+      assert_match_in_file(/namespace :sample do/, file_path)
+      assert_match_in_file(/desc "This is a sample"/, file_path)
+      assert_match_in_file(/task :demo_task => :environment do/, file_path)
+    end
+  end
+end


### PR DESCRIPTION
ref #1200 

```
$ padrino g task
Usage:
  padrino-gen task [name]

Options:
  -r, [--root=ROOT]                # The root destination
                                   # Default: .
  -d, [--description=DESCRIPTION]  # The description of your application task
  -n, [--namespace=NAMESPACE]      # The namespace of your application task

Description:

    padrino-gen task generates a new task file.

```

How about this one?
