### PR TITLE
Modify the encoding of crypted_password.

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/activerecord.rb.tt
@@ -29,7 +29,9 @@ class <%= @model_name %> < ActiveRecord::Base
 
   private
     def encrypt_password
-      self.crypted_password = ::BCrypt::Password.create(password)
+      value = ::BCrypt::Password.create(password)
+      value = value.force_encoding(Encoding::UTF_8) if value.respond_to?(:encoding) && value.encoding == Encoding::ASCII_8BIT
+      self.crypted_password = value
     end
 
     def password_required

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/minirecord.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/minirecord.rb.tt
@@ -32,7 +32,9 @@ class <%= @model_name %> < ActiveRecord::Base
 
   private
     def encrypt_password
-      self.crypted_password = ::BCrypt::Password.create(password)
+      value = ::BCrypt::Password.create(password)
+      value = value.force_encoding(Encoding::UTF_8) if value.respond_to?(:encoding) && value.encoding == Encoding::ASCII_8BIT
+      self.crypted_password = value
     end
 
     def password_required


### PR DESCRIPTION
ref #1121
I changed encoding to avoid activerecord [conditional expression](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L266).
