### PR TITLE
Fixed populating fields on session new by rendering new view instead of redirecting

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/app/controllers/sessions.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/app/controllers/sessions.rb.tt
@@ -16,7 +16,7 @@
       set_current_account(account)
       redirect url(:base, :index)
     else
-      params[:email], params[:password] = h(params[:email]), h(params[:password])
+      params[:email] = h(params[:email])
       flash.now[:error] = pat('login.error')
       render "/sessions/new", nil, :layout => false
     end

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/app/sessions/new.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/app/sessions/new.erb.tt
@@ -27,7 +27,7 @@
 
         <div class="form-group">
           <label for="password" class="col-lg-2 control-label"><%%= pat('login.password') %></label>
-          <div class="col-lg-10"><%%= password_field_tag :password, :value => params[:password], :class => 'form-control' %></div>
+          <div class="col-lg-10"><%%= password_field_tag :password, :class => 'form-control' %></div>
         </div>
 
         <fieldset class="login-control-group-last control-group">


### PR DESCRIPTION
The fields seem to not work as intended to repopulate the form and this fixes it.
