### PR TITLE
Change Mustermann::Rails to Mustermann::Sinatra.

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -500,7 +500,7 @@ module Padrino
 
         invoke_hook(:route_added, verb, path, block)
 
-        path[0, 0] = "/" if path == "(.:format)"
+        path[0, 0] = "/" if path == "(.:format)?"
         route = router.add(verb.downcase.to_sym, path, route_options)
         route.name = name if name
         route.action = action
@@ -636,7 +636,7 @@ module Padrino
         parent_prefix = parent_params.flatten.compact.uniq.map do |param|
           map  = (param.respond_to?(:map) && param.map ? param.map : param.to_s)
           part = "#{map}/:#{param.to_s.singularize}_id/"
-          part = "(#{part})" if param.respond_to?(:optional) && param.optional?
+          part = "(#{part})?" if param.respond_to?(:optional) && param.optional?
           part
         end
 
@@ -648,7 +648,7 @@ module Padrino
       # Used for calculating path in route method.
       #
       def process_path_for_provides(path, format_params)
-        path << "(.:format)" unless path[-10, 10] == '(.:format)'
+        path << "(.:format)?" unless path[-11, 11] == '(.:format)?'
       end
 
       ##

--- a/padrino-core/lib/padrino-core/path_router.rb
+++ b/padrino-core/lib/padrino-core/path_router.rb
@@ -253,13 +253,13 @@ module Padrino
       end
   
       def mustermann?
-        handler.class == Mustermann::Rails
+        handler.instance_of?(Mustermann::Sinatra)
       end
   
       def handler
         @handler ||= case @path
         when String
-          Mustermann.new(@path, :type => :rails, :capture => @capture)
+          Mustermann.new(@path, :capture => @capture)
         when Regexp
           /^(?:#{@path})$/
         end

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -144,7 +144,7 @@ describe "Mounter" do
       assert_equal "posts show", first_route.identifier.to_s
       assert_equal "(:posts, :show)", first_route.name
       assert_equal "GET", first_route.verb
-      assert_equal "/posts/show/:id(.:format)", first_route.path
+      assert_equal "/posts/show/:id(.:format)?", first_route.path
       another_route = Padrino.mounted_apps[1].named_routes[2]
       assert_equal "users create", another_route.identifier.to_s
       assert_equal "(:users, :create)", another_route.name

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -464,14 +464,14 @@ describe "Routing" do
   should "should inject the action name into the request" do
     mock_app do
       controller :posts do
-        get('/omnomnom(/:id)') { request.action.inspect }
+        get('/omnomnom(/:id)?') { request.action.inspect }
         controller :mini do
           get([:a, :b, :c]) { request.action.inspect }
         end
       end
     end
     get "/posts/omnomnom"
-    assert_equal "\"/omnomnom(/:id)\"", body
+    assert_equal "\"/omnomnom(/:id)?\"", body
     get "/mini/a/b/c"
     assert_equal ":a", body
   end
@@ -889,7 +889,7 @@ describe "Routing" do
 
   should 'allow optionals' do
     mock_app do
-      get(:show, :map => "/stories/:type(/:category)") do
+      get(:show, :map => "/stories/:type(/:category)?") do
         "#{params[:type]}/#{params[:category]}"
       end
     end
@@ -1401,7 +1401,7 @@ describe "Routing" do
 
   should 'works with optionals params' do
     mock_app do
-      get("/foo(/:bar)") { params[:bar] }
+      get("/foo(/:bar)?") { params[:bar] }
     end
 
     get "/foo/bar"
@@ -1504,7 +1504,7 @@ describe "Routing" do
 
   should "use optionals params" do
     mock_app do
-      get(:index, :map => "/(:foo(/:bar))") { "#{params[:foo]}-#{params[:bar]}" }
+      get(:index, :map => "/:foo(/:bar)?") { "#{params[:foo]}-#{params[:bar]}" }
     end
     get "/foo"
     assert_equal "foo-", body


### PR DESCRIPTION
ref #1433
I think the new router should follow sinatra style.
This will change optional syntax.

before: `/stories/:type(/:category)`
after: `/stories/:type(/:category)?`
