### PR TITLE
Make broken async stream callbacks work again in Padrino

### DIFF
--- a/padrino-core/lib/padrino-core/application/application_setup.rb
+++ b/padrino-core/lib/padrino-core/application/application_setup.rb
@@ -107,6 +107,7 @@ module Padrino
       # Also initializes the application after setting up the middleware.
       def setup_default_middleware(builder)
         setup_sessions builder
+        builder.use Sinatra::ExtendedRack # Fixes lost callbacks on async web streaming
         builder.use Padrino::ShowExceptions         if show_exceptions?
         builder.use Padrino::Logger::Rack, uri_root if Padrino.logger && logging?
         builder.use Padrino::Reloader::Rack         if reload?


### PR DESCRIPTION
This is a fix for #1704 

It patches the issue where streaming connections never get closed after the connection is lost.

The async streaming callback functions that Sinatra sets via the ExtendedRack class in setup_default_middleware method gets overridden by Padrino's middleware builder.

