### PR TITLE
fix ignore newline by after textarea's opening tag

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -397,7 +397,7 @@ module Padrino
       #   text_area_tag :username, :class => 'long', :value => "Demo?"
       #
       def text_area_tag(name, options={})
-        inner_html = options.delete(:value).to_s
+        inner_html = "\n#{options.delete(:value)}"
         options = { :name => name, :rows => "", :cols => "" }.update(options)
         content_tag(:textarea, inner_html, options)
       end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -498,6 +498,12 @@ describe "FormHelpers" do
       assert_has_tag(:textarea, :content => "a test", :name => 'about', :rows => "5", :cols => "6") { actual_html }
     end
 
+    it 'should insert newline to before of content' do
+      actual_html = text_area_tag(:about, :value => "\na test")
+      assert_has_tag(:textarea, :content => "\na test", :name => 'about') { actual_html }
+      assert_match(%r{<textarea[^>]*>\n\na test</textarea>}, actual_html)
+    end
+
     it 'should display text area in erb' do
       visit '/erb/form_tag'
       assert_have_selector 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'


### PR DESCRIPTION
The textarea tag is missing first newline. I want to save the input as content.

From the [HTML 4.01 specification appendices:](http://www.w3.org/TR/html401/appendix/notes.html#notes-line-breaks)

> SGML (see [ISO8879], section 7.6.1) specifies that a line break immediately following a start tag must be ignored, as must a line break immediately before an end tag. This applies to all HTML elements without exception.
> The following two HTML examples must be rendered identically:

So insert newline after the textarea opening tag.

for example

```
text_area_tag :test, value: "\n\nfoo\nbar"
```

output html is

```
<textarea name="test">\n\nfoo\nbar</textarea>
```

But what is sent to the server is the only "\nfoo\nbar".

I want to solve this problem.
