### PR TITLE
Replaces instances of deprecated 'File.exists?' with 'File.exist?'

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -21,7 +21,7 @@ module Padrino
 
       # Look for custom template files in a generators folder under the project root.
       def source_paths
-        if File.exists? destination_root('generators', 'templates')
+        if File.exist? destination_root('generators', 'templates')
           ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
         else
           [File.expand_path(File.dirname(__FILE__))]

--- a/padrino-admin/lib/padrino-admin/generators/admin_page.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_page.rb
@@ -22,7 +22,7 @@ module Padrino
 
       # Look for custom template files in a generators folder under the project root.
       def source_paths
-        if File.exists? destination_root('generators')
+        if File.exist? destination_root('generators')
           ["#{destination_root('generators')}", File.expand_path(File.dirname(__FILE__))]
         else
           [File.expand_path(File.dirname(__FILE__))]

--- a/padrino-admin/test/helper.rb
+++ b/padrino-admin/test/helper.rb
@@ -67,7 +67,7 @@ class MiniTest::Spec
   end
 
   def assert_no_match_in_file(pattern, file)
-    File.exists?(file) ? assert_no_match(pattern, File.read(file)) : assert_file_exists(file)
+    File.exist?(file) ? assert_no_match(pattern, File.read(file)) : assert_file_exists(file)
   end
 
   # Delegate other missing methods to response.

--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -280,7 +280,7 @@ module Padrino
 
         stream = case config[:stream]
           when :to_file
-            FileUtils.mkdir_p(Padrino.root('log')) unless File.exists?(Padrino.root('log'))
+            FileUtils.mkdir_p(Padrino.root('log')) unless File.exist?(Padrino.root('log'))
             File.new(Padrino.root('log', "#{Padrino.env}.log"), 'a+')
           when :null   then StringIO.new
           when :stdout then $stdout

--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -87,7 +87,7 @@ module Padrino
       app_obj.set :app_name,       app_data.app_obj.app_name.to_s
       app_obj.set :app_file,       app_data.app_file unless ::File.exist?(app_obj.app_file)
       app_obj.set :root,           app_data.app_root unless app_data.app_root.blank?
-      app_obj.set :public_folder,  Padrino.root('public', app_data.uri_root) unless File.exists?(app_obj.public_folder)
+      app_obj.set :public_folder,  Padrino.root('public', app_data.uri_root) unless File.exist?(app_obj.public_folder)
       app_obj.set :static,         File.exist?(app_obj.public_folder) if app_obj.nil?
       app_obj.set :cascade,        app_data.cascade
       app_obj.setup_application! # Initializes the app here with above settings.

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -240,7 +240,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       desc "Load a schema.rb file into the database"
       task :load => :environment do
         file = ENV['SCHEMA'] || Padrino.root("db", "schema.rb")
-        if File.exists?(file)
+        if File.exist?(file)
           load(file)
         else
           raise %{#{file} doesn't exist yet. Run "rake ar:migrate" to create it then try again. If you do not intend to use a database, you should instead alter #{Padrino.root}/config/boot.rb to limit the frameworks that will be loaded}

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -87,7 +87,7 @@ class MiniTest::Spec
   end
 
   def assert_no_match_in_file(pattern, file)
-    File.exists?(file) ? assert_no_match(pattern, File.read(file)) : assert_file_exists(file)
+    File.exist?(file) ? assert_no_match(pattern, File.read(file)) : assert_file_exists(file)
   end
 
   # expects_generated :model, "post title:string body:text"


### PR DESCRIPTION
`File.exists?` has been deprecated for a while. `File.exist?` and `File.exists?` are synonyms going all the way back to [1.8.7](https://github.com/ruby/ruby/blob/ruby_1_8_7/file.c#L4660-L4661), though.

This will remove the deprecation warnings in recent versions and should be harmless otherwise.
