### PR TITLE
Fix the wrong cache adapter [ci skip]

### DIFF
--- a/padrino-cache/README.rdoc
+++ b/padrino-cache/README.rdoc
@@ -255,7 +255,8 @@ You can set a global caching option or a per app caching options.
 
 === Global Caching Options
 
-  Padrino.cache = Padrino::Cache.new(:LRUHash) # Keeps cached values in memory
+  Padrino.cache = Padrino::Cache.new(:LRUHash) # default choice
+  Padrino.cache = Padrino::Cache.new(:File, :dir => Padrino.root('tmp', app_name.to_s, 'cache')) # Keeps cached values in file
   Padrino.cache = Padrino::Cache.new(:Memcached) # Uses default server at localhost
   Padrino.cache = Padrino::Cache.new(:Memcached, :server => '127.0.0.1:11211', :exception_retry_limit => 1)
   Padrino.cache = Padrino::Cache.new(:Memcached, :backend => memcached_or_dalli_instance)
@@ -264,7 +265,6 @@ You can set a global caching option or a per app caching options.
   Padrino.cache = Padrino::Cache.new(:Redis, :backend => redis_instance)
   Padrino.cache = Padrino::Cache.new(:Mongo) # Uses default server at localhost
   Padrino.cache = Padrino::Cache.new(:Mongo, :backend => mongo_client_instance)
-  Padrino.cache = Padrino::Cache.new(:File, :dir => Padrino.root('tmp', app_name.to_s, 'cache')) # default choice
 
 You can manage your cache from anywhere in your app:
 

--- a/padrino-cache/lib/padrino-cache.rb
+++ b/padrino-cache/lib/padrino-cache.rb
@@ -28,8 +28,8 @@ module Padrino
     #   Instance of Moneta store
     #
     # @example
-    #   Padrino.cache = Padrino::Cache.new(:File, :dir => Padrino.root('tmp', app_name.to_s, 'cache')) # default choice
-    #   Padrino.cache = Padrino::Cache.new(:LRUHash) # Keeps cached values in memory
+    #   Padrino.cache = Padrino::Cache.new(:LRUHash) # default choice
+    #   Padrino.cache = Padrino::Cache.new(:File, :dir => Padrino.root('tmp', app_name.to_s, 'cache')) # Keeps cached values in file
     #   Padrino.cache = Padrino::Cache.new(:Memcached) # Uses default server at localhost
     #   Padrino.cache = Padrino::Cache.new(:Memcached, :server => '127.0.0.1:11211', :exception_retry_limit => 1)
     #   Padrino.cache = Padrino::Cache.new(:Memcached, :backend => memcached_or_dalli_instance)


### PR DESCRIPTION
I think the default choice in comment is wrong.
The default adapter of `Padrino.cache` is set LRUHash in [this code](https://github.com/padrino/padrino-framework/blob/master/padrino-cache/lib/padrino-cache.rb#L123).
