### PR TITLE
Fix short time format [skip ci]

### DIFF
--- a/padrino-core/lib/padrino-core/locale/zh_cn.yml
+++ b/padrino-core/lib/padrino-core/locale/zh_cn.yml
@@ -22,7 +22,7 @@ zh_cn:
     formats:
       default: "%Y年%b月%d日 %H:%M:%S %z"
       short: "%b月%d日 %H:%M"
-      long: "%Y年%B月%d日 %H时%M分"
+      long: "%Y年%B%d日 %H时%M分"
     am: "上午"
     pm: "下午"
 


### PR DESCRIPTION
Fix Chinese locale time format, It's wrong with line 24 <code>short: "%d 月 %b 日 %H:%M"</code> and line 25 <code>long: "%Y 年 %B 月 %d 日 %H 时 %M 分"</code>
