### PR TITLE
ensure that captured blocks in erb and slim templates return nil, fixes #1582

### DIFF
--- a/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
+++ b/padrino-core/lib/padrino-core/application/rendering/extensions/erubis.rb
@@ -13,6 +13,12 @@ begin
           src << " #{@bufvar}.concat((" << code << ').to_s);'
         end
 
+        def add_stmt(src, code)
+          code = code.sub('end', 'nil;end') if code =~ /\A\s*end\s*\Z/
+          src << code
+          src << ';' unless code[-1] == ?\n
+        end
+
         def add_expr_escaped(src, code)
           src << " #{@bufvar}.safe_concat " << code << ';'
         end

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/abstract_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/abstract_handler.rb
@@ -33,7 +33,7 @@ module Padrino
           raw = block.call(*args)
           captured = template.instance_variable_get(:@_out_buf)
           self.output_buffer = _buf_was
-          engine_matches?(block) ? captured : raw
+          engine_matches?(block) && !captured.empty? ? captured : raw.to_s
         end
 
         ##

--- a/padrino-helpers/test/test_render_helpers.rb
+++ b/padrino-helpers/test/test_render_helpers.rb
@@ -159,7 +159,6 @@ describe "RenderHelpers" do
     end
 
     should "support weird ruby blocks in erb" do
-      skip
       visit '/ruby_block_capture_erb'
       assert_have_selector 'b', :content => 'c'
     end
@@ -170,7 +169,6 @@ describe "RenderHelpers" do
     end
     
     should "support weird ruby blocks in slim" do
-      skip
       visit '/ruby_block_capture_slim'
       assert_have_selector 'b', :content => 'c'
     end


### PR DESCRIPTION
Rebased on current master, doesn't require a new Slim version. Should work like this. I recommend pulling this one.
