### PR TITLE
Helpful links in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 Padrino is the godfather of Sinatra. Follow us on
 {www.padrinorb.com}[http://padrinorb.com] and on twitter
-{@padrinorb}[http://twitter.com/padrinorb]
+{@padrinorb}[http://twitter.com/padrinorb]. Join us on {gitter}[https://gitter.im/padrino/padrino-framework]
 
 {<img src="https://api.travis-ci.org/padrino/padrino-framework.svg" alt="Build Status" />}[http://travis-ci.org/padrino/padrino-framework]
 {<img src="https://gemnasium.com/padrino/padrino-framework.svg" alt="Dependency Status" />}[https://gemnasium.com/padrino/padrino-framework]


### PR DESCRIPTION
Further to the communication issue I thought it would be a good idea to direct people as quickly as possible to current channels for information. Particularly prevalent as the current padrinorb website points people to a whole host of resources but no mention of the gitter.
