### PR TITLE
add button content tag to button_to with block, fixes #1772

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -583,8 +583,19 @@ module Padrino
         name, url = *args
         options['data-remote'] = 'true' if options.delete(:remote)
         submit_options = options.delete(:submit_options) || {}
-        block ||= proc { submit_tag(name, submit_options) }
-        form_tag(url || name, options, &block)
+        form_tag(url || name, options) do
+          if block_given?
+            inner_html = capture_html(&block)
+            if inner_html.match /<button[^>]*>.*<\/button>/m
+              warn 'adding button content tag manually to button_to is deprecated #1772'
+              inner_html
+            else
+              content_tag('button', inner_html)
+            end
+          else
+            submit_tag(name, submit_options)
+          end
+        end
       end
 
       ##

--- a/padrino-helpers/test/fixtures/markup_app/views/button_to.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/button_to.erb
@@ -6,3 +6,9 @@
 <% end %>
 <%= content_tag(:p, 'button_to test', :id => 'test-point') %>
 <%= button_to 'Bar button', '/bar' %>
+
+<% button_to 'button button', '/bar' do %>
+  <% content_tag :button do %>
+    <img />my deprecated button
+  <% end %>
+<% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/button_to.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/button_to.haml
@@ -3,3 +3,8 @@
     = label_tag :username
 = content_tag(:p, 'button_to test', :id => 'test-point')
 = button_to 'Bar button', '/bar'
+
+= button_to 'button button', '/bar' do
+  = content_tag :button do
+    %img
+    my deprecated button

--- a/padrino-helpers/test/fixtures/markup_app/views/button_to.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/button_to.slim
@@ -4,3 +4,8 @@
     = label_tag :username
 = content_tag(:p, 'button_to test', :id => 'test-point')
 = button_to 'Bar button', '/bar'
+
+= button_to 'button button', '/bar' do
+  = content_tag :button do
+    img
+    | my deprecated button

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -991,6 +991,7 @@ describe "FormHelpers" do
         content_tag :button, "My button's content", :type => :submit, :title => "My button"
       end
       assert_has_tag('form button', :type => 'submit', :content => "My button's content", :title => "My button") { actual_html }
+      assert_has_no_tag('form button button') { actual_html }
     end
 
     it 'should pass options on submit button when submit_options are given' do
@@ -1005,6 +1006,7 @@ describe "FormHelpers" do
       assert_have_selector('form label', :for => 'username', :content => 'Username: ')
       assert_have_selector('form', :action => '/bar')
       assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      assert_have_no_selector('button button')
     end
 
     it 'should display correct button_to in haml' do
@@ -1013,6 +1015,7 @@ describe "FormHelpers" do
       assert_have_selector('form label', :for => 'username', :content => 'Username: ')
       assert_have_selector('form', :action => '/bar')
       assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      assert_have_no_selector('button button')
     end
 
     it 'should display correct button_to in slim' do
@@ -1021,6 +1024,7 @@ describe "FormHelpers" do
       assert_have_selector('form label', :for => 'username', :content => 'Username: ')
       assert_have_selector('form', :action => '/bar')
       assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      assert_have_no_selector('button button')
     end
   end
 


### PR DESCRIPTION
This PR fixes #1772 respecting application with the old behavior and adding a warning for it.
Removing the deprecation would shrink the code significantly.
