### PR TITLE
Temporary patch for raising an exception

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -241,7 +241,8 @@ module Padrino
       #     end
       #   end
       #
-      def parent(name, options={})
+      def parent(name = nil, options={})
+        return super() unless name
         defaults = { :optional => false, :map => name.to_s }
         options = defaults.merge(options)
         @_parent = Array(@_parent) unless @_parent.is_a?(Array)


### PR DESCRIPTION
If the padrino project is including uninitialized constant, `NameError` should be raised.
But the error won't be raised because [the active_support's extension](http://api.rubyonrails.org/v2.3.8/classes/ActiveSupport/CoreExtensions/Module.html#M000806) and [Padrino::Routing#parent](https://github.com/padrino/padrino-framework/blob/master/padrino-core/lib/padrino-core/application/routing.rb#L244) are colliding.

This patch fixes the error by using temporary patch.
Also, I'd like to drop the active-support gem and implement similar extensions as parts of padrino-support. Thoughts?
