### PR TITLE
add tests for csrf-protection with http header X-CSRF-TOKEN

### DIFF
--- a/padrino-core/test/test_csrf_protection.rb
+++ b/padrino-core/test/test_csrf_protection.rb
@@ -27,6 +27,17 @@ describe "Application" do
         post "/", {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "b"}
         assert_equal 403, status
       end
+
+      it 'should allow requests with correct X-CSRF-TOKEN' do
+        post "/", {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "a"
+        assert_equal 200, status
+      end
+
+      it 'should not allow requests with incorrect X-CSRF-TOKEN' do
+        post "/", {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "b"
+        assert_equal 403, status
+      end
+
     end
 
     describe "without CSRF protection on" do
@@ -45,11 +56,21 @@ describe "Application" do
 
       it 'should allow requests with correct tokens' do
         post "/", {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "a"}
-        assert_equal 200, status        
+        assert_equal 200, status
       end
 
       it 'should allow requests with incorrect tokens' do
         post "/", {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "b"}
+        assert_equal 200, status
+      end
+
+      it 'should allow requests with correct X-CSRF-TOKEN' do
+        post "/", {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "a"
+        assert_equal 200, status
+      end
+
+      it 'should allow requests with incorrect X-CSRF-TOKEN' do
+        post "/", {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "b"
         assert_equal 200, status
       end
     end


### PR DESCRIPTION
Some javascript framework, such as angularjs, use custom HTTP header to pass csrf-token in ajax requests,
and rack-protection could validate csrf-token with http header named X-CSRF-TOKEN.
Padrino should have tests for that feature.
