### PR TITLE
Fix broken slim templates.

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
@@ -8,6 +8,17 @@ begin
 
     class Slim::Template
       include Padrino::Rendering::SafeTemplate
+
+      def precompiled_preamble(locals)
+        result = locals.map do |k,v|
+          if k.to_s =~ /\A[a-z_][a-zA-Z_0-9]*\z/
+            "#{k} = locals[#{k.inspect}]"
+          else
+            raise "invalid locals key: #{k.inspect} (keys must be variable names)"
+          end
+        end.join("\n")
+        "#{result}; __in_erb_template = true;"
+      end
     end
   end
 rescue LoadError


### PR DESCRIPTION
This PR will solve #1434.
If merge this commit, both `-` and `=` are acceptable.
If using block in template,  `content_tag` helper seems to concatenates content to temlate.

/cc @ujifgc @dariocravero 
