### PR TITLE
Bad example in generated apps

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/app/app.rb.tt
+++ b/padrino-gen/lib/padrino-gen/generators/app/app.rb.tt
@@ -57,8 +57,8 @@ module <%= @project_name %>
     #     render 'errors/404'
     #   end
     #
-    #   error 505 do
-    #     render 'errors/505'
+    #   error 500 do
+    #     render 'errors/500'
     #   end
     #
   end


### PR DESCRIPTION
505 is HTTP Version Not Supported - We probably want to handle Internal server error instead?
