### PR TITLE
Fix for autofocus in admin panel.

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/application.js
+++ b/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/application.js
@@ -112,6 +112,7 @@
     }
 
     // Autofocus first field with an error. (usability)
-    $('.has-error :input').first().focus();
+    var error_input;
+    if (error_input = $('.has-error :input').first()) { error_input.focus(); }
   });
 }(window.jQuery);


### PR DESCRIPTION
Hi,

Fix for script used in admin panel.
In case of bad input first input field with error should be focused,
but if there is no error - default autofucus should work.
