### PR TITLE
Re-implement recognize, closes #1862

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -505,7 +505,7 @@ module Padrino
         invoke_hook(:route_added, verb, path, block)
 
         path[0, 0] = "/" if path == "(.:format)?"
-        route = router.add(verb.downcase.to_sym, path, route_options)
+        route = router.add(verb, path, route_options)
         route.name = name if name
         route.action = action
         priority_name = options.delete(:priority) || :normal
@@ -935,7 +935,7 @@ module Padrino
         end
 
         if routes.present?
-          verb = request.request_method.downcase.to_sym
+          verb = request.request_method
           candidacies, allows = routes.partition{|route| route.verb == verb }
           if candidacies.empty?
             response["Allows"] = allows.map(&:verb).join(", ")

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -927,9 +927,11 @@ module Padrino
 
         routes = base.compiled_router.call(@request) do |route, params|
           next if route.user_agent && !(route.user_agent =~ @request.user_agent)
+          original_params, parent_layout = @params.dup, @layout
           returned_pass_block = invoke_route(route, params, first_time)
           pass_block = returned_pass_block if returned_pass_block
           first_time = false if first_time
+          @params, @layout = original_params, parent_layout
         end
 
         if routes.present?
@@ -951,8 +953,6 @@ module Padrino
       end
 
       def invoke_route(route, params, first_time)
-        original_params, parent_layout = @params.dup, @layout
-
         @_response_buffer = nil
         @route = request.route_obj = route
         captured_params = captures_from_params(params)
@@ -972,7 +972,6 @@ module Padrino
               halt(route_response)
           ensure
             (route.after_filters - settings.filters[:after]).each {|block| instance_eval(&block) }
-            @params, @layout = original_params, parent_layout
           end
         end
       end

--- a/padrino-core/lib/padrino-core/path_router.rb
+++ b/padrino-core/lib/padrino-core/path_router.rb
@@ -40,7 +40,15 @@ module Padrino
       #
       def call(request, &block)
         prepare! unless prepared?
-        @engine.find_by_request(request, &block)
+        @engine.call_by_request(request, &block)
+      end
+
+      ##
+      # Returns all routes which are matched with the condition without block
+      #
+      def recognize(request_or_env)
+        prepare! unless prepared?
+        @engine.find_by(request_or_env)
       end
 
       ##

--- a/padrino-core/lib/padrino-core/path_router/compiler.rb
+++ b/padrino-core/lib/padrino-core/path_router/compiler.rb
@@ -41,7 +41,7 @@ module Padrino
       def find_by(request_or_env)
         request = request_or_env.is_a?(Hash) ? Sinatra::Request.new(request_or_env) : request_or_env
         pattern = encode_default_external(request.path_info)
-        verb    = request.request_method.downcase.to_sym
+        verb    = request.request_method
         rotation { |offset| match?(offset, pattern) }.select { |route| route.verb == verb }
       end
 
@@ -53,7 +53,7 @@ module Padrino
           pattern  = encode_default_external(request.path_info)
           if route = match?(offset, pattern)
             params = route.params_for(pattern, request.params)
-            yield(route, params) if route.verb == request.request_method.downcase.to_sym
+            yield(route, params) if route.verb == request.request_method
             route
           end
         end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2244,4 +2244,23 @@ describe "Routing" do
     get "/foo/123/bar/456"
     assert_equal "123, 456", body
   end
+
+  it "should be able to use PathRouter#recognize to recognize routes" do
+    mock_app do
+      get(:sample){}
+    end
+    env = Rack::MockRequest.env_for("/sample")
+    request = Rack::Request.new(env)
+    assert_equal :sample, @app.router.recognize(request).first.name
+  end
+
+  it "should be able to use PathRouter#recognize to recognize routes by using Rack::MockRequest" do
+    mock_app do
+      get(:mock_sample){}
+    end
+    env = Rack::MockRequest.env_for("/mock_sample")
+    assert_equal :mock_sample, @app.router.recognize(env).first.name
+    env = Rack::MockRequest.env_for("/invalid")
+    assert_equal [], @app.router.recognize(env)
+  end
 end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2263,4 +2263,12 @@ describe "Routing" do
     env = Rack::MockRequest.env_for("/invalid")
     assert_equal [], @app.router.recognize(env)
   end
+
+  it "should be able to use params after sending request" do
+    last_app = mock_app do
+      get("/foo/:id"){ params.inspect }
+    end
+    get "/foo/123"
+    assert_equal({"id"=>"123"}, Thread.current['padrino.instance'].instance_variable_get(:@params))
+  end
 end


### PR DESCRIPTION
ref #1862
Implemented PathRouter#recognize to recognize routes by using request or env without block.
I think this can resolve the problem.
@fj @dariocravero What do you think?

And, I found a little bit problem about compatibility with old routing, so I also fixed it.
