### PR TITLE
Removed repopulating password in session new

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/app/controllers/sessions.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/app/controllers/sessions.rb.tt
@@ -16,7 +16,7 @@
       set_current_account(account)
       redirect url(:base, :index)
     else
-      params[:email], params[:password] = h(params[:email]), h(params[:password])
+      params[:email] = h(params[:email])
       flash[:error] = pat('login.error')
       redirect url(:sessions, :new)
     end

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/app/sessions/new.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/app/sessions/new.erb.tt
@@ -27,7 +27,7 @@
 
         <div class="form-group">
           <label for="password" class="col-lg-2 control-label"><%%= pat('login.password') %></label>
-          <div class="col-lg-10"><%%= password_field_tag :password, :value => params[:password], :class => 'form-control' %></div>
+          <div class="col-lg-10"><%%= password_field_tag :password, :class => 'form-control' %></div>
         </div>
 
         <fieldset class="login-control-group-last control-group">


### PR DESCRIPTION
I think it is generally bad practice to repopulate password field on login forms. What do you think? Granted it seems to be broken, but my other PR fixes them.
