### PR TITLE
Change request.accepts to an empty array if request.accepts is `*/*`.

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -859,6 +859,7 @@ module Padrino
           mime_types        = types.map { |t| mime_type(t) }.compact
           url_format        = params[:format].to_sym if params[:format]
           accepts           = request.accept.map(&:to_str)
+          accepts           = [] if accepts == ["*/*"]
 
           # Per rfc2616-sec14:
           # Assume */* if no ACCEPT header is given.


### PR DESCRIPTION
ref #1465
I guess [this changes](https://github.com/sinatra/sinatra/commit/4762e4a92bab58d1973c5b3500a3db2e01149e38) is the cause of the problem.
This PR is a simple way of solving.
