### PR TITLE
Introduce #default method to set application options

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -201,6 +201,10 @@ module Padrino
         @_prerequisites ||= []
       end
 
+      def default(option, *args, &block)
+        set(option, *args, &block) unless respond_to?(option)
+      end
+
       protected
 
       ##

--- a/padrino-core/test/test_core.rb
+++ b/padrino-core/test/test_core.rb
@@ -69,5 +69,18 @@ describe "Core" do
       res = Rack::MockRequest.new(Padrino.application).get("/")
       assert_equal "yes", res["Middleware-Called"]
     end
+
+    should "properly set default options" do
+      mock_app do
+        default :foo, :bar
+        default :zoo, :baz
+        set :foo, :bam
+        set :moo, :bam
+        default :moo, :ban
+      end
+      assert_equal @app.settings.foo, :bam
+      assert_equal @app.settings.zoo, :baz
+      assert_equal @app.settings.moo, :bam
+    end
   end
 end


### PR DESCRIPTION
Working on Padrino extensions with a lot of configuration options I ended up with calling tons of

``` ruby
        app.set :login_url, '/login'             unless app.respond_to?(:login_url)
        app.set :login_model, :account           unless app.respond_to?(:login_model)
```

Since we are claiming to be modular do you think it would be handy to have `app.default` method to be able to set these options if they are not already set?
