### PR TITLE
Enumerable#reverse.each instead Enumerable#reverse.each. Faster code.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -308,7 +308,7 @@ WARNING
       #
       def require_dependencies(*gem_names)
         options = gem_names.extract_options!
-        gem_names.reverse.each { |lib| insert_into_gemfile(lib, options) }
+        gem_names.reverse_each { |lib| insert_into_gemfile(lib, options) }
       end
 
       ##


### PR DESCRIPTION
More info at https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
