### PR TITLE
Fixed the loading order of an app's dependencies.

### DIFF
--- a/padrino-core/lib/padrino-core/loader.rb
+++ b/padrino-core/lib/padrino-core/loader.rb
@@ -57,7 +57,7 @@ module Padrino
       require_dependencies("#{root}/config/database.rb")
       Reloader.lock!
       before_load.each(&:call)
-      dependency_paths.each{ |path| require_dependencies(path) }
+      require_dependencies(*dependency_paths)
       after_load.each(&:call)
       logger.devel "Loaded Padrino in #{Time.now - began_at} seconds"
       Thread.current[:padrino_loaded] = true


### PR DESCRIPTION
If we load apps first, libraries won't be there, hence throwing exceptions at run time.
For example, this can be reproduced with any library that needs to be registered like ScssInitialiazer.
See #1448#issuecomment-26143346. This bug was introduced with [this commit](https://github.com/padrino/padrino-framework/commit/d64144fa2a1956b26e55ff71b90a1e9cd6235f9c#diff-d747a81be0777d9d6b40b6ed22a8d789R214)

/cc @ujifgc @padrino/core-members 
