### PR TITLE
Drop the test code that requires webrat, fixes #1569

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
@@ -46,7 +46,7 @@ When /^I press '(.*)'$/ do |name|
 end
 
 Then /^I should see '(.*)'$/ do |text|
-  response_body.should contain(/#\{text}/m)
+  page.should have_content(text)
 end
 TEST
 


### PR DESCRIPTION
ref #1569 
I want to suggest adding a gem instead of modifying the test code
@padrino/core-members @fgarcia What do you think?
