### PR TITLE
Increase strictness of explicit i18n dependency

### DIFF
--- a/padrino-helpers/padrino-helpers.gemspec
+++ b/padrino-helpers/padrino-helpers.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-core", Padrino.version)
-  s.add_dependency("i18n", "~> 0.6")
+  s.add_dependency("i18n", "~> 0.6", ">= 0.6.7")
 end


### PR DESCRIPTION
- Padrino depends on `I18n.enforce_available_locales=` existing.
- However, this method only exists at [this commit](https://github.com/svenfuchs/i18n/commit/88b643e85e2c7d0eae71ff1abd5aaaae254e135f) in `i18n/lib/i18n.rb`, which is part of i18n version [0.6.7](https://github.com/svenfuchs/i18n/blob/v0.6.7/lib/i18n.rb).
- Versions prior to 0.6.7 do not have that method in that spot.
- However, Padrino's dependency on i18n is listed as `~> 0.6`.

Therefore, this is a bug; a version like 0.6.5 will satisfy the gemspec dependency but won't let the tests pass. The dependency string should be `>= 0.6.7` and `~> 0.6`.

Otherwise, someone working on Padrino will see spurious test failures from attempts to invoke `I18n.enforce_available_locales=`, since that method doesn't exist.
