### PR TITLE
Fix Padrino::Mailer::Mime.mime_type

### DIFF
--- a/padrino-mailer/lib/padrino-mailer/mime.rb
+++ b/padrino-mailer/lib/padrino-mailer/mime.rb
@@ -27,7 +27,7 @@ module Padrino
       #   Padrino::Mailer::Mime::MIME_TYPES.fetch('text/plain', :plain)
       #
       def self.mime_type(mime, fallback=:plain)
-        MIME_TYPES.fetch(mime.to_s.downcase, fallback)
+        MIME_TYPES.fetch(mime.to_s.split(';').first.to_s.downcase, fallback)
       end
 
       ##

--- a/padrino-mailer/test/test_message.rb
+++ b/padrino-mailer/test/test_message.rb
@@ -133,6 +133,8 @@ describe "Message" do
       assert_equal ['padrino@you.com'],   message.to
       assert_equal 'Hello there Padrino', message.subject
       assert_equal 'text html',           message.body.to_s.chomp
+      message.encoded
+      assert_equal :html,                 message.content_type
 
       message = Mail::Message.new do
         views        File.dirname(__FILE__) + '/fixtures/views/mailers'
@@ -147,6 +149,8 @@ describe "Message" do
       assert_equal ['padrino@you.com'],   message.to
       assert_equal 'Hello there Padrino', message.subject
       assert_equal 'plain text',          message.body.to_s.chomp
+      message.encoded
+      assert_equal :plain,                message.content_type
     end
   end
 end


### PR DESCRIPTION
If we called #encoded or #to_s of mail message object,
charset will be append to the 'content_type' of the mail-header.
In this state, Messge#content_type return incorrect value.

``` ruby
message = Sample::App._padrino_mailer::Message.new { content_type 'text/html'; body 'I wanna eat sushi.' }
message.header['content_type'].to_s # => "text/html"
message.content_type #=> :html

message.encoded # or #to_s

message.header['content_type'].to_s #=> "text/html; charset=UTF-8"
message.content_type #=> :plain
```

This PR will fix it.

``` ruby
message = Sample::App._padrino_mailer::Message.new { content_type 'text/html'; body 'I wanna eat sushi.' }
message.header['content_type'].to_s # => "text/html"
message.content_type #=> :html

message.encoded # or #to_s

message.header['content_type'].to_s #=> "text/html; charset=UTF-8"
message.content_type #=> :html
```
