### PR TITLE
Update plugin base url since plugin generator doesn't follow redirect

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/runner.rb
+++ b/padrino-gen/lib/padrino-gen/generators/runner.rb
@@ -128,7 +128,7 @@ module Padrino
             raw_link, _ = *open(template_file).read.scan(/<a\s+href\s?\=\"(.*?)\"\>raw/)
             raw_link ? "https://gist.github.com#{raw_link[0]}" : template_file
           when File.extname(template_file).blank? # referencing official plugin (i.e hoptoad)
-            "https://github.com/padrino/padrino-recipes/raw/master/#{kind.to_s.pluralize}/#{template_file}_#{kind}.rb"
+            "https://raw.github.com/padrino/padrino-recipes/master/#{kind.to_s.pluralize}/#{template_file}_#{kind}.rb"
           else # local file on system
             File.expand_path(template_file)
           end

--- a/padrino-gen/test/test_plugin_generator.rb
+++ b/padrino-gen/test/test_plugin_generator.rb
@@ -68,7 +68,7 @@ describe "PluginGenerator" do
 
     should "resolve official template" do
       template_file = 'sampleblog'
-      resolved_path = "https://github.com/padrino/padrino-recipes/raw/master/templates/sampleblog_template.rb"
+      resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/templates/sampleblog_template.rb"
       project_gen = Padrino::Generators::Project.new(['sample_project'], ["-p=#{template_file}", "-r=#{@apptmp}"], {})
       project_gen.expects(:apply).with(resolved_path).returns(true).once
       capture_io { project_gen.invoke_all }
@@ -83,7 +83,7 @@ describe "PluginGenerator" do
 
     should "resolve official plugin" do
       template_file = 'hoptoad'
-      resolved_path = "https://github.com/padrino/padrino-recipes/raw/master/plugins/hoptoad_plugin.rb"
+      resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/plugins/hoptoad_plugin.rb"
       plugin_gen = Padrino::Generators::Plugin.new([ template_file], ["-r=#{@apptmp}/sample_project"],{})
       plugin_gen.expects(:in_app_root?).returns(true).once
       plugin_gen.expects(:apply).with(resolved_path).returns(true).once
@@ -92,7 +92,7 @@ describe "PluginGenerator" do
 
     should "print a warning if template cannot be found" do
       template_file  = 'hwat'
-      resolved_path = "https://github.com/padrino/padrino-recipes/raw/master/plugins/hwat_plugin.rb"
+      resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/plugins/hwat_plugin.rb"
       plugin_gen = Padrino::Generators::Plugin.new([ template_file], ["-r=#{@apptmp}/sample_project"],{})
       plugin_gen.expects(:in_app_root?).returns(true).once
       plugin_gen.expects(:say).with("The template at #{resolved_path} could not be found!", :red).returns(true).once


### PR DESCRIPTION
I've noticed padrino plugins stop working since github redirects to separate domain to get raw file
