### PR TITLE
Fix incorrect behavior when using content_tag with block.

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
@@ -48,7 +48,7 @@ begin
         def precompiled_preamble(locals)
           buf = @padrino_app ? "ActiveSupport::SafeBuffer.new" : "''"
           old_postamble = super.split("\n")[0..-2]
-          [old_postamble, "#{@outvar} = _buf = (#{@outvar} || #{buf})"].join("\n")
+          [old_postamble, "__in_erb_template = true;#{@outvar} = _buf = (#{@outvar} || #{buf})"].join("\n")
         end
       end
     end

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
@@ -54,7 +54,7 @@ module Padrino
         #   @handler.block_is_type?(block) => true
         #
         def block_is_type?(block)
-          is_type? || (block && eval('defined?(__in_erb_template)', block.binding))
+          block && eval('!!defined?(__in_erb_template)', block.binding)
         end
 
         ##

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
@@ -54,7 +54,7 @@ module Padrino
         #   @handler.block_is_type?(block) => true
         #
         def block_is_type?(block)
-          is_type? || (block && eval('defined? __in_erb_template', block.binding))
+          block && eval('defined? __in_erb_template', block.binding)
         end
 
         ##

--- a/padrino-helpers/test/fixtures/markup_app/app.rb
+++ b/padrino-helpers/test/fixtures/markup_app/app.rb
@@ -50,6 +50,18 @@ class MarkupDemo < Sinatra::Base
         content_tag(:span, "This not a template block")
       end
     end
+
+    def content_tag_with_block
+      one = content_tag(:p) do
+        "one"
+      end
+      two = content_tag(:p) do
+        "two"
+      end
+      one << two
+    rescue
+      "<p>failed</p>".html_safe
+    end
   end
 end
 

--- a/padrino-helpers/test/fixtures/markup_app/views/content_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/content_tag.erb
@@ -9,3 +9,5 @@
 <% content_tag(:p) do %>
   <span>Test 4</span>
 <% end %>
+
+<%= content_tag_with_block %>

--- a/padrino-helpers/test/fixtures/markup_app/views/content_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/content_tag.haml
@@ -7,3 +7,5 @@
 
 - content_tag(:p) do
   %span Test 4
+
+= content_tag_with_block

--- a/padrino-helpers/test/fixtures/markup_app/views/content_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/content_tag.slim
@@ -7,3 +7,5 @@
 
 =content_tag(:p) do
   span Test 4
+
+= content_tag_with_block

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -70,6 +70,9 @@ describe "TagHelpers" do
       assert_have_selector :p, :content => "Test 2"
       assert_have_selector :p, :content => "Test 3"
       assert_have_selector :p, :content => "Test 4"
+      assert_have_selector :p, :content => "one"
+      assert_have_selector :p, :content => "two"
+      assert_have_no_selector :p, :content => "failed"
     end
 
     should "support tags with haml" do
@@ -78,6 +81,9 @@ describe "TagHelpers" do
       assert_have_selector :p, :content => "Test 2"
       assert_have_selector :p, :content => "Test 3", :class => 'test', :id => 'test3'
       assert_have_selector :p, :content => "Test 4"
+      assert_have_selector :p, :content => "one"
+      assert_have_selector :p, :content => "two"
+      assert_have_no_selector :p, :content => "failed"
     end
 
     should "support tags with slim" do
@@ -86,6 +92,9 @@ describe "TagHelpers" do
       assert_have_selector :p, :content => "Test 2"
       assert_have_selector :p, :content => "Test 3", :class => 'test', :id => 'test3'
       assert_have_selector :p, :content => "Test 4"
+      assert_have_selector :p, :content => "one"
+      assert_have_selector :p, :content => "two"
+      assert_have_no_selector :p, :content => "failed"
     end
   end
 


### PR DESCRIPTION
ref #1430
The behavior of haml is correct, so I fixed only problem of slim and erb.

/cc @phobetron @padrino/core-members
