### PR TITLE
Add :as option to form_for helper

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -238,6 +238,7 @@ module Padrino
         # Returns the object's models name.
         #
         def object_model_name(explicit_object=object)
+          return @options[:as] if root_form? && @options[:as].is_a?(Symbol)
           explicit_object.is_a?(Symbol) ? explicit_object : explicit_object.class.to_s.underscore.gsub(/\//, '_')
         end
 

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -19,6 +19,8 @@ module Padrino
       #   Also accepts HTML options.
       # @option settings [String] :builder ("StandardFormBuilder")
       #   The FormBuilder class to use such as StandardFormBuilder.
+      # @option settings [Symbol] :as
+      #   Sets custom form object name.
       # @param [Proc] block
       #   The fields and content inside this form.
       #
@@ -29,12 +31,14 @@ module Padrino
       # @example
       #   form_for :user, '/register' do |f| ... end
       #   form_for @user, '/register', :id => 'register' do |f| ... end
+      #   form_for @user, '/register', :as => :customer do |f| ... end
       #
       def form_for(object, url, settings={}, &block)
         instance = builder_instance(object, settings)
         html = capture_html(instance, &block)
         settings[:multipart] = instance.multipart unless settings.include?(:multipart)
         settings.delete(:namespace)
+        settings.delete(:as)
         form_tag(url, settings) { html }
       end
 
@@ -883,7 +887,7 @@ module Padrino
           :disabled => Array(options.delete(:disabled_options))
         }
       end
-      
+
       def extract_option_tags!(options)
         state = extract_option_state!(options)
         option_tags = case

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -70,6 +70,16 @@ describe "FormBuilder" do
       assert_has_tag(:input, :type => 'text', :name => 'user[role_types_attributes][0][name]', :id => 'foo_user_role_types_attributes_0_name') { actual_html }
     end
 
+    should "display correct form html with :as option" do
+      actual_html = form_for(@user, '/update', :as => :customer) do |f|
+        f.text_field(:first_name) << f.fields_for(:role_types) { |role| role.text_field(:name) }
+      end
+
+      assert_has_no_tag(:form, :as => 'customer') { actual_html }
+      assert_has_tag(:input, :type => 'text', :name => 'customer[first_name]', :id => 'customer_first_name') { actual_html }
+      assert_has_tag(:input, :type => 'text', :name => 'customer[role_types_attributes][0][name]', :id => 'customer_role_types_attributes_0_name') { actual_html }
+    end
+
     should "display correct form html with remote option and method put" do
       actual_html = form_for(@user, '/update', :"accept-charset" => "UTF-8", :remote => true, :method => 'put') { "Demo" }
       assert_has_tag('form', :"accept-charset" => "UTF-8", :method => 'post', "data-remote" => 'true') { actual_html }


### PR DESCRIPTION
:as option can now be used to override default object name when building
form.

This is especially useful if you are using proxy object and don't want
world to know about it.
