### PR TITLE
I18n.enforce_available_locales should be true.

### DIFF
--- a/padrino-core/test/test_rendering.rb
+++ b/padrino-core/test/test_rendering.rb
@@ -422,11 +422,15 @@ describe "Rendering" do
       mock_app do
         get("/foo", :provides => [:html, :js]) { render :foo }
       end
+
+      I18n.enforce_available_locales = false
       I18n.locale = :none
       get "/foo.js"
       assert_equal "Im Js", body
       get "/foo"
       assert_equal "Im Erb", body
+      I18n.enforce_available_locales = true
+
       I18n.locale = :en
       get "/foo"
       assert_equal "Im English Erb", body
@@ -442,6 +446,7 @@ describe "Rendering" do
       I18n.locale = :en
       get "/foo.pk"
       assert_equal 404, status
+
     end
 
     should 'resolve template content_type and locale with layout' do
@@ -462,11 +467,15 @@ describe "Rendering" do
         layout :foo
         get("/bar", :provides => [:html, :js, :json]) { render :bar }
       end
+
+      I18n.enforce_available_locales = false
       I18n.locale = :none
       get "/bar.js"
       assert_equal "Hello Im Js in a Js layout", body
       get "/bar"
       assert_equal "Hello Im Erb in a Erb layout", body
+      I18n.enforce_available_locales = true
+
       I18n.locale = :en
       get "/bar"
       assert_equal "Hello Im English Erb in a Erb-En layout", body
@@ -484,6 +493,7 @@ describe "Rendering" do
       assert_equal "Im a json", body
       get "/bar.pk"
       assert_equal 404, status
+
     end
 
     should 'renders erb with blocks' do

--- a/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
@@ -16,6 +16,7 @@ Bundler.require(:default, PADRINO_ENV)
 # ## Configure your I18n
 #
 # I18n.default_locale = :en
+# I18n.enforce_available_locales = false
 #
 # ## Configure your HTML5 data helpers
 #

--- a/padrino-helpers/lib/padrino-helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers.rb
@@ -9,6 +9,7 @@ require 'active_support/inflector'                    # humanize
 
 FileSet.glob_require('padrino-helpers/**/*.rb', __FILE__)
 I18n.load_path += Dir["#{File.dirname(__FILE__)}/padrino-helpers/locale/*.yml"]
+I18n.enforce_available_locales = true
 
 module Padrino
   ##


### PR DESCRIPTION
This gets rid of some deprecation warnings on tests
and in apps using I18n.

ref:
https://github.com/svenfuchs/i18n/commit/3b6e56e06fd70f6e4507996b017238505e66608c

ref:
http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
