### PR TITLE
Empty folder in spec folder causes rspec's rake task to run tests multiple times

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -39,7 +39,10 @@ RSPEC_RAKE = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_RAKE)
 begin
   require 'rspec/core/rake_task'
 
-  spec_tasks = Dir['spec/*/'].map { |d| File.basename(d) }
+	spec_tasks = Dir['spec/*/'].inject([]) do |result, d|
+	  result << File.basename(d) unless Dir["\#{d}*"].empty?
+	  result
+	end
 
   spec_tasks.each do |folder|
     RSpec::Core::RakeTask.new("spec:\#{folder}") do |t|


### PR DESCRIPTION
To reproduce, generate a project and create a spec that passes.  If you run padrino rake spec, it will run it once and pass.  Create an empty folder in the spec folder, and it will now run it twice.

``` bash
padrino g project example -t rspec -e erb -s jquery -d sequel
cd ./example
padrino g controller example
```

edit spec/app/example_controller_spec.rb to return true

``` ruby
# spec/app/example_controller_spec.rb
require 'spec_helper'
describe "ExampleController" do
  it "returns true" do
    true
  end
end
```

``` bash
padrino rake spec
=> Executing Rake spec ...
/ruby-2.0.0-p195/bin/ruby -S rspec ./spec/app/controllers/example_controller_spec.rb -fs --color

ExampleController
  returns true

Finished in 0.00035 seconds
1 example, 0 failures

```

``` bash
mkdir spec/empty_folder
padrino rake spec
/ruby-2.0.0-p195/bin/ruby -S rspec ./spec/app/controllers/example_controller_spec.rb -fs --color

ExampleController
  returns true

Finished in 0.00045 seconds
1 example, 0 failures
/ruby-2.0.0-p195/bin/ruby -S rspec -fs --color

ExampleController
  returns true

Finished in 0.00047 seconds
1 example, 0 failures
```

The issue seems to come from the spec_tasks being created for each folder in spec.rake, but the empty folder doesn't have any file names to pass in, so rspec is just called on the whole folder, which causes all of the tests to run.  It looks like other test frameworks padrino generates do something similar, but I don't know if they will have the same issue.

I'm also not sure if my changes are the correct way to go about fixing it.
