### PR TITLE
Fix the issue that params is not set correctly, fixes #1648

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -132,6 +132,19 @@ class HttpRouter
     @routes.sort!{ |a, b| a.order <=> b.order }
   end
 
+  class Node::Glob
+    def to_code
+      id = root.next_counter
+      "request.params << (globbed_params#{id} = [])
+       until request.path.empty?
+         globbed_params#{id} << request.path.shift
+         #{super}
+       end
+       request.path[0,0] = globbed_params#{id}
+       request.params.pop"
+    end
+  end
+
   class Node::SpanningRegex
     def to_code
       params_count = @ordered_indicies.size

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -898,6 +898,17 @@ describe "Routing" do
     assert_equal "hello", body
   end
 
+  it 'should set the params correctly even if using prioritized routes' do
+    mock_app do
+      get("*__sinatra__/:image.png"){}
+      get "/:primary/:secondary", :priority => :low do
+        "#{params[:primary]} #{params[:secondary]}"
+      end
+    end
+    get "/abc/def"
+    assert_equal "abc def", body
+  end
+
   it 'should catch all after controllers' do
     mock_app do
       get(:index, :with => :slug, :priority => :low) { "catch all" }


### PR DESCRIPTION
ref #1648 
http_router doesn't set the params correctly if the other route is using glob pattern.
In this case, the issue is caused by [this route](https://github.com/padrino/padrino-framework/blob/master/padrino-core/lib/padrino-core/application/application_setup.rb#L127-L132).
