### PR TITLE
Don't load dependency files if app's root isn't started with Padrino.root

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -57,7 +57,7 @@ module Padrino
         @configured ||=
           begin
             $LOAD_PATH.concat(prerequisite)
-            Padrino.require_dependencies(dependencies, :force => true)
+            Padrino.require_dependencies(dependencies, :force => true) if root.start_with?(Padrino.root)
             true
           end
       end

--- a/padrino-core/test/fixtures/apps/external_apps/fake_lib.rb
+++ b/padrino-core/test/fixtures/apps/external_apps/fake_lib.rb
@@ -1,0 +1,1 @@
+FakeLib = 1

--- a/padrino-core/test/fixtures/apps/external_apps/fake_root.rb
+++ b/padrino-core/test/fixtures/apps/external_apps/fake_root.rb
@@ -1,0 +1,2 @@
+class FakeRoot < Sinatra::Base
+end

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -285,5 +285,18 @@ describe "Mounter" do
       assert_equal "api app", res.body
       assert defined?(DemoProject::APILib)
     end
+
+    it "should not load dependency files if app's root isn't started with Padrino.root" do
+      path = File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/demo_project/app')
+      fake_path = File.expand_path(File.dirname(__FILE__) + "/fixtures/apps/external_apps/fake_root")
+      require path
+      require fake_path
+      Padrino.mount("fake_root", :app_class => "FakeRoot").to('/fake_root')
+      Padrino.mount('main_app', :app_class => 'DemoProject::App').to('/')
+      Padrino.stub(:root, File.expand_path(File.dirname(__FILE__) + "/fixtures/apps/demo_project")) do
+        Padrino.application
+      end
+      assert !defined?(FakeLib)
+    end
   end
 end


### PR DESCRIPTION
ref #1819 
I'd like to support for external app.
