### PR TITLE
Fixes deprecated AR::Migrator constructor used in ar:abort_if_pending_migrations

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -212,7 +212,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
     desc "Raises an error if there are pending migrations"
     task :abort_if_pending_migrations => :environment do
       if defined? ActiveRecord
-        pending_migrations = ActiveRecord::Migrator.new(:up, 'db/migrate').pending_migrations
+        pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations
 
         if pending_migrations.any?
           puts "You have #{pending_migrations.size} pending migrations:"


### PR DESCRIPTION
As of this Rails commit [0], it is no longer legal to pass a string
constructor instead of a list of migration paths. This commit deletes
the deprecated approach and uses the recommended approach, passing the
list of paths to migrate.

[0] https://github.com/rails/rails/commit/685631285f21e2f63b1ecbdb1495f25c97b6bf41
