### PR TITLE
Fix bug in Padrino::Mounter.app_constant (#1595)

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -137,7 +137,7 @@ module Padrino
       klass = Object
       for piece in app_class.split("::")
         piece = piece.to_sym
-        if klass.const_defined?(piece)
+        if klass.const_defined?(piece, false)
           klass = klass.const_get(piece)
         else
           return

--- a/padrino-core/test/fixtures/apps/demo_app.rb
+++ b/padrino-core/test/fixtures/apps/demo_app.rb
@@ -1,0 +1,7 @@
+PADRINO_ROOT = File.dirname(__FILE__) unless defined? PADRINO_ROOT
+
+module Demo
+  class App < Padrino::Application
+    set :reload, true
+  end
+end

--- a/padrino-core/test/fixtures/apps/demo_demo.rb
+++ b/padrino-core/test/fixtures/apps/demo_demo.rb
@@ -1,0 +1,7 @@
+PADRINO_ROOT = File.dirname(__FILE__) unless defined? PADRINO_ROOT
+
+module Demo
+  class Demo < Padrino::Application
+    set :reload, true
+  end
+end

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -118,6 +118,15 @@ describe "Mounter" do
       assert_equal ["one_app", "two_app"], Padrino.mounted_apps.map(&:name)
     end
 
+    should 'mount app with the same name as the module' do
+      Padrino.mount("Demo::App",  :app_file => File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/demo_app.rb')).to("/app")
+      Padrino.mount("Demo::Demo", :app_file => File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/demo_demo.rb')).to("/")
+
+      Padrino.mounted_apps.each do |app|
+        assert_equal app.app_obj.setup_application!, true
+      end
+    end
+
     should 'change mounted_root' do
       Padrino.mounted_root = "fixtures"
       assert_equal Padrino.root("fixtures", "test", "app.rb"), Padrino.mounted_root("test", "app.rb")


### PR DESCRIPTION
If the module with the same name as the application class has already been defined,
Padrino::Mounter.app_constant had returned the very module object.

So I intend not to search towards ancestors with second parameter 'false' in 'const_defined?'.
This code is only valid in the Ruby 1.9 or later.

(see #1595 )
