### PR TITLE
Fixed double escape of & in mail_to helper

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -147,7 +147,7 @@ module Padrino
       #
       def mail_to(email, caption=nil, mail_options={})
         html_options = mail_options.slice!(:cc, :bcc, :subject, :body)
-        mail_query = Rack::Utils.build_query(mail_options).gsub(/\+/, '%20').gsub('%40', '@').gsub('&', '&amp;')
+        mail_query = Rack::Utils.build_query(mail_options).gsub(/\+/, '%20').gsub('%40', '@')
         mail_href = "mailto:#{email}"; mail_href << "?#{mail_query}" if mail_query.present?
         link_to((caption || email), mail_href, html_options)
       end

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -102,6 +102,8 @@ describe "AssetTagHelpers" do
     it 'should not double-escape' do
       actual_link = link_to('test escape', '?a=1&b=2')
       assert_has_tag('a', :href => '?a=1&b=2') { actual_link }
+      assert_match %r{&amp;}, actual_link
+      refute_match %r{&amp;amp;}, actual_link
     end
 
     it 'should escape scary things' do
@@ -133,6 +135,13 @@ describe "AssetTagHelpers" do
       actual_html = mail_to('test@demo.com', "My&Email", :subject => "this&that")
       assert_match 'this%26that', actual_html
       assert_match 'My&amp;Email', actual_html
+    end
+
+    it 'should not double-escape ampersands in query' do
+      actual_html = mail_to('to@demo.com', "Email", :subject => 'Hi there', :bcc => 'bcc@test.com')
+      assert_has_tag(:a, :href => 'mailto:to@demo.com?bcc=bcc@test.com&subject=Hi%20there', :content => 'Email') { actual_html }
+      assert_match %r{&amp;}, actual_html
+      refute_match %r{&amp;amp;}, actual_html
     end
 
     it 'should display mail link element in haml' do


### PR DESCRIPTION
- This only manifests itself with `mail_to` links that have more than
  one query option (subject, body, cc, bcc)
- Escaping & in mail_to is unnecessary, because it is already later
  handled when link_to is called
