### PR TITLE
Don't step over :session_id setting on admin apps

### DIFF
--- a/padrino-admin/lib/padrino-admin/access_control.rb
+++ b/padrino-admin/lib/padrino-admin/access_control.rb
@@ -13,7 +13,7 @@ module Padrino
         # Method used by Padrino::Application when we register the extension
         #
         def registered(app)
-          app.set :session_id, "_padrino_#{File.basename(Padrino.root)}_#{app.app_name}".to_sym
+          app.set :session_id, "_padrino_#{File.basename(Padrino.root)}_#{app.app_name}".to_sym unless app.respond_to?(:session_id)
           app.set :admin_model, 'Account' unless app.respond_to?(:admin_model)
           app.helpers Padrino::Admin::Helpers::AuthenticationHelpers
           app.helpers Padrino::Admin::Helpers::ViewHelpers

--- a/padrino-admin/test/test_admin_application.rb
+++ b/padrino-admin/test/test_admin_application.rb
@@ -6,6 +6,26 @@ describe "AdminApplication" do
     load_fixture 'data_mapper'
   end
 
+  describe "session id setting" do
+    it "should provide it if it doesn't exist" do
+      mock_app do
+        register Padrino::Admin::AccessControl
+      end
+
+      assert_equal @app.session_id, "_padrino_#{File.basename(Padrino.root)}_#{@app.app_name}".to_sym
+    end
+
+    # it "should preserve it if it already existed" do
+    #   Padrino.configure_apps { enable :sessions; set :session_id, "foo" }
+
+    #   mock_app do
+    #     register Padrino::Admin::AccessControl
+    #   end
+
+    #   assert_equal @app.session_id, "foo"
+    # end
+  end
+
   it 'should require correctly login' do
     mock_app do
       register Padrino::Admin::AccessControl


### PR DESCRIPTION
The `:session_id` is currently overwritten in the admin regardless whether it was set globally or not. This doesn't allow for shared sessions between admins and apps. This patch fixes [this issue](https://github.com/padrino/padrino-framework/issues/500#issuecomment-16836189). @padrino/core-members thoughts?
