### PR TITLE
Widen the range of default_dependency_paths

### DIFF
--- a/padrino-core/lib/padrino-core/loader.rb
+++ b/padrino-core/lib/padrino-core/loader.rb
@@ -181,8 +181,7 @@ module Padrino
         "#{root}/config/database.rb",
         "#{root}/lib/**/*.rb",
         "#{root}/models/**/*.rb",
-        "#{root}/shared/lib/**/*.rb",
-        "#{root}/shared/models/**/*.rb",
+        "#{root}/shared/**/*.rb",
         "#{root}/config/apps.rb",
       ]
     end


### PR DESCRIPTION
Reloader treats shared/**/*.rb  as monitored, but the loader hasn't loaded it
see https://github.com/padrino/padrino-framework/blob/1b5b0716d75d6e6ca9c1d523caa7016713ea7fcc/padrino-core/lib/padrino-core/reloader.rb#L224

/cc @ujifgc @padrino/core-members 