### PR TITLE
Get rid of the :format parameter from the captured params if the block arity isn't same with captured params size

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -496,7 +496,8 @@ module Padrino
         method_name = "#{verb} #{path}"
         unbound_method = generate_method(method_name, &block)
 
-        block = if block.arity == 0
+        block_arity = block.arity
+        block = if block_arity == 0
                   proc{ |request, _| unbound_method.bind(request).call }
                 else
                   proc{ |request, block_params| unbound_method.bind(request).call(*block_params) }
@@ -506,6 +507,7 @@ module Padrino
 
         path[0, 0] = "/" if path == "(.:format)?"
         route = router.add(verb, path, route_options)
+        route.original_block_arity = block_arity
         route.name = name if name
         route.action = action
         priority_name = options.delete(:priority) || :normal
@@ -983,7 +985,7 @@ module Padrino
           params[:splat]
         else
           names = route.matcher.names.dup
-          names.delete("format") unless names.length == route.block.arity
+          names.delete("format") unless names.length == route.original_block_arity
           params.values_at(*names)
         end
       end

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -982,7 +982,9 @@ module Padrino
         elsif params[:splat].instance_of?(Array)
           params[:splat]
         else
-          params.values_at(*route.matcher.names.dup)
+          names = route.matcher.names.dup
+          names.delete("format") unless names.length == route.block.arity
+          params.values_at(*names)
         end
       end
     end

--- a/padrino-core/lib/padrino-core/path_router/route.rb
+++ b/padrino-core/lib/padrino-core/path_router/route.rb
@@ -19,7 +19,7 @@ module Padrino
       ##
       # The accessors will be used in other classes
       #
-      attr_accessor :action, :cache, :cache_key, :cache_expires,
+      attr_accessor :action, :cache, :cache_key, :cache_expires, :original_block_arity,
                     :parent, :use_layout, :controller, :user_agent, :path_for_generation, :default_values
   
   

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2281,4 +2281,16 @@ describe "Routing" do
     get "/sample/foo/bar"
     assert_equal "foo, bar", body
   end
+
+  it "should add the :format parameter to :captures hash if block arity is same with captured params size" do
+    mock_app do
+      get "/sample/:a/:b", :provides => :xml do |a, b, format|
+        "#{a}, #{b}, #{format}"
+      end
+    end
+    get "/sample/foo/bar"
+    assert_equal "foo, bar, ", body
+    get "/sample/foo/bar.xml"
+    assert_equal "foo, bar, xml", body
+  end
 end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2271,4 +2271,14 @@ describe "Routing" do
     get "/foo/123"
     assert_equal({"id"=>"123"}, Thread.current['padrino.instance'].instance_variable_get(:@params))
   end
+
+  it "should not add the :format parameter to :captures hash unless block arity is same with captured params size" do
+    mock_app do
+      get "/sample/:a/:b", :provides => :xml do |a, b|
+        "#{a}, #{b}"
+      end
+    end
+    get "/sample/foo/bar"
+    assert_equal "foo, bar", body
+  end
 end


### PR DESCRIPTION
ref #1868
This patch add more support for the captured params.

```ruby
get "/foo/:id/", provides: :html do |id|
  id
end

# before
get "/foo/123/" #=> ArgumentError
# after
get "/foo/123/" #=> "123"
```
```ruby
get "/foo/:id/", provides: :html do |id, format|
  "#{id}, #{format}"
end

# before
get "/foo/123/" #=> "123, html"
# after
get "/foo/123/" #=> "123, html"
```