### PR TITLE
New test to show that params is NOT actually a HashWithIndifferentAccess

### DIFF
--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -1956,7 +1956,8 @@ describe "Routing" do
     mock_app do
       get('/foo/:bar') { "#{params["bar"]} #{params[:bar]}" }
       get(:foo, :map => '/prefix/:var') { "#{params["var"]} #{params[:var]}" }
-      get(:bar, :map => '/slice/:var') { params.slice("var", :var).values.join(" ") }
+      get(:bar, :map => '/string/:foo/slices/:bar') { params.slice('foo', 'bar').values.join(" ") }
+      get(:baz, :map => '/symbol/:foo/slices/:bar') { params.slice(:foo, :bar).values.join(" ") }
     end
 
     get('/foo/some_text')
@@ -1965,8 +1966,11 @@ describe "Routing" do
     get('/prefix/var')
     assert_equal "var var", body
 
-    get('/slice/slicey')
-    assert_equal "slicey slicey", body
+    get('/string/strings/slices/slicey')
+    assert_equal "strings slicey", body
+
+    get('/symbol/symbols/slices/slicey')
+    assert_equal "symbols slicey", body
   end
 
   it 'should return params as a HashWithIndifferentAccess object via POST' do


### PR DESCRIPTION
#1405 was not correctly fixed... params in a controller is not a HashWithIndifferentAccess, only env['router.params'] is.

From within a controller scope:
1.9.3-p484 :012 > self.env['router.params'].class
 => ActiveSupport::HashWithIndifferentAccess
1.9.3-p484 :013 > params.class
 => Hash
