### PR TITLE
Get rid of the default_filters method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   gem "erubis",    ">= 2.7.0"
   gem "slim",      ">= 1.3.0"
   gem "builder",   ">= 2.1.2"
+  gem "sass"
   platforms :jruby do
     gem "jruby-openssl"
   end

--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -65,7 +65,6 @@ module Padrino
         reset_router!
         Padrino.require_dependencies(settings.app_file, :force => true)
         require_dependencies
-        default_filters
         default_routes
         default_errors
         I18n.reload! if defined?(I18n)

--- a/padrino-core/lib/padrino-core/application/application_setup.rb
+++ b/padrino-core/lib/padrino-core/application/application_setup.rb
@@ -42,7 +42,6 @@ module Padrino
       def setup_application!
         return if @_configured
         require_dependencies
-        default_filters
         default_routes
         default_errors
         setup_locale
@@ -107,16 +106,6 @@ module Padrino
         setup_protection builder
         setup_csrf_protection builder
         setup_application!
-      end
-
-      ##
-      # This filter it's used for know the format of the request, and
-      # automatically set the content type.
-      #
-      def default_filters
-        before do
-          response['Content-Type'] = 'text/html;charset=utf-8' unless @_content_type
-        end
       end
 
       ##

--- a/padrino-core/test/test_reloader_simple.rb
+++ b/padrino-core/test/test_reloader_simple.rb
@@ -79,7 +79,7 @@ describe "SimpleReloader" do
       get "/rand"
       assert ok?
       last_body = body
-      assert_equal 2, @app.filters[:before].size # one is ours the other is default_filter for content type
+      assert_equal 1, @app.filters[:before].size
       assert_equal 1, @app.errors.size
       assert_equal 2, @app.filters[:after].size # app + content-type + padrino-flash
       assert_equal 0, @app.middleware.size
@@ -89,7 +89,7 @@ describe "SimpleReloader" do
       @app.reload!
       get "/rand"
       refute_equal last_body, body
-      assert_equal 2, @app.filters[:before].size # one is ours the other is default_filter for content type
+      assert_equal 1, @app.filters[:before].size
       assert_equal 1, @app.errors.size
       assert_equal 2, @app.filters[:after].size
       assert_equal 0, @app.middleware.size

--- a/padrino-helpers/test/test_rendering.rb
+++ b/padrino-helpers/test/test_rendering.rb
@@ -691,4 +691,14 @@ describe "Rendering" do
       end
     end
   end
+
+  describe 'sinatra template helpers' do
+    it "should respect default_content_type option defined by sinatra" do
+      mock_app do
+        get(:index){ sass ".hey\n  border: 0" }
+      end
+      get '/'
+      assert_equal "text/css;charset=utf-8", response['Content-Type']
+    end
+  end
 end


### PR DESCRIPTION
The `default_filters` method seems no need to us.
Also the filter has continued to break the compatibility with Sinatra.
Thoughts?
