### PR TITLE
Raise an exception if the block arity is nonzero and isn't same with capture parameter length

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -996,7 +996,7 @@ module Padrino
         elsif params[:splat].instance_of?(Array)
           params[:splat]
         else
-          params.values_at(*route.matcher.names.dup)
+          params.values_at(*route.matcher.names)
         end
       end
     end

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -23,7 +23,11 @@ module Padrino
 
     # Raised when block arity was nonzero and was not same with
     # captured parameter length.
-    class WrongArityException < RuntimeError; end
+    class BlockArityError < ArgumentError
+      def initialize(path, block_arity, required_arity)
+        super "route block arity does not match path '#{path}' (#{block_arity} for #{required_arity})"
+      end
+    end
 
     class Parent < String
       attr_reader :map
@@ -543,9 +547,8 @@ module Padrino
         invoke_hook(:padrino_route_added, route, verb, path, args, options, block)
 
         block_parameter_length = route.block_parameter_length
-        if block_arity.nonzero? && block_parameter_length != block_arity
-          raise WrongArityException,
-            "wrong number of block arguments (#{block_arity} for #{block_parameter_length})"
+        if block_arity > 0 && block_parameter_length != block_arity
+          fail BlockArityError.new(route.path, block_arity, block_parameter_length)
         end
 
         # Add Application defaults.

--- a/padrino-core/lib/padrino-core/path_router/matcher.rb
+++ b/padrino-core/lib/padrino-core/path_router/matcher.rb
@@ -3,6 +3,9 @@ require 'mustermann/sinatra'
 module Padrino
   module PathRouter
     class Matcher
+      # To count group of regexp
+      GROUP_REGEXP = %r{\((?!\?:|\?!|\?<=|\?<!|\?=).+?\)}.freeze
+
       ##
       # Constructs an instance of PathRouter::Matcher.
       #
@@ -91,6 +94,17 @@ module Padrino
       #
       def names
         handler.names
+      end
+
+      ##
+      # Returns captures parameter length.
+      #
+      def capture_length
+        if mustermann?
+          handler.named_captures.inject(0) { |count, (_, capture)| count += capture.length }
+        else
+          handler.inspect.scan(GROUP_REGEXP).length
+        end
       end
 
       private

--- a/padrino-core/lib/padrino-core/path_router/route.rb
+++ b/padrino-core/lib/padrino-core/path_router/route.rb
@@ -19,7 +19,7 @@ module Padrino
       ##
       # The accessors will be used in other classes
       #
-      attr_accessor :action, :cache, :cache_key, :cache_expires, :original_block_arity,
+      attr_accessor :action, :cache, :cache_key, :cache_expires,
                     :parent, :use_layout, :controller, :user_agent, :path_for_generation, :default_values
   
   
@@ -132,12 +132,19 @@ module Padrino
       end
   
       ##
-      # Returns custom_conditions as an array
+      # Returns custom_conditions as an array.
       #
       def custom_conditions(&block)
         @_custom_conditions ||= []
         @_custom_conditions << block if block_given?
         @_custom_conditions
+      end
+
+      ##
+      # Returns block parameter length.
+      #
+      def block_parameter_length
+        matcher.capture_length
       end
 
       private

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2272,17 +2272,15 @@ describe "Routing" do
     assert_equal({"id"=>"123"}, Thread.current['padrino.instance'].instance_variable_get(:@params))
   end
 
-  it "should not add the :format parameter to :captures hash unless block arity is same with captured params size" do
-    mock_app do
-      get "/sample/:a/:b", :provides => :xml do |a, b|
-        "#{a}, #{b}"
+  it "should raise an exception if block arity is not same with captured params size" do
+    assert_raises(Padrino::Routing::WrongArityException) do
+      mock_app do
+        get("/sample/:a/:b") { |a| }
       end
     end
-    get "/sample/foo/bar"
-    assert_equal "foo, bar", body
   end
 
-  it "should add the :format parameter to :captures hash if block arity is same with captured params size" do
+  it "should pass format value as a block parameter" do
     mock_app do
       get "/sample/:a/:b", :provides => :xml do |a, b, format|
         "#{a}, #{b}, #{format}"

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2273,7 +2273,7 @@ describe "Routing" do
   end
 
   it "should raise an exception if block arity is not same with captured params size" do
-    assert_raises(Padrino::Routing::WrongArityException) do
+    assert_raises(Padrino::Routing::BlockArityError) do
       mock_app do
         get("/sample/:a/:b") { |a| }
       end
@@ -2290,5 +2290,11 @@ describe "Routing" do
     assert_equal "foo, bar, ", body
     get "/sample/foo/bar.xml"
     assert_equal "foo, bar, xml", body
+  end
+
+  it "should raise an exception if block arity is not same with captured params size" do
+    mock_app do
+      get("/:a/sample/*/*") { |*all| }
+    end
   end
 end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2292,7 +2292,7 @@ describe "Routing" do
     assert_equal "foo, bar, xml", body
   end
 
-  it "should raise an exception if block arity is not same with captured params size" do
+  it "should allow negative arity in route block" do
     mock_app do
       get("/:a/sample/*/*") { |*all| }
     end


### PR DESCRIPTION
ref #1868
As @ujifgc said, I stopped adjusting captures at runtime.
Instead, an exception will be raised if the arity is wrong.

Please push commits into this branch if you have more friendly error message.