### PR TITLE
Router: Pass the same `env` variable down

### DIFF
--- a/padrino-core/lib/padrino-core/router.rb
+++ b/padrino-core/lib/padrino-core/router.rb
@@ -79,13 +79,17 @@ module Padrino
 
         rest = "/" if rest.empty?
 
-        last_result = app.call(env.merge('SCRIPT_NAME' => script_name + path, 'PATH_INFO' => rest))
+        env['SCRIPT_NAME'] = script_name + path
+        env['PATH_INFO'] = rest
+        last_result = app.call(env)
 
         cascade_setting = app.respond_to?(:cascade) ? app.cascade : true
         cascade_statuses = cascade_setting.respond_to?(:include?) ? cascade_setting : Mounter::DEFAULT_CASCADE
         break unless cascade_setting && cascade_statuses.include?(last_result[0])
       end
       last_result || begin
+        env['SCRIPT_NAME'] = script_name
+        env['PATH_INFO'] = path_info
         Padrino::Logger::Rack.new(nil,'/').send(:log, env, 404, {}, began_at) if logger.debug?
         [404, {"Content-Type" => "text/plain", "X-Cascade" => "pass"}, ["Not Found: #{path_info}"]]
       end

--- a/padrino-core/test/test_router.rb
+++ b/padrino-core/test/test_router.rb
@@ -262,4 +262,20 @@ describe "Router" do
     res = Rack::MockRequest.new(Padrino.application).get("/foo/", "HTTP_HOST" => "bar.padrino.org")
     assert res.ok?
   end
+
+  it 'should keep the same environment object' do
+    app = lambda { |env|
+      env['path'] = env['PATH_INFO']
+      [200, {'Content-Type' => 'text/plain'}, [""]]
+    }
+    map = Padrino::Router.new(
+      { :path => '/bar',     :to => app },
+      { :path => '/foo/bar', :to => app },
+      { :path => '/foo',     :to => app }
+    )
+
+    env = Rack::MockRequest.env_for("/bar/foo")
+    map.call(env)
+    assert_equal "/foo", env["path"]
+  end
 end


### PR DESCRIPTION
This is very useful when you're writing controller tests:

``` ruby
env = env_for(…)
res = app.call(env)
p env['rack.session']
```

This is currently impossible with the current code. I also think in
general it's a good idea to use the same `env` everywhere. It's quite
useful being able to pass data up and down the middleware stack.
