### PR TITLE
Fix padrino-cache example comment

### DIFF
--- a/padrino-cache/README.rdoc
+++ b/padrino-cache/README.rdoc
@@ -257,7 +257,7 @@ You can set a global caching option or a per app caching options.
 
   Padrino.cache = Padrino::Cache.new(:LRUHash) # Keeps cached values in memory
   Padrino.cache = Padrino::Cache.new(:Memcached) # Uses default server at localhost
-  Padrino.cache = Padrino::Cache.new(:Memcached, '127.0.0.1:11211', :exception_retry_limit => 1)
+  Padrino.cache = Padrino::Cache.new(:Memcached, :server => '127.0.0.1:11211', :exception_retry_limit => 1)
   Padrino.cache = Padrino::Cache.new(:Memcached, :backend => memcached_or_dalli_instance)
   Padrino.cache = Padrino::Cache.new(:Redis) # Uses default server at localhost
   Padrino.cache = Padrino::Cache.new(:Redis, :host => '127.0.0.1', :port => 6379, :db => 0)

--- a/padrino-cache/lib/padrino-cache.rb
+++ b/padrino-cache/lib/padrino-cache.rb
@@ -31,7 +31,7 @@ module Padrino
     #   Padrino.cache = Padrino::Cache.new(:File, :dir => Padrino.root('tmp', app_name.to_s, 'cache')) # default choice
     #   Padrino.cache = Padrino::Cache.new(:LRUHash) # Keeps cached values in memory
     #   Padrino.cache = Padrino::Cache.new(:Memcached) # Uses default server at localhost
-    #   Padrino.cache = Padrino::Cache.new(:Memcached, '127.0.0.1:11211', :exception_retry_limit => 1)
+    #   Padrino.cache = Padrino::Cache.new(:Memcached, :server => '127.0.0.1:11211', :exception_retry_limit => 1)
     #   Padrino.cache = Padrino::Cache.new(:Memcached, :backend => memcached_or_dalli_instance)
     #   Padrino.cache = Padrino::Cache.new(:Redis) # Uses default server at localhost
     #   Padrino.cache = Padrino::Cache.new(:Redis, :host => '127.0.0.1', :port => 6379, :db => 0)


### PR DESCRIPTION
If memcache server is specified, it must be set options hash with `:server` key
ref: https://github.com/minad/moneta#creating-a-store

```
store = Moneta.new(:Memcached, server: 'localhost:11211')
```
### Right case

```
Padrino.cache = Padrino::Cache.new(:Memcached, :server => '127.0.0.1:11211', :exception_retry_limit => 1
```
### In such a case...

```
Padrino.cache = Padrino::Cache.new(:Memcached, '127.0.0.1:11211', :exception_retry_limit => 1
```
#### raise error.

```
  ERROR -  TypeError: no implicit conversion of Symbol into String; /path/to/vendor/bundle/ruby/2.1.0/gems/padrino-cache-0.12.0/lib/padrino-cache.rb:112:in `include?'
  ERROR -  TypeError: no implicit conversion of Symbol into String; /path/to/vendor/bundle/ruby/2.1.0/gems/padrino-cache-0.12.0/lib/padrino-cache.rb:112:in `include?'
/path/to/vendor/bundle/ruby/2.1.0/gems/padrino-cache-0.12.0/lib/padrino-cache.rb:112:in `include?': no implicit conversion of Symbol into String (TypeError)
    from /path/to/vendor/bundle/ruby/2.1.0/gems/padrino-cache-0.12.0/lib/padrino-cache.rb:112:in `new'
```
