### PR TITLE
Describe overloads of submit_tag

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -513,10 +513,11 @@ module Padrino
       ##
       # Constructs a submit button from the given options.
       #
-      # @param [String] caption (defaults to: +Submit+)
-      #   The caption for the submit button.
-      # @param [Hash] options
-      #   The html options for the input field.
+      # @overload submit_tag(options={})
+      #   @param [Hash]    options  The html options for the input field.
+      # @overload submit_tag(caption, options={})
+      #   @param [String]  caption  The caption for the submit button.
+      #   @param [Hash]    options  The html options for the input field.
       #
       # @return [String] The html submit button based on the +options+ specified.
       #


### PR DESCRIPTION
Since the method accepts `*args`, it is useful to describe which overloads are accepted:
- only `options`, or
- `caption` and `options`

[ci skip]
