### PR TITLE
ApplicationWrapper Prerequisite Issue

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -27,8 +27,8 @@ module Padrino
         @__dependencies ||= Dir["#{root}/**/*.rb"]
       end
 
-      def prerequisite
-        @__prerequisite ||= []
+      def prerequisites
+        @__prerequisites ||= []
       end
 
       def app_file
@@ -56,7 +56,7 @@ module Padrino
       def setup_application!
         @configured ||=
           begin
-            $LOAD_PATH.concat(prerequisite)
+            $LOAD_PATH.concat(prerequisites)
             Padrino.require_dependencies(dependencies, :force => true) if root.start_with?(Padrino.root)
             true
           end


### PR DESCRIPTION
The Reloader and other classes assume that any mounted Padrino app has "prerequisites" (plural!) set, and uses that to figure out what files need to be reloaded. And, in the documentation, it says to `MyApp.prerequisites << "somefile.rb"` if you want to configure your application to reload/require new things. 

This doesn't seem to break an actual Padrino app, as all the internal Padrino code (besides this) uses the plural. However, when I mount (and therefore wrap) my Grape::API application, reloading breaks, because there is no list of pluralized prerequisites to work with. Boo!
