### PR TITLE
capture ruby block in erb and slim templates, fixes #1582

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
@@ -10,7 +10,7 @@ begin
       # @api private
       module SafeBufferEnhancer
         def add_expr_literal(src, code)
-          src << " #{@bufvar}.concat((" << code << ').to_s);'
+          src << "__in_erb_template = false; #{@bufvar}.concat((" << code << ').to_s); __in_erb_template = true;'
         end
 
         def add_expr_escaped(src, code)

--- a/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/slim.rb
@@ -2,8 +2,18 @@ begin
   require 'slim'
 
   if defined? Padrino::Rendering
+    module Temple
+      module Generators
+        class PadrinoOutputBuffer < RailsOutputBuffer
+          def on_dynamic(code)
+            concat("__in_slim_template = false; __code_result = (#{code}).to_s; __in_slim_template = true; __code_result")
+          end
+        end
+      end
+    end
+
     Padrino::Rendering.engine_configurations[:slim] = {
-      :generator => Temple::Generators::RailsOutputBuffer,
+      :generator => Temple::Generators::PadrinoOutputBuffer,
       :buffer => "@_out_buf",
       :use_html_safe => true,
       :disable_capture => true,

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
@@ -17,7 +17,7 @@ module Padrino
         # Returns true if the block is Erb.
         #
         def engine_matches?(block)
-          block.binding.eval('defined? __in_erb_template')
+          block.binding.eval('defined?(__in_erb_template)&&__in_erb_template')
         end
       end
       OutputHelpers.register(:erb, ErbHandler)

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/slim_handler.rb
@@ -9,7 +9,7 @@ module Padrino
         # Returns true if the block is for Slim.
         #
         def engine_matches?(block)
-          block.binding.eval('defined? __in_slim_template')
+          block.binding.eval('defined?(__in_slim_template)&&__in_slim_template')
         end
       end
       OutputHelpers.register(:slim, SlimHandler)

--- a/padrino-helpers/test/test_render_helpers.rb
+++ b/padrino-helpers/test/test_render_helpers.rb
@@ -159,7 +159,6 @@ describe "RenderHelpers" do
     end
 
     should "support weird ruby blocks in erb" do
-      skip
       visit '/ruby_block_capture_erb'
       assert_have_selector 'b', :content => 'c'
     end
@@ -170,7 +169,6 @@ describe "RenderHelpers" do
     end
     
     should "support weird ruby blocks in slim" do
-      skip
       visit '/ruby_block_capture_slim'
       assert_have_selector 'b', :content => 'c'
     end


### PR DESCRIPTION
ref #1582 

This patch allows this weird stuff:

ERB:

``` ruby
<%= content_tag(:a) { content_tag :b, 'c' } %>
```

Slim:

``` ruby
= content_tag(:a) { content_tag :b, 'c' }
```

It was not working before because `__in_erb_template` and `__in_slim_template` flag was set in the preamble for generated ruby code and these flags were affecting behavior of #content_tag called with ruby or template block.

@minad, @padrino/core-members better suggestions would be appreciated
