### PR TITLE
Fix seeds admin generator

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/seeds.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/seeds.rb.tt
@@ -21,7 +21,7 @@ if account.valid?
   shell.say "   password: #{password}"
   shell.say "================================================================="
 else
-  shell.say "Sorry but some thing went wrong!"
+  shell.say "Sorry, but something went wrong!"
   shell.say ""
   account.errors.full_messages.each { |m| shell.say "   - #{m}" }
 end

--- a/padrino-admin/lib/padrino-admin/generators/templates/account/seeds.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/seeds.rb.tt
@@ -10,9 +10,10 @@ password  = shell.ask "Tell me the password to use:"
 
 shell.say ""
 
-account = <%= @model_name %>.create(:email => email, :name => "Foo", :surname => "Bar", :password => password, :password_confirmation => password, :role => "admin")
+account = <%= @model_name %>.new(:email => email, :name => "Foo", :surname => "Bar", :password => password, :password_confirmation => password, :role => "admin")
 
 if account.valid?
+  account.save
   shell.say "================================================================="
   shell.say "<%= @model_name %> has been successfully created, now you can login with:"
   shell.say "================================================================="

--- a/padrino-admin/test/generators/test_admin_app_generator.rb
+++ b/padrino-admin/test/generators/test_admin_app_generator.rb
@@ -212,7 +212,7 @@ describe "AdminAppGenerator" do
       refute_match /Overwrite\s.*?\/db\/seeds.rb/, out
 
       assert_file_exists "#{@apptmp}/sample_project/db/seeds.old"
-      assert_match_in_file 'Account.create(', "#{@apptmp}/sample_project/db/seeds.rb"
+      assert_match_in_file 'Account.new(', "#{@apptmp}/sample_project/db/seeds.rb"
     end
   end
 end


### PR DESCRIPTION
Using `Account.create` will fail if any of the provided information fail the validation and cause the seeds.rb to file on line 15 with `NoMethodError: undefined method 'valid?' for nil:NilClass` instead of actually displaying the error.