### PR TITLE
Fixed url when both uri_root and RACK_BASE_URI is setting

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -634,8 +634,8 @@ module Padrino
       def rebase_url(url)
         if url.start_with?('/')
           new_url = ''
-          new_url << conform_uri(uri_root) if defined?(uri_root)
           new_url << conform_uri(ENV['RACK_BASE_URI']) if ENV['RACK_BASE_URI']
+          new_url << conform_uri(uri_root) if defined?(uri_root)
           new_url << url
         else
           url.blank? ? '/' : url

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -7,6 +7,7 @@ class FooError < RuntimeError; end
 describe "Routing" do
   before do
     Padrino.clear!
+    ENV['RACK_BASE_URI'] = nil
   end
 
   it 'should serve static files with simple cache control' do
@@ -855,6 +856,18 @@ describe "Routing" do
     assert_equal "/foo", @app.url(:foo)
     ENV['RACK_BASE_URI'] = '/testing'
     assert_equal "/testing/foo", @app.url(:foo)
+    ENV['RACK_BASE_URI'] = nil
+  end
+
+  it 'should use uri_root and RACK_BASE_URI' do
+    mock_app do
+      controller :foo do
+        get(:bar){ "bar" }
+      end
+    end
+    ENV['RACK_BASE_URI'] = '/base'
+    @app.uri_root = 'testing'
+    assert_equal '/base/testing/foo/bar', @app.url(:foo, :bar)
     ENV['RACK_BASE_URI'] = nil
   end
 


### PR DESCRIPTION
When both Application#uri_root and RACK_BASE_URI environment variable is setting, Application#url() returns "uri_root/RACK_BASE_URI/controller/action". It should be "RACK_BASE_URI/uri_root/controller/action".
