### PR TITLE
Padrino::Logger::Levels constants do not Severity from stdlib Logger class

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -52,10 +52,10 @@ module Padrino
     # :devel:: Development-related information that is unnecessary in debug mode
     #
     Levels = {
-      :fatal =>  7,
-      :error =>  6,
-      :warn  =>  4,
-      :info  =>  3,
+      :fatal =>  4,
+      :error =>  3,
+      :warn  =>  2,
+      :info  =>  1,
       :debug =>  0,
       :devel => -1,
     } unless defined?(Levels)


### PR DESCRIPTION
Not sure if it was done on purpose, but there is a mismatch between Logger::Severity constants (see http://rubydoc.info/stdlib/logger/Logger/Severity ) and constants in Padrino::Logger::Levels, which can lead to inconsitent results when using both loggers side by side, as I do.
