### PR TITLE
Add 'rake db:create' instruction

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/admin_app.rb
+++ b/padrino-admin/lib/padrino-admin/generators/admin_app.rb
@@ -144,8 +144,10 @@ module Padrino
 
           instructions = []
           instructions << "Run 'bundle'"
-          instructions << "Run 'bundle exec rake db:create'" if (orm == :activerecord || orm == :datamapper || orm == :sequel)
-          instructions << "Run 'bundle exec rake db:migrate'" if (orm == :activerecord || orm == :datamapper || orm == :sequel)
+          if [:activerecord, :datamapper, :sequel].include?(orm)
+            instructions << "Run 'bundle exec rake db:create'"
+            instructions << "Run 'bundle exec rake db:migrate'"
+          end
           instructions << "Now repeat after me... 'ohm mani padme hum', 'ohm mani padme hum'... :)" if orm == :ohm
           instructions << "Run 'bundle exec rake db:seed'"
           instructions << "Visit the admin panel in the browser at '/#{@admin_path}'"


### PR DESCRIPTION
Add an instruction to create the database which better reflects reality, 
especially when going through the 'Quick Install' shown on the first page
of the Padrino website.

```
gem install padrino
padrino g project myapp -d datamapper -b
cd myapp
padrino g admin
padrino rake dm:migrate seed
padrino start
```
