### PR TITLE
Replace tab characters with spaces in rspec generator

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -39,10 +39,10 @@ RSPEC_RAKE = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_RAKE)
 begin
   require 'rspec/core/rake_task'
 
-	spec_tasks = Dir['spec/*/'].inject([]) do |result, d|
-	  result << File.basename(d) unless Dir["\#{d}*"].empty?
-	  result
-	end
+  spec_tasks = Dir['spec/*/'].inject([]) do |result, d|
+    result << File.basename(d) unless Dir["\#{d}*"].empty?
+    result
+  end
 
   spec_tasks.each do |folder|
     RSpec::Core::RakeTask.new("spec:\#{folder}") do |t|


### PR DESCRIPTION
Removed erroneous tab characters in rspec generator.
