### PR TITLE
Fix incorrect namespace of #named_routes.

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -194,7 +194,7 @@ module Padrino
     def apply?(request)
       detect = @args.any? do |arg|
         case arg
-        when Symbol then request.route_obj && (request.route_obj.name == arg or request.route_obj.name == [@scoped_controller, arg].flatten.join("_").to_sym)
+        when Symbol then request.route_obj && (request.route_obj.name == arg or request.route_obj.name == [@scoped_controller, arg].flatten.join(" ").to_sym)
         else             arg === request.path_info
         end
       end || @options.any? do |name, val|
@@ -558,7 +558,7 @@ module Padrino
       def url(*args)
         params = args.extract_options!  # parameters is hash at end
         names, params_array = args.partition{|a| a.is_a?(Symbol)}
-        name = names.join("_").to_sym    # route name is concatenated with underscores
+        name = names[0, 2].join(" ").to_sym    # route name is concatenated with underscores
         if params.is_a?(Hash)
           params[:format] = params[:format].to_s unless params[:format].nil?
           params = value_to_param(params)
@@ -787,7 +787,7 @@ module Padrino
         name = options.delete(:name) if name.nil? && options.key?(:name)
         if name
           controller_name = controller.join("_")
-          name = "#{controller_name}_#{name}".to_sym unless controller_name.blank?
+          name = "#{controller_name} #{name}".to_sym unless controller_name.blank?
         end
 
         # Merge in option defaults.

--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -110,7 +110,7 @@ module Padrino
     def named_routes
       app_obj.routes.map { |route|
         route_name = route.name.to_s
-        route_name.sub!(/^#{route.controller}_/, "") if route.controller
+        route_name.sub!(/^#{route.controller} /, "") if route.controller
         name_array = "(#{route.controller ? %Q[:#{route.controller}] + ", " : ""}:#{route_name})"
         request_method = route.request_methods.first
         next if route.name.blank? || request_method == 'HEAD'

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -148,17 +148,17 @@ describe "Mounter" do
       assert_equal 10, Padrino.mounted_apps[1].named_routes.size
 
       first_route = Padrino.mounted_apps[0].named_routes[3]
-      assert_equal "posts_show", first_route.identifier.to_s
+      assert_equal "posts show", first_route.identifier.to_s
       assert_equal "(:posts, :show)", first_route.name
       assert_equal "GET", first_route.verb
       assert_equal "/posts/show/:id(.:format)", first_route.path
       another_route = Padrino.mounted_apps[1].named_routes[2]
-      assert_equal "users_create", another_route.identifier.to_s
+      assert_equal "users create", another_route.identifier.to_s
       assert_equal "(:users, :create)", another_route.name
       assert_equal "POST", another_route.verb
       assert_equal "/two_app/users/create", another_route.path
       regexp_route = Padrino.mounted_apps[0].named_routes[5]
-      assert_equal "posts_regexp", regexp_route.identifier.to_s
+      assert_equal "posts regexp", regexp_route.identifier.to_s
       assert_equal "(:posts, :regexp)", regexp_route.name
       assert_equal "/\\/foo|\\/baz/", regexp_route.path
       foo_bar_route = Padrino.mounted_apps[1].named_routes[5]

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -56,6 +56,32 @@ describe "Routing" do
     }
   end
 
+  should 'fail with unrecognized route exception when namespace is invalid' do
+    mock_app do
+      controller :foo_bar do
+        get(:index){ "okey" }
+        get(:test_baz){ "okey" }
+      end
+    end
+    assert_equal "/foo_bar", @app.url_for(:foo_bar, :index)
+    assert_raises(Padrino::Routing::UnrecognizedException) {
+      get @app.url_for(:foo, :bar, :index)
+    }
+    assert_raises(Padrino::Routing::UnrecognizedException) {
+      get @app.url_for(:foo, :bar_index)
+    }
+    assert_equal "/foo_bar/test_baz", @app.url_for(:foo_bar, :test_baz)
+    assert_raises(Padrino::Routing::UnrecognizedException) {
+      get @app.url_for(:foo_bar, :test, :baz)
+    }
+    assert_raises(Padrino::Routing::UnrecognizedException) {
+      get @app.url_for(:foo, :bar_test, :baz)
+    }
+    assert_raises(Padrino::Routing::UnrecognizedException) {
+      get @app.url_for(:foo, :bar_test_baz)
+    }
+  end
+
   should 'accept regexp routes' do
     mock_app do
       get(%r./fob|/baz.) { "regexp" }
@@ -474,7 +500,7 @@ describe "Routing" do
       end
     end
     get "/posts"
-    assert_equal "posts_index", body
+    assert_equal "posts index", body
   end
 
   should "preserve the format if you set it manually" do
@@ -676,8 +702,8 @@ describe "Routing" do
     assert_equal "1", body
     get "/admin/show/1"
     assert_equal "show 1", body
-    assert_equal "/admin/1", @app.url(:admin_index, :id => 1)
-    assert_equal "/admin/show/1", @app.url(:admin_show, :id => 1)
+    assert_equal "/admin/1", @app.url(:admin, :index, :id => 1)
+    assert_equal "/admin/show/1", @app.url(:admin, :show, :id => 1)
     get "/foo/bar"
     assert_equal "foo_bar_index", body
   end
@@ -1894,8 +1920,8 @@ describe "Routing" do
       get(:simple, :map => "/simple/:id") { }
       get(:with_format, :with => :id, :provides => :js) { }
     end
-    assert_equal [:foo_bar, { :id => "fantastic" }], @app.recognize_path(@app.url(:foo, :bar, :id => :fantastic))
-    assert_equal [:foo_bar, { :id => "18" }], @app.recognize_path(@app.url(:foo, :bar, :id => 18))
+    assert_equal [:"foo bar", { :id => "fantastic" }], @app.recognize_path(@app.url(:foo, :bar, :id => :fantastic))
+    assert_equal [:"foo bar", { :id => "18" }], @app.recognize_path(@app.url(:foo, :bar, :id => 18))
     assert_equal [:simple, { :id => "bar" }], @app.recognize_path(@app.url(:simple, :id => "bar"))
     assert_equal [:simple, { :id => "true" }], @app.recognize_path(@app.url(:simple, :id => true))
     assert_equal [:simple, { :id => "9" }], @app.recognize_path(@app.url(:simple, :id => 9))


### PR DESCRIPTION
ref #1095
I fixed #named_routes behavior.

BTW, should we fix `url` behavior?
If so, I'm going to modify the behavior in this way.

``` ruby
url(:cap_alerts, :index) #=> "/cap_alerts"
url(:cap, :alerts, :index) #=> UnrecognizedException
url(:cap, :alerts_index) #=> UnrecognizedException
```
