### PR TITLE
Fix documentation of link_to when passing block

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/asset_tag_helpers.rb
@@ -69,7 +69,7 @@ module Padrino
       #   link_to('click me', '/dashboard', :class => 'linky')
       #   link_to('click me', '/dashboard', :remote => true)
       #   link_to('click me', '/dashboard', :method => :delete)
-      #   link_to('click me', :class => 'blocky') do; end
+      #   link_to('/dashboard', :class => 'blocky') do; end
       #
       # Note that you can pass :+if+ or :+unless+ conditions, but if you provide :current as
       # condition padrino return true/false if the request.path_info match the given url.


### PR DESCRIPTION
[ci skip]

When a block is passed the `link_to` helper, the first parameter becomes the URL.
This commit fixes the `@example` in the documentation to match the code.
