### PR TITLE
The generator should abort if constant name already exists.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -199,6 +199,14 @@ module Padrino
       end
 
       ##
+      # Returns true if constant name already exists.
+      #
+      def already_exists?(name, project_name = nil)
+        project_name = project_name ? (Object.const_get(project_name) rescue nil) : nil
+        Object.const_defined?(name) || (project_name && project_name.const_defined?(name))
+      end
+
+      ##
       # Returns the field with an unacceptable name(for symbol) else returns nil.
       #
       # @param [Array<String>] fields

--- a/padrino-gen/lib/padrino-gen/generators/app.rb
+++ b/padrino-gen/lib/padrino-gen/generators/app.rb
@@ -35,19 +35,25 @@ module Padrino
         if in_app_root?
           @project_name = options[:namespace].underscore.camelize
           @project_name = fetch_project_name(@app_folder) if @project_name.empty?
-          lowercase_app_folder = @app_folder.downcase
-          self.behavior = :revoke if options[:destroy]
-          app_skeleton(lowercase_app_folder, options[:tiny])
-          empty_directory destination_root("public/#{lowercase_app_folder}")
-          inject_into_file destination_root('config/apps.rb'), "\nPadrino.mount('#{@project_name}::#{@app_name}', :app_file => Padrino.root('#{lowercase_app_folder}/app.rb')).to('/#{lowercase_app_folder}')\n", :before => /^Padrino.mount.*\.to\('\/'\)$/
-
-          return if self.behavior == :revoke
-          say
-          say '=' * 65, :green
-          say "Your #{@app_name} application has been installed."
-          say '=' * 65, :green
-          say "This application has been mounted to /#{@app_name.downcase}"
-          say "You can configure a different path by editing 'config/apps.rb'"
+          if already_exists?(@app_name, @project_name)
+            say "#{@app_name} already exists."
+            say "Please, change the name."
+            return
+          else
+            lowercase_app_folder = @app_folder.downcase
+            self.behavior = :revoke if options[:destroy]
+            app_skeleton(lowercase_app_folder, options[:tiny])
+            empty_directory destination_root("public/#{lowercase_app_folder}")
+            inject_into_file destination_root('config/apps.rb'), "\nPadrino.mount('#{@project_name}::#{@app_name}', :app_file => Padrino.root('#{lowercase_app_folder}/app.rb')).to('/#{lowercase_app_folder}')\n", :before => /^Padrino.mount.*\.to\('\/'\)$/
+  
+            return if self.behavior == :revoke
+            say
+            say '=' * 65, :green
+            say "Your #{@app_name} application has been installed."
+            say '=' * 65, :green
+            say "This application has been mounted to /#{@app_name.downcase}"
+            say "You can configure a different path by editing 'config/apps.rb'"
+          end
         else
           say 'You are not at the root of a Padrino application! (config/boot.rb not found)'
         end

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -10,7 +10,6 @@ require 'padrino-gen'
 require 'padrino-core'
 require 'padrino-mailer'
 require 'padrino-helpers'
-require 'padrino-core/support_lite' unless defined?(SupportLite)
 
 Padrino::Generators.load_components!
 

--- a/padrino-gen/test/test_app_generator.rb
+++ b/padrino-gen/test/test_app_generator.rb
@@ -96,5 +96,26 @@ describe "AppGenerator" do
       assert_no_dir_exists("#{@apptmp}/sample_project/demo/views")
       assert_no_match_in_file(/Padrino\.mount\("Demo"\).to\("\/demo"\)/,"#{@apptmp}/sample_project/config/apps.rb")
     end
+
+    should "abort if app name already exists" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      out, err = capture_io { generate(:app, 'kernel', "--root=#{@apptmp}/sample_project") }
+      assert_match(/Kernel already exists/, out)
+      assert_no_dir_exists("#{@apptmp}/sample_project/public/kernel")
+      assert_no_dir_exists("#{@apptmp}/sample_project/kernel/controllers")
+      assert_no_dir_exists("#{@apptmp}/sample_project/kernel/helpers")
+      assert_no_file_exists("#{@apptmp}/sample_project/kernel/app.rb")
+    end
+
+    should "abort if app name already exists in root" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
+      capture_io { generate(:app, 'subapp', "--root=#{@apptmp}/sample_project") }
+      out, err = capture_io { generate_with_parts(:app, 'subapp', "--root=#{@apptmp}/sample_project", :apps => "subapp") }
+      assert_dir_exists("#{@apptmp}/sample_project/public/subapp")
+      assert_dir_exists("#{@apptmp}/sample_project/subapp/controllers")
+      assert_dir_exists("#{@apptmp}/sample_project/subapp/helpers")
+      assert_file_exists("#{@apptmp}/sample_project/subapp/app.rb")
+      assert_match(/Subapp already exists/, out)
+    end
   end
 end

--- a/padrino-gen/test/test_model_generator.rb
+++ b/padrino-gen/test/test_model_generator.rb
@@ -97,6 +97,23 @@ describe "ModelGenerator" do
       assert_match_in_file(/      t.string :email/m,  migration_file_path)
       assert_match_in_file(/    drop_table :people/m, migration_file_path)
     end
+
+    should "abort if model name already exists" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", "-d=activerecord") }
+      out, err = capture_io { generate(:model, 'kernel', "--root=#{@apptmp}/sample_project") }
+      assert_match(/Kernel already exists/, out)
+      assert_no_file_exists("#{@apptmp}/sample_project/db/migrate/001_create_kernel.rb")
+      assert_no_file_exists("#{@apptmp}/sample_project/models/kernel.rb")
+    end
+
+    should "abort if model name already exists in root" do
+      capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", "-d=activerecord") }
+      capture_io { generate(:app, 'user', "--root=#{@apptmp}/sample_project") }
+      out, err = capture_io { generate_with_parts(:model, 'user', "--root=#{@apptmp}/sample_project", :apps => "user") }
+      assert_file_exists("#{@apptmp}/sample_project/user/app.rb")
+      assert_no_file_exists("#{@apptmp}/sample_project/models/user.rb")
+      assert_match(/User already exists/, out)
+    end
   end
 
   # ACTIVERECORD


### PR DESCRIPTION
ref #1511 
The approach is a way of solving for the real environment.
In test case, #generate_with_parts calls the `require` for files.
Then, the required files and constants will be deleted.
