### PR TITLE
Refactored the Mounter::ApplicationWrapper

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -67,11 +67,7 @@ module Padrino
         @configured ||=
           begin
             $LOAD_PATH.concat(prerequisites)
-<<<<<<< HEAD
             require_dependencies if root.start_with?(Padrino.root)
-=======
-            Padrino.require_dependencies(dependencies, :force => true) if root.start_with?(Padrino.root)
->>>>>>> c4e789cd75617f037d3fc7369140f801f8bda4b3
             true
           end
       end

--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -20,6 +20,10 @@ module Padrino
 
       def initialize(app, options = {})
         @options = options
+        app.instance_variable_set(:@padrino_wrapper, self)
+        if app.respond_to?(:setup_padrino_application)
+          app.setup_padrino_application(@options)
+        end
         super(app)
       end
 
@@ -27,8 +31,8 @@ module Padrino
         @__dependencies ||= Dir["#{root}/**/*.rb"]
       end
 
-      def prerequisite
-        @__prerequisite ||= []
+      def prerequisites
+        dependencies
       end
 
       def app_file
@@ -39,25 +43,31 @@ module Padrino
 
       def root
         return @__root if @__root
-        obj = __getobj__
         @__root = obj.respond_to?(:root) ? obj.root : File.expand_path("#{app_file}/../")
+      end
+
+      def obj
+        __getobj__
       end
 
       def public_folder
         return @public_folder if @public_folder
-        obj = __getobj__
         @public_folder = obj.respond_to?(:public_folder) ? obj.public_folder : ""
       end
 
       def app_name
-        @__app_name ||= @options[:app_name] || __getobj__.to_s.underscore.to_sym
+        @__app_name ||= @options[:app_name] || obj.to_s.underscore.to_sym
+      end
+
+      def require_dependencies
+        Padrino.require_dependencies(dependencies, :force => true)
       end
 
       def setup_application!
         @configured ||=
           begin
-            $LOAD_PATH.concat(prerequisite)
-            Padrino.require_dependencies(dependencies, :force => true) if root.start_with?(Padrino.root)
+            $LOAD_PATH.concat(prerequisites)
+            require_dependencies if root.start_with?(Padrino.root)
             true
           end
       end
@@ -174,7 +184,7 @@ module Padrino
     def named_routes
       app_obj.routes.map { |route|
         route_name = route.name.to_s
-        route_name = 
+        route_name =
           if route.controller
             route_name.split(" ", 2).map{|name| ":#{name}" }.join(", ")
           else


### PR DESCRIPTION
I didn't go as far as I could, but I basically had the ApplicationWrapper (and therefore Padrino) register itself with the application that is being mounted by setting a ```@padrino_wrapper``` class variable on the application. This means that you can customize your app to work better within a Padrino environment.