### PR TITLE
Avoid editing destination file if it does not exist

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -13,6 +13,14 @@ module Padrino
       def self.included(base)
         base.extend(ClassMethods)
       end
+      ##
+      # Avoids editing destination file if it does not exist.
+      #
+      def inject_into_file(destination, *args, &block)
+        destination_path = destination.start_with?("/") ? destination : destination_root(destination)
+        return unless File.exist?(destination_path)
+        super
+      end
 
       ##
       # Performs the necessary generator for a given component choice.

--- a/padrino-gen/test/test_plugin_generator.rb
+++ b/padrino-gen/test/test_plugin_generator.rb
@@ -39,12 +39,14 @@ describe "PluginGenerator" do
       expects_generated :migration, "AddEmailToUser email:string -r=#{@apptmp}/sample_project"
       expects_generated :fake, "foo bar -r=#{@apptmp}/sample_project"
       expects_generated :plugin, "carrierwave -r=#{@apptmp}/sample_project"
+      File.stubs(:exist?).returns(true)
       expects_dependencies 'nokogiri'
       expects_initializer :test, "# Example", :root => "#{@apptmp}/sample_project"
       expects_generated :app, "testapp -r=#{@apptmp}/sample_project"
       expects_generated :controller, "users get:index -r=#{@apptmp}/sample_project --app=testapp"
       example_template_path = File.join(File.dirname(__FILE__), 'fixtures', 'example_template.rb')
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", "-p=#{example_template_path}", '> /dev/null') }
+      File.unstub(:exist?)
     end
   end
 

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -93,6 +93,11 @@ describe "ProjectGenerator" do
       assert_no_match_in_file(/Padrino.mount\('SampleProject::App'/, "#{@apptmp}/sample_project/config/apps.rb")
     end
 
+    it 'should generate lean project correctly even if the component is specified' do
+      out, err = capture_io { generate(:project,'sample_project', '--lean', "--root=#{@apptmp}", "--orm=activerecord", "--stylesheet=compass") }
+      assert_match("", err)
+    end
+
     it 'should generate tiny skeleton' do
       capture_io { generate(:project,'sample_project', '--tiny', "--root=#{@apptmp}") }
       assert_file_exists("#{@apptmp}/sample_project")


### PR DESCRIPTION
If specify `:lean` option and component options which are need to edit `app.rb`, an error will occur.
The error can be reproduced by executing this command.
`padrino g project sample --lean --orm=activerecord`
/cc @ujifgc @padrino/core-members 
