### PR TITLE
Bubble up router exceptions

### DIFF
--- a/padrino-core/lib/padrino-core/path_router.rb
+++ b/padrino-core/lib/padrino-core/path_router.rb
@@ -36,19 +36,8 @@ module Padrino
         request = Request.new(env)
         return bad_request unless HTTP_VERBS.include?(request.request_method.downcase.to_sym)
         compile unless compiled?
-        begin
-          matched_routes = recognize(request)
-          [200, {}, matched_routes]
-        rescue => evar
-          case evar
-          when NotFound
-            not_found
-          when MethodNotAllowed
-            method_not_allowed('Allow' => request.acceptable_methods.sort.join(", "))
-          else
-            server_error
-          end
-        end
+        matched_routes = recognize(request)
+        [200, {}, matched_routes]
       end
 
       def compiled?


### PR DESCRIPTION
@namusyaka I've been trying out this branch for a while now and it behaves very well :).

On this PR I'm letting the errors bubble up so that they're caught by Padrino itself -otherwise we don't get a stack trace or error logs at all.

The other point I'd like to review is how we're implementing Mustermann. First of all, [I don't think we should tie it to Rails like patterns](https://github.com/padrino/padrino-framework/blob/replace-with-new-router/padrino-core/lib/padrino-core/path_router.rb#L261). Since this change set will probably be released together with Sinatra 2.0, perhaps we're better off defaulting to [Sinatra 2.0 patterns](https://github.com/rkh/mustermann#sinatra)?
I also reckon we should allow for [options to be configured](https://github.com/rkh/mustermann#options). So maybe we can make those available through settings?

Thoughts @padrino/core-members?
