### PR TITLE
Skip loading models for sequel migration tasks, closes #1520

### DIFF
--- a/padrino-core/lib/padrino-core/cli/rake_tasks.rb
+++ b/padrino-core/lib/padrino-core/cli/rake_tasks.rb
@@ -16,6 +16,16 @@ task :environment do
   end
 end
 
+# Loads skeleton Padrino environment, no models, no application settings.
+task :skeleton do
+  module Padrino::Reloader
+    def self.safe_load(file, options)
+      super unless file.include?('/models/')
+    end
+  end
+  require File.expand_path('config/boot.rb', Rake.application.original_dir)
+end
+
 desc "Generate a secret key"
 task :secret do
   shell.say SecureRandom.hex(32)

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/sequel.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/sequel.rb
@@ -2,7 +2,7 @@ if PadrinoTasks.load?(:sequel, defined?(Sequel))
   namespace :sq do
     namespace :migrate do
       desc "Perform automigration (reset your db data)"
-      task :auto => :environment do
+      task :auto => :skeleton do
         ::Sequel.extension :migration
         ::Sequel::Migrator.run Sequel::Model.db, "db/migrate", :target => 0
         ::Sequel::Migrator.run Sequel::Model.db, "db/migrate"
@@ -10,7 +10,7 @@ if PadrinoTasks.load?(:sequel, defined?(Sequel))
       end
 
       desc "Perform migration up/down to VERSION"
-      task :to, [:version] => :environment do |t, args|
+      task :to, [:version] => :skeleton do |t, args|
         version = (args[:version] || ENV['VERSION']).to_s.strip
         ::Sequel.extension :migration
         raise "No VERSION was provided" if version.empty?
@@ -19,14 +19,14 @@ if PadrinoTasks.load?(:sequel, defined?(Sequel))
       end
 
       desc "Perform migration up to latest migration available"
-      task :up => :environment do
+      task :up => :skeleton do
         ::Sequel.extension :migration
         ::Sequel::Migrator.run Sequel::Model.db, "db/migrate"
         puts "<= sq:migrate:up executed"
       end
 
       desc "Perform migration down (erase all data)"
-      task :down => :environment do
+      task :down => :skeleton do
         ::Sequel.extension :migration
         ::Sequel::Migrator.run Sequel::Model.db, "db/migrate", :target => 0
         puts "<= sq:migrate:down executed"
@@ -37,7 +37,7 @@ if PadrinoTasks.load?(:sequel, defined?(Sequel))
     task :migrate => 'sq:migrate:up'
 
     desc "Create the database"
-    task :create => :environment do
+    task :create => :skeleton do
       config = Sequel::Model.db.opts
       user, password, host = config[:user], config[:password], config[:host]
       database = config[:database]
@@ -55,7 +55,7 @@ if PadrinoTasks.load?(:sequel, defined?(Sequel))
     end
 
     desc "Drop the database (postgres and mysql only)"
-    task :drop => :environment do
+    task :drop => :skeleton do
       config = ::Sequel::Model.db.opts
       user, password, host, database = config[:user], config[:password], config[:host], config[:database]
 


### PR DESCRIPTION
Here is a patch allowing to avoid errors on loading models before migration task. I'm not sure if this approach is suitable for the other adapters, so it's applied only to Sequel now.
