### PR TITLE
Fixed tests falling behind cache API

### DIFF
--- a/padrino-cache/test/test_legacy_store.rb
+++ b/padrino-cache/test/test_legacy_store.rb
@@ -14,40 +14,40 @@ describe Padrino::Cache::LegacyStore do
   end
 
   it "return nil trying to get a value that doesn't exist" do
-    Padrino.cache.flush
-    assert_equal nil, Padrino.cache.get(@test_key)
+    Padrino.cache.clear
+    assert_equal nil, Padrino.cache[@test_key]
   end
 
   it 'set and get an object with marshal' do
-    Padrino.cache.set(@test_key, Foo.new)
-    assert_equal "bar", Padrino.cache.get(@test_key).bar
+    Padrino.cache.store(@test_key, Foo.new)
+    assert_equal "bar", Padrino.cache[@test_key].bar
   end
 
   it 'set and get a nil value' do
-    Padrino.cache.set(@test_key, nil)
-    assert_equal '', Padrino.cache.get(@test_key).to_s
+    Padrino.cache.store(@test_key, nil)
+    assert_equal '', Padrino.cache[@test_key].to_s
   end
 
   it 'set and get a raw value' do
-    Padrino.cache.set(@test_key, 'foo')
-    assert_equal 'foo', Padrino.cache.get(@test_key)
+    Padrino.cache.store(@test_key, 'foo')
+    assert_equal 'foo', Padrino.cache[@test_key]
   end
 
   it "set a value that expires" do
     init_time = ( Time.now - 20 )
-    Time.stub(:now, init_time) { Padrino.cache.set(@test_key, 'test', :expires_in => 1) }
-    Time.stub(:now, init_time + 20) { assert_equal nil, Padrino.cache.get(@test_key) }
+    Time.stub(:now, init_time) { Padrino.cache.store(@test_key, 'test', :expires => 1) }
+    Time.stub(:now, init_time + 20) { assert_equal nil, Padrino.cache[@test_key] }
   end
 
   it "be able to cache forever" do
-    Padrino.cache.set('forever', 'cached', :expires_in => -1)
-    2.times { |i| assert_equal 'cached', Padrino.cache.get('forever') }
+    Padrino.cache.store('forever', 'cached', :expires => false)
+    2.times { |i| assert_equal 'cached', Padrino.cache['forever'] }
   end
 
   it 'delete a value' do
-    Padrino.cache.set(@test_key, 'test')
-    assert_equal 'test', Padrino.cache.get(@test_key)
+    Padrino.cache.store(@test_key, 'test')
+    assert_equal 'test', Padrino.cache[@test_key]
     Padrino.cache.delete(@test_key)
-    assert_equal nil, Padrino.cache.get(@test_key)
+    assert_equal nil, Padrino.cache[@test_key]
   end
 end


### PR DESCRIPTION
Cache tests had a lot of dep warnings from the API changing.  Fixed tests to use newer API.
