### PR TITLE
Use compass-blueprint gem for Compass generator

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
@@ -31,7 +31,7 @@ COMPASS_REGISTER = <<-COMPASSR unless defined?(COMPASS_REGISTER)
 COMPASSR
 
 def setup_stylesheet
-  require_dependencies 'compass'
+  require_dependencies 'compass-blueprint'
   create_file destination_root('/lib/compass_plugin.rb'), COMPASS_INIT
   inject_into_file destination_root('/app/app.rb'), COMPASS_REGISTER, :after => "register Padrino::Helpers\n"
 

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -663,7 +663,7 @@ describe "ProjectGenerator" do
 
     it 'should properly generate for compass' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=haml','--script=none','--stylesheet=compass') }
-      assert_match_in_file(/gem 'compass'/, "#{@apptmp}/sample_project/Gemfile")
+      assert_match_in_file(/gem 'compass-blueprint'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/Compass.configure_sass_plugin\!/, "#{@apptmp}/sample_project/lib/compass_plugin.rb")
       assert_match_in_file(/module CompassInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/lib/compass_plugin.rb")
       assert_match_in_file(/register CompassInitializer/m, "#{@apptmp}/sample_project/app/app.rb")


### PR DESCRIPTION
The application.scss generated by `padrino g project NAME -c compass`
uses the Blueprint framework, but it has been removed from Compass.
It has moved to compass-blueprint gem.

We should use compass-blueprint gem, or don't use Blueprint framework
in the application.scss.

See:

  * https://github.com/padrino/padrino-framework/blob/master/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass/application.scss#L2
  * https://github.com/Compass/compass/blob/stable/compass-style.org/content/CHANGELOG.markdown#013alpha8-10212013
  * https://github.com/Compass/compass-blueprint