### PR TITLE
Correct fix for Slim #1431, #1434, #1435

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
@@ -4,20 +4,13 @@ begin
   if defined? Padrino::Rendering
     Padrino::Rendering.engine_configurations[:slim] =
       {:generator => Temple::Generators::RailsOutputBuffer,
-      :buffer => "@_out_buf", :use_html_safe => true}
+      :buffer => "@_out_buf", :use_html_safe => true, :disable_capture => true}
 
     class Slim::Template
       include Padrino::Rendering::SafeTemplate
 
       def precompiled_preamble(locals)
-        result = locals.map do |k,v|
-          if k.to_s =~ /\A[a-z_][a-zA-Z_0-9]*\z/
-            "#{k} = locals[#{k.inspect}]"
-          else
-            raise "invalid locals key: #{k.inspect} (keys must be variable names)"
-          end
-        end.join("\n")
-        "#{result}; __in_erb_template = true;"
+        "__in_slim_template = true;#{super}"
       end
     end
   end

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
@@ -54,7 +54,7 @@ module Padrino
         #   @handler.block_is_type?(block) => true
         #
         def block_is_type?(block)
-          block && eval('defined? __in_erb_template', block.binding)
+          block && eval('defined? __in_slim_template', block.binding)
         end
 
         ##


### PR DESCRIPTION
This is the correct way how to fix the issues #1431, #1434, #1435. Since you want to use a capture helper you have to disable the internal Slim capturing. This is how it is also done in Rails. I don't recommend to monkey patch the Slim::Template how you did in #1435.

Unfortunately your test cases somehow don't cover the capturing very well and the problems described in #1431, #1434, #1435. You should definitely improve that.
