### PR TITLE
Fix rr deprecation warning when using it together with rspec

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/mocks/rr.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/mocks/rr.rb
@@ -1,8 +1,8 @@
 def setup_mock
-  require_dependencies 'rr', :group => 'test'
+  require_dependencies 'rr', :require => false, :group => 'test'
   case options[:test].to_s
     when 'rspec'
-      inject_into_file 'spec/spec_helper.rb', "  conf.mock_with :rr\n", :after => "RSpec.configure do |conf|\n"
+      inject_into_file 'spec/spec_helper.rb', "require 'rr'\n", :after => "\"/../config/boot\")\n"
     when 'riot'
       inject_into_file "test/test_config.rb","require 'riot/rr'\n", :after => "\"/../config/boot\")\n"
     when 'minitest'

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -211,8 +211,8 @@ describe "ProjectGenerator" do
     should "properly generate for rr and rspec" do
       out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--test=rspec', '--mock=rr', '--script=none') }
       assert_match(/applying.*?rr.*?mock/, out)
-      assert_match_in_file(/gem 'rr'/, "#{@apptmp}/sample_project/Gemfile")
-      assert_match_in_file(/conf.mock_with :rr/m, "#{@apptmp}/sample_project/spec/spec_helper.rb")
+      assert_match_in_file(/gem 'rr', :require => false/, "#{@apptmp}/sample_project/Gemfile")
+      assert_match_in_file(/require 'rr'/m, "#{@apptmp}/sample_project/spec/spec_helper.rb")
     end
 
     should "properly generate for mocha and rspec" do


### PR DESCRIPTION
This commit fixes the following error:

```
    DEPRECATION: RSpec::Core::Configuration#backtrace_clean_patterns is
   deprecated. Use RSpec::Core::Configuration#backtrace_exclusion_patterns
   instead.
```

...that appears when using rspec + rr. Since a while there's no need of using
the `conf.with_mock :rr` in Rspec conf. See more info [here](https://github.com/rr/rr/pull/37#issuecomment-22833629).
