### PR TITLE
#1405 params hash keys

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -172,6 +172,7 @@ class HttpRouter
             env['router.request'] = request
             env['router.params'] ||= {}
             #{"env['router.params'].merge!(Hash[#{param_names.inspect}.zip(request.params)])" if dynamic?}
+            env['router.params'] = env['router.params'].with_indifferent_access
             @router.rewrite#{"_partial" if route.match_partially}_path_info(env, request)
             response = @router.process_destination_path(#{path_ivar}, env)
             return response unless router.pass_on_response(response)
@@ -959,10 +960,12 @@ module Padrino
       #
       def current_path(*path_params)
         if path_params.last.is_a?(Hash)
-          path_params[-1] = params.merge(path_params[-1])
+          path_params[-1] = params.merge(path_params[-1].with_indifferent_access)
         else
           path_params << params
         end
+
+        path_params[-1] = path_params[-1].symbolize_keys
         @route.path(*path_params)
       end
 

--- a/padrino-core/lib/padrino-core/support_lite.rb
+++ b/padrino-core/lib/padrino-core/support_lite.rb
@@ -4,6 +4,7 @@
 require 'active_support/core_ext/module/aliasing'           # alias_method_chain
 require 'active_support/core_ext/hash/keys'                 # symbolize_keys
 require 'active_support/core_ext/hash/reverse_merge'        # reverse_merge
+require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/slice'                # slice
 require 'active_support/core_ext/object/blank'              # present?
 require 'active_support/core_ext/array/extract_options'     # extract_options

--- a/padrino-core/test/test_reloader_complex.rb
+++ b/padrino-core/test/test_reloader_complex.rb
@@ -65,7 +65,7 @@ describe "ComplexReloader" do
         assert_equal 200, status
 
         get "/complex_2_demo/var/destroy/variable"
-        assert_equal '{:id=>"variable"}', body
+        assert_equal '{"id"=>"variable"}', body
       ensure
         # Now we need to prevent to commit a new changed file so we revert it
         File.open(Complex1Demo.app_file, "w") { |f| f.write(buffer) }

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -1790,6 +1790,33 @@ describe "Routing" do
     assert ok?
   end
 
+  should 'return params as a HashWithIndifferentAccess object via GET' do
+    mock_app do
+      get('/foo/:bar') { "#{params["bar"]} #{params[:bar]}" }
+      get(:foo, :map => '/prefix/:var') { "#{params["var"]} #{params[:var]}" }
+    end
+
+    get('/foo/some_text')
+    assert_equal "some_text some_text", body
+
+    get('/prefix/var')
+    assert_equal "var var", body
+  end
+
+  should 'return params as a HashWithIndifferentAccess object via POST' do
+    mock_app do
+      post('/user') do
+        "#{params["user"]["full_name"]} #{params[:user][:full_name]}"
+      end
+    end
+
+    post '/user', {:user => {:full_name => 'example user'}}
+    assert_equal "example user example user", body
+
+    post '/user', {"user" => {"full_name" => 'example user'}}
+    assert_equal "example user example user", body
+  end
+
   should 'have MethodOverride middleware with more options' do
     mock_app do
       put('/hi', :provides => [:json]) { 'hi' }


### PR DESCRIPTION
Fixes #1405.

Only breaking change seems to be the to_s prints out keys as quoted strings as opposed to symbolized. 
