### PR TITLE
Fix execution sequence of configuration methods when Padrino::Application is inherited

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -43,10 +43,10 @@ module Padrino
       def inherited(base)
         begun_at = Time.now
         CALLERS_TO_IGNORE.concat(PADRINO_IGNORE_CALLERS)
+        super(base)
         base.prerequisites.replace(self.prerequisites.dup)
         base.default_configuration!
         logger.devel :setup, begun_at, base
-        super(base)
       end
 
       ##

--- a/padrino-core/lib/padrino-core/loader.rb
+++ b/padrino-core/lib/padrino-core/loader.rb
@@ -72,6 +72,7 @@ module Padrino
       @_dependency_paths = nil
       before_load.clear
       after_load.clear
+      global_configurations.clear
       Reloader.clear!
       Thread.current[:padrino_loaded] = nil
     end

--- a/padrino-core/test/test_application.rb
+++ b/padrino-core/test/test_application.rb
@@ -66,6 +66,13 @@ describe "Application" do
       assert_equal 'shared', body
     end
 
+    it 'should be able to execute the register keyword inside the configure_apps block' do
+      Asdf = Module.new
+      Padrino.configure_apps { register Asdf }
+      class GodFather < Padrino::Application; end
+      assert_includes GodFather.extensions, Asdf
+    end
+
     it 'should able to set custome session management' do
       class PadrinoTestApp3 < Padrino::Application
         set :sessions, :use => Rack::Session::Pool


### PR DESCRIPTION
Currently, we couldn't use the `register` keyword inside the
`configure_apps` block, so this fixes it.

``` ruby
  NewPlugin = Module.new
  Padrino.configure_apps { register NewPlugin }
  class App < Padrino::Application; end
```
