### PR TITLE
load config.ru with padrino server, fixes #1260

### DIFF
--- a/padrino-core/lib/padrino-core/cli/base.rb
+++ b/padrino-core/lib/padrino-core/cli/base.rb
@@ -21,7 +21,7 @@ module Padrino
       method_option :options,   :type => :array,  :aliases => "-O", :desc => "--options NAME=VALUE NAME2=VALUE2'. pass VALUE to the server as option NAME. If no VALUE, sets it to true. Run '#{$0} --server_options"
       method_option :server_options,   :type => :boolean, :desc => "Tells the current server handler's options that can be used with --options"
 
-      def start
+      def start(*args)
         prepare :start
         require File.expand_path("../adapter", __FILE__)
         require File.expand_path('config/boot.rb')
@@ -29,7 +29,7 @@ module Padrino
         if options[:server_options]
           puts server_options(options)
         else
-          Padrino::Cli::Adapter.start(options)
+          Padrino::Cli::Adapter.start(args.last ? options.merge(:config => args.last).freeze : options)
         end
       end
 

--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -9,7 +9,18 @@ module Padrino
   #
   def self.run!(options={})
     Padrino.load!
-    Server.start(Padrino.application, options)
+    default_config_file = 'config.ru'
+    app =
+      if options[:config] || File.file?(default_config_file)
+        options[:config] ||= default_config_file
+        fail "Rack config file `#{options[:config]}` must have `.ru` extension" unless options[:config] =~ /\.ru$/
+        rack_app, rack_options = Rack::Builder.parse_file(options[:config])
+        options = rack_options.merge(options)
+        rack_app
+      else
+        Padrino.application
+      end
+    Server.start(app, options)
   end
 
   ##


### PR DESCRIPTION
`bundle exec padrino s` to load config.ru
`bundle exec padrino s app.ru` to load app.ru

It should default to config file options and override them with command line options.
