### PR TITLE
Test should not depend on the execution order, fixes #1683

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
@@ -1,7 +1,7 @@
 BACON_SETUP = (<<-TEST).gsub(/^ {10}/, '') unless defined?(BACON_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 class Bacon::Context
   include Rack::Test::Methods

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
@@ -3,7 +3,7 @@ apply_component_for(:rspec, :test)
 CUCUMBER_SETUP = (<<-TEST) unless defined?(CUCUMBER_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 require 'capybara/cucumber'
 require 'rspec/expectations'

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
@@ -1,7 +1,7 @@
 MINITEST_SETUP = (<<-TEST).gsub(/^ {10}/, '') unless defined?(MINITEST_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
-require File.expand_path('../../config/boot', __FILE__)
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 class MiniTest::Spec
   include Rack::Test::Methods

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
@@ -1,7 +1,7 @@
 RIOT_SETUP = (<<-TEST).gsub(/^ {10}/, '') unless defined?(RIOT_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 # Specify your app using the #app helper inside a context.
 # Takes either an app class or a block argument.

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -1,7 +1,7 @@
 RSPEC_SETUP = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 RSpec.configure do |conf|
   conf.include Rack::Test::Methods

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
@@ -1,7 +1,7 @@
 SHOULDA_SETUP = (<<-TEST).gsub(/^ {10}/, '') unless defined?(SHOULDA_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 require "test/unit"
 

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/steak.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/steak.rb
@@ -1,7 +1,7 @@
 STEAK_SETUP = (<<-TEST).gsub(/^ {12}/, '') unless defined?(STEAK_SETUP)
 RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
-Dir[File.expand_path("../../app/helpers/**/*.rb", __FILE__)].each(&method(:require))
+Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
 RSpec.configure do |conf|
   conf.include Rack::Test::Methods


### PR DESCRIPTION
ref #1683 
Helper's tests must be consider the execution order, it means the tests are weak.
The issue will be fixed by loading helper files in advance.
