### PR TITLE
Skip the `:path_traversal` protection, fixes #1391.

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -206,7 +206,7 @@ module Padrino
       end
       
       def default_security!
-        set :protection, true
+        set :protection, :except => :path_traversal
         set :authentication, false
         set :sessions, false
         set :protect_from_csrf, false


### PR DESCRIPTION
refs #1391 #1471 
I think `PathTraversal` protection is not necessary.
