### PR TITLE
Add explicit specification of ActiveRecord::Base.default_timezone in AR template

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -53,6 +53,9 @@ ActiveSupport.escape_html_entities_in_json = false
 
 # Now we can establish connection with our db.
 ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+
+# Timestamps are in the utc by default.
+ActiveRecord::Base.default_timezone = :utc
 AR
 
 MYSQL = (<<-MYSQL) unless defined?(MYSQL)

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/minirecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/minirecord.rb
@@ -53,6 +53,9 @@ ActiveSupport.escape_html_entities_in_json = false
 
 # Now we can establish connection with our db.
 ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+
+# Timestamps are in the utc by default.
+ActiveRecord::Base.default_timezone = :utc
 MR
 
 MYSQL = (<<-MYSQL) unless defined?(MYSQL)


### PR DESCRIPTION
You might want to set aware of this value.
The default value of ActiveRecord.default_timezone is :utc at AR4.
However, AR3 default was :local.
