### PR TITLE
Revert "fix bundle for ruby 1.8.7. Before allowing AS 4, we MUST branch ...

### DIFF
--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |s|
   end
   s.add_dependency("http_router", "~> 0.11.0")
   s.add_dependency("thor", "~> 0.17.0")
-  s.add_dependency("activesupport", ">= 3.1", "< 4.0")
+  s.add_dependency("activesupport", ">= 3.1", "<= 4.0")
   s.add_dependency("rack-protection", ">= 1.5.0")
 end


### PR DESCRIPTION
> ...away with statement about dropping 1.8.7"

It's time
