### PR TITLE
Avoid reloading the file if its path is not started with Padrino.root, fixes #1746

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -289,7 +289,10 @@ module Padrino
     # Return the apps that allow reloading.
     #
     def reloadable_apps
-      Padrino.mounted_apps.select{ |app| app.app_obj.respond_to?(:reload) && app.app_obj.reload? }
+      Padrino.mounted_apps.select do |app|
+        next unless app.app_file.start_with?(Padrino.root)
+        app.app_obj.respond_to?(:reload) && app.app_obj.reload?
+      end
     end
 
     ##

--- a/padrino-core/test/fixtures/reloadable_apps/external/app/app.rb
+++ b/padrino-core/test/fixtures/reloadable_apps/external/app/app.rb
@@ -1,0 +1,6 @@
+
+module ReloadableApp
+  class External < Padrino::Application
+    set :reload, true
+  end
+end

--- a/padrino-core/test/fixtures/reloadable_apps/external/app/controllers/base.rb
+++ b/padrino-core/test/fixtures/reloadable_apps/external/app/controllers/base.rb
@@ -1,0 +1,6 @@
+
+ReloadableApp::External.controller :base do
+  get :index do
+    "Hello External App"
+  end
+end

--- a/padrino-core/test/fixtures/reloadable_apps/main/app.rb
+++ b/padrino-core/test/fixtures/reloadable_apps/main/app.rb
@@ -1,0 +1,10 @@
+require File.expand_path(File.dirname(__FILE__) + '/../external/app/app')
+
+module ReloadableApp
+  class Main < Padrino::Application
+    set :reload, true
+    get :index do
+      "hey"
+    end
+  end
+end

--- a/padrino-core/test/test_reloader_external.rb
+++ b/padrino-core/test/test_reloader_external.rb
@@ -1,0 +1,21 @@
+require File.expand_path(File.dirname(__FILE__) + '/helper')
+require File.expand_path(File.dirname(__FILE__) + '/fixtures/reloadable_apps/main/app')
+
+describe "ExternalReloader" do
+  describe "for external app" do
+    before do
+      Padrino.clear!
+      Padrino.mount("ReloadableApp::External").to("/reloadable/external")
+      Padrino.mount("ReloadableApp::Main").to("/reloadable")
+      Padrino.load!
+    end
+
+    it "should avoid reloading the file if its path is not started with Padrino.root" do
+      @app = Padrino.application
+      Padrino.stub(:root, File.expand_path(File.dirname(__FILE__) + '/fixtures/reloadable_apps/main')) do
+        get "/reloadable/external/base"
+      end
+      assert_equal "Hello External App", body
+    end
+  end
+end


### PR DESCRIPTION
ref #1746 
This fixes that bug.
