### PR TITLE
Mention where FormBuilders search for model property label ('caption') translations (i18n)

### DIFF
--- a/padrino-docs/guides/application-helpers.md
+++ b/padrino-docs/guides/application-helpers.md
@@ -463,6 +463,41 @@ The form builder can even be made into the default builder when form\_for is inv
 And there you have it, a fairly complete form builder solution for Padrino (and Sinatra).
  I hope to create or merge in an even better ‘default’ form\_builder in the near future.
 
+### Form Builders and I18n
+
+When no caption to an e.g. input field is given, the StandardFormBuilder will look for keys
+(for the current locale) and add a respective localized caption for you.
+
+A rake task will help you to create respective files for you, if you use Active Record as ORM.
+If you do not, its super easy to do by hand:
+
+Given a model like
+
+    # lib/models/nature.rb
+    class Nature
+      property :health # exact definition depends on the ORM you use
+      property :issues
+    end
+
+the path to translated labels to be used in your locale file (e.g. `app/locale/en.yml`) is:
+
+    # app/locale/en.yml
+    models:
+      nature:
+        attributes:
+          health: Overall Health
+          issues: Issues
+.
+This will allow you to call
+
+    # your_nature_view.haml
+    = form_for @nature, '/nature', :id => 'create' do |f|
+        = f.text_field_block :health
+
+instead of including `:caption => I18n.t('nature.health')`.
+
+For more information on i18n look at the [Localization Guide](http://www.padrinorb.com/guides/localization) .
+
 ### Nested Object Form Support
 
 Available in the 0.9.21 Padrino release is support for nested object form helpers. This allows forms to have arbitrarily complex nested forms that can build multiple related objects together. Let’s take a simple example of a person with an address. Here are the related psuedo models:

--- a/padrino-docs/guides/localization.md
+++ b/padrino-docs/guides/localization.md
@@ -119,7 +119,7 @@ Using *form\_builder* like:
 
 the tag **label** automatically translates for **you** the field name!!
 
-Therefore, it searches for translations/label strings at:
+Therefore, it searches for translations/label e.g. in `app/locale/en.yml` for strings at:
 
     models:
       account:

--- a/padrino-docs/guides/localization.md
+++ b/padrino-docs/guides/localization.md
@@ -93,9 +93,9 @@ run padrino rake task for localizing your model:
 
     padrino rake ar:translate
 
-a new it.yml file will be created into `/app/locale/models/account/it.yml` with the following:
+a new it.yml file will be created into `/app/locale/models/account/it.yml` .
 
-you can now edit your generated `it.yml` file to reflect your current locale (Italian):
+You can now edit your generated `it.yml` file to reflect your current locale (Italian) .
 
 padrino-admin will now use your newly created yml file for translating the column names of grids, forms, error\_messages etc…
 
@@ -118,3 +118,14 @@ Using *form\_builder* like:
           %td=f.select :role, :options => access_control.roles
 
 the tag **label** automatically translates for **you** the field name!!
+
+Therefore, it searches for translations/label strings at:
+
+    models:
+      account:
+        attributes:
+          name: Name
+          other_attribute: Label for other attribute ...
+
+.
+

--- a/padrino-docs/guides/rake-tasks.md
+++ b/padrino-docs/guides/rake-tasks.md
@@ -129,6 +129,12 @@ Basically, instead of writing migrations you can directly edit your **schema.rb*
     rake dm:reset                  # Drops the database, and migrates from scratch
     rake dm:setup                  # Create the database migrate and initialize with the seed data
 
+Example of [version] argument:
+
+    rake dm:migrate:down --version 3
+
+(looks for migration file in db/migrations/003***.rb)
+
 #### Sequel Tasks:
 
     rake sq:migrate:auto           # Perform automigration (reset your db data)
@@ -136,6 +142,12 @@ Basically, instead of writing migrations you can directly edit your **schema.rb*
     rake sq:migrate:up             # Perform migration up to latest migration available
     rake sq:migrate:down           # Perform migration down (erase all data)
     rake sq:reset                  # Drops the database, and migrates from scratch
+
+Example of [version] argument:
+
+    rake sq:migrate:to --version 3
+
+(looks for migration file in db/migrations/003***.rb)
 
 #### Mongomapper Tasks:
 


### PR DESCRIPTION
In Localization Guide and Application Helpers Post, mention path to models property label caption translations, which is a pretty handy feature.

Also add example of how to use version argument in migration rake tasks.