### PR TITLE
[padrino-gen] Add 'no-helper' option to controller generator

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/controller.rb
+++ b/padrino-gen/lib/padrino-gen/generators/controller.rb
@@ -16,15 +16,16 @@ module Padrino
 
       desc "Description:\n\n\tpadrino-gen controller generates a new Padrino controller"
 
-      argument     :name,      :desc => 'The name of your padrino controller'
-      argument     :fields,    :desc => 'The fields for the controller',                            :default => [],     :type => :array
-      class_option :root,      :desc => 'The root destination',                   :aliases => '-r', :default => '.',    :type => :string
-      class_option :app,       :desc => 'The application destination path',       :aliases => '-a', :default => '/app', :type => :string
-      class_option :destroy,                                                      :aliases => '-d', :default => false,  :type => :boolean
-      class_option :namespace, :desc => 'The name space of your padrino project', :aliases => '-n', :default => '',     :type => :string
-      class_option :layout,    :desc => 'The layout for the controller',          :aliases => '-l', :default => '',     :type => :string
-      class_option :parent,    :desc => 'The parent of the controller',           :aliases => '-p', :default => '',     :type => :string
-      class_option :provides,  :desc => 'the formats provided by the controller', :aliases => '-f', :default => '',     :type => :string
+      argument     :name,       :desc => 'The name of your padrino controller'
+      argument     :fields,     :desc => 'The fields for the controller',                            :default => [],     :type => :array
+      class_option :root,       :desc => 'The root destination',                   :aliases => '-r', :default => '.',    :type => :string
+      class_option :app,        :desc => 'The application destination path',       :aliases => '-a', :default => '/app', :type => :string
+      class_option :destroy,                                                       :aliases => '-d', :default => false,  :type => :boolean
+      class_option :namespace,  :desc => 'The name space of your padrino project', :aliases => '-n', :default => '',     :type => :string
+      class_option :layout,     :desc => 'The layout for the controller',          :aliases => '-l', :default => '',     :type => :string
+      class_option :parent,     :desc => 'The parent of the controller',           :aliases => '-p', :default => '',     :type => :string
+      class_option :provides,   :desc => 'The formats provided by the controller', :aliases => '-f', :default => '',     :type => :string
+      class_option :'no-helper',:desc => 'Not generate helper',                                      :default => false,  :type => :boolean
 
       # Show help if no ARGV given
       require_arguments!
@@ -52,12 +53,12 @@ module Padrino
 
           self.behavior = :revoke if options[:destroy]
           template 'templates/controller.rb.tt', destination_root(app, 'controllers', "#{name.to_s.underscore}.rb")
-          template 'templates/helper.rb.tt',     destination_root(app, 'helpers', "#{name.to_s.underscore}_helper.rb")
+          template 'templates/helper.rb.tt',     destination_root(app, 'helpers', "#{name.to_s.underscore}_helper.rb") unless options[:'no-helper']
           empty_directory destination_root(app, "/views/#{name.to_s.underscore}")
           include_component_module_for(:test)
           if test?
             generate_controller_test(name)
-            generate_helper_test(@helper_name, @project_name, @app_name)
+            generate_helper_test(@helper_name, @project_name, @app_name) unless options[:'no-helper']
           end
         else
           say 'You are not at the root of a Padrino application! (config/boot.rb not found)'

--- a/padrino-gen/test/test_controller_generator.rb
+++ b/padrino-gen/test/test_controller_generator.rb
@@ -185,6 +185,19 @@ describe "ControllerGenerator" do
       assert_match_in_file(/get :test do\n\n  end\n/m, @controller_path)
       assert_match_in_file(/post :yada do\n\n  end\n/m, @controller_path)
     end
+
+    describe "with 'no-helper' option" do
+      it 'should not generate helper within existing project' do
+        capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--script=none', '-t=rspec') }
+        capture_io { generate(:controller, 'DemoItems', "-r=#{@apptmp}/sample_project", '--no-helper') }
+        assert_file_exists("#{@apptmp}/sample_project/app/views/demo_items")
+        assert_file_exists("#{@apptmp}/sample_project/app/controllers/demo_items.rb")
+        assert_file_exists("#{@apptmp}/sample_project/spec/app/controllers/demo_items_controller_spec.rb")
+        assert_no_file_exists("#{@apptmp}/sample_project/app/helpers/demo_items_helper.rb")
+        assert_no_file_exists("#{@apptmp}/sample_project/spec/app/helpers/demo_items_helper_spec.rb")
+      end
+    end
+
   end
 
   describe "the controller destroy option" do


### PR DESCRIPTION
Use this options with controller generator, If we not want to generate a helper files.

```
$ padrino g controller User get:index --no-helper
```
