### PR TITLE
patch jruby utf-8 method naming, fixes #1507

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -18,7 +18,7 @@ end
 ##
 # This patches Sinatra to accept UTF-8 urls on JRuby 1.7.6
 #
-if RUBY_ENGINE == 'jruby' && RUBY_VERSION > '1.7.4'
+if RUBY_ENGINE == 'jruby' && defined?(JRUBY_VERSION) && JRUBY_VERSION > '1.7.4'
   class Sinatra::Base
     class << self
       alias_method :old_generate_method, :generate_method


### PR DESCRIPTION
This patches Sinatra to accept UTF-8 urls on JRuby 1.7.6
