### PR TITLE
Allow asset_folders to be configured in settings

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -359,8 +359,8 @@ module Padrino
       #   asset_folder_name(:images) => 'images'
       #
       def asset_folder_name(kind)
-        if settings.respond_to? "#{kind}_asset_folder"
-          settings.send "#{kind}_asset_folder"
+        if self.class.respond_to? "#{kind}_asset_folder"
+          self.class.send "#{kind}_asset_folder"
         else
           case kind
           when :css then 'stylesheets'

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -269,6 +269,14 @@ describe "AssetTagHelpers" do
       assert actual_html.html_safe?
     end
 
+    should "respond to js_asset_folder setting" do
+      time = stop_time_for_test
+      self.class.stubs(:js_asset_folder).returns('js')
+      assert_equal 'js', asset_folder_name(:js)
+      actual_html = javascript_include_tag('application')
+      assert_has_tag('script', :src => "/js/application.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+    end
+
     should "display javascript item for long relative path" do
       time = stop_time_for_test
       actual_html = javascript_include_tag('example/demo/application')


### PR DESCRIPTION
In your app, you can now add `set :css_asset_folder, 'css'` to your app and have `<%= stylesheet_link_tag 'style' %>` link to `/css/style.css` instead of `/stylesheets/style.css`.
