### PR TITLE
Prevent `Padrino::Cache#registered` from overriding cache and caching

### DIFF
--- a/padrino-cache/lib/padrino-cache.rb
+++ b/padrino-cache/lib/padrino-cache.rb
@@ -97,9 +97,11 @@ module Padrino
         app.helpers Padrino::Cache::Helpers::CacheStore
         app.helpers Padrino::Cache::Helpers::Fragment
         app.helpers Padrino::Cache::Helpers::Page
-        app.set :cache, Padrino::Cache.new(:File,
-                                           :dir => Padrino.root('tmp', defined?(app.app_name) ? app.app_name.to_s : '', 'cache'))
-        app.disable :caching
+        unless app.respond_to?(:cache)
+          cache_dir = Padrino.root('tmp', defined?(app.app_name) ? app.app_name.to_s : '', 'cache')
+          app.set :cache, Padrino::Cache.new(:File, :dir => cache_dir)
+        end
+        app.disable :caching unless app.respond_to?(:caching)
         included(app)
       end
 

--- a/padrino-cache/test/test_padrino_cache.rb
+++ b/padrino-cache/test/test_padrino_cache.rb
@@ -457,4 +457,22 @@ describe "PadrinoCache" do
     assert_equal 4, called_times_a
     assert_equal 2, called_times_b
   end
+
+  it "preserve the app's `caching` setting if set before registering the module" do
+    mock_app do
+      enable :caching
+      register Padrino::Cache
+    end
+
+    assert @app.caching
+  end
+
+  it "preserve the app's `cache` setting if set before registering the module" do
+    mock_app do
+      set :cache, Padrino::Cache.new(:Memory)
+      register Padrino::Cache
+    end
+
+    assert @app.cache.adapter.adapter.is_a?(Moneta::Adapters::Memory)
+  end
 end


### PR DESCRIPTION
Prevent `Padrino::Cache#registered` from overriding both `cache` and `caching` settings if set before the call to `register Padrino::Cache`.

```
  # app.rb
  enable :caching
  register Padrino::Cache

  # app.caching #> false
```

That's because of the explicit [disable](https://github.com/padrino/padrino-framework/blob/master/padrino-cache/lib/padrino-cache.rb#L102) we set by default.

This issue will also arise when doing a global config in `config/apps.rb` and it's trickier to track over there.
