### PR TITLE
Set @html_part / @text_part properly

### DIFF
--- a/padrino-mailer/lib/padrino-mailer/ext.rb
+++ b/padrino-mailer/lib/padrino-mailer/ext.rb
@@ -107,6 +107,7 @@ module Mail # @private
       new_part.instance_eval(&part_block) if part_block
       yield new_part if block_given?
       add_part(new_part)
+      new_part
     end
 
     def do_delivery_with_logging

--- a/padrino-mailer/test/test_part.rb
+++ b/padrino-mailer/test/test_part.rb
@@ -31,6 +31,9 @@ describe "Part" do
       assert_equal 'This is a foo message in mailers/sample dir', message.parts[1].body.decoded.chomp
       assert_equal :plain, message.parts[2].content_type
       assert_equal 'other', message.parts[2].body.decoded
+
+      assert_equal 'This is a foo message in mailers/sample dir', message.html_part.body.decoded.chomp
+      assert_equal 'plain text', message.text_part.body.decoded
     end
 
     it 'should works with multipart templates' do


### PR DESCRIPTION
There's a bug which causes #html_part to not work properly:

``` ruby
message.html_part { body "hello" }
message.html_part # => Doesn't actually return the html_part
```
