### PR TITLE
add custom index option for form_for abstract form helper

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -135,13 +135,23 @@ module Padrino
         # f.fields_for :addresses
         # f.fields_for :addresses, address
         # f.fields_for :addresses, @addresses
-        def fields_for(child_association, instance_or_collection=nil, &block)
+        # f.fields_for :addresses, address, index: i
+        def fields_for(child_association, instance_or_collection=nil, options={}, &block)
           default_collection = self.object.send(child_association)
+
           include_index = default_collection.respond_to?(:each)
+          custom_index = options.has_key?(:index)
+
           nested_options = { :parent => self, :association => child_association }
           nested_objects = instance_or_collection ? Array(instance_or_collection) : Array(default_collection)
           nested_objects.each_with_index.map do |child_instance, index|
-            nested_options[:index] = include_index ? index : nil
+            if custom_index
+              nested_options[:index] = options[:index]
+            elsif include_index
+              nested_options[:index] = index
+            else
+              nested_options[:index] = nil
+            end
             @template.fields_for(child_instance,  { :nested => nested_options }, &block)
           end.join("\n").html_safe
         end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -927,6 +927,23 @@ describe "FormBuilder" do
       assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_0_name', :name => 'user[addresses_attributes][1][businesses_attributes][0][name]') { actual_html }
     end
 
+    should "display fields for nested forms with custom indices" do
+      actual_html = standard_builder.fields_for :addresses do |child_form|
+        html = ''.html_safe
+        child_form.object.businesses.each_with_index do |business, i|
+          html += child_form.fields_for(:businesses, business, :index => ('a'..'z').to_a[i]) do |second_child_form|
+            second_child_form.label(:name) +
+            second_child_form.text_field(:name) +
+            second_child_form.check_box('_destroy')
+          end
+        end
+        html
+      end
+
+      assert_has_tag('label', :for => 'user_addresses_attributes_1_businesses_attributes_a_name', :content => 'Name') { actual_html }
+      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_a_name', :name => 'user[addresses_attributes][1][businesses_attributes][a][name]') { actual_html }
+    end
+
     should "display nested children fields in erb" do
       visit '/erb/fields_for'
       # Telephone


### PR DESCRIPTION
Use case:

``` haml
= form_for @gallery, url_for(:galleries, :create), :method => :post do |f|
  %template
    = render_partial 'form_picture', :locals => { :f => f, :index => :_template_, :picture => Picture.new }
  - f.object.pictures.each_with_index do |picture, i|
    = render_partial 'form_picture', :locals => { :f => f, :index => i, :picture => picture }
  -# ...
  %button.add_nested_picture Add picture
```

``` haml
.picture
  = f.fields_for :pictures, picture, index: index do |ff|
    .field
      .label_wrap= ff.label :title
      .input_wrap= ff.text_field :title
      .error_wrap= ff.error_message_on :title
      .clear
```

Custom index would give all sorts of flexibility for nested forms.
In example above I would write custom javascript to be able to add nested fields to form without making requests to server.

It would just copy template and append it form (in most simple case).

If you need more detailed explanation why I want this feature, let me know.
