### PR TITLE
AbstractFormBuilder#fields_for should respect the builder of parent

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -135,7 +135,7 @@ module Padrino
           nested_options = { :parent => self, :association => child_association }
           Array(collection).each_with_index.inject(ActiveSupport::SafeBuffer.new) do |all,(child_instance,index)|
             nested_options[:index] = options[:index] || (include_index ? index : nil)
-            all << @template.fields_for(child_instance,  { :nested => nested_options }, &block) << "\n"
+            all << @template.fields_for(child_instance,  { :nested => nested_options, :builder => self.class }, &block) << "\n"
           end
         end
 

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -167,6 +167,16 @@ describe "FormBuilder" do
       assert_raises(RuntimeError) { fields_for(@not_real) { |f| "Demo" } }
     end
 
+    it 'should respect the builder of parent' do
+      assert_raises(NoMethodError) do
+        form_for(@user, '/register', builder: "AbstractFormBuilder") do |f|
+          f.fields_for(:role_types, @user.role_types) do |field|
+            field.submit_block "Submit"
+          end
+        end
+      end
+    end
+
     it 'should display correct simple fields in haml' do
       visit '/haml/fields_for'
       assert_have_selector :form, :action => '/demo1', :id => 'demo-fields-for'


### PR DESCRIPTION
Now:

``` ruby
form_for(@user, '/register', builder: "AbstractFormBuilder") do |f|
  f #=> AbstractFormBuilder
  f.fields_for(:role_types, @user.role_types) do |field|
    field #=> StandardFormBuilder
    field.submit_block "Submit"
  end
end
```

I'd expected this:

``` ruby
form_for(@user, '/register', builder: "AbstractFormBuilder") do |f|
  f #=> AbstractFormBuilder
  f.fields_for(:role_types, @user.role_types) do |field|
    field #=> AbstractFormBuilder
    field.submit_block "Submit"
  end
end
```
