### PR TITLE
Add missing helpers for the input element

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -137,6 +137,10 @@ module Padrino
           @template.week_field_tag field_name(field), default_options(field, options)
         end
 
+        def time_field(field, options={})
+          @template.time_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -133,6 +133,10 @@ module Padrino
           @template.month_field_tag field_name(field), default_options(field, options)
         end
 
+        def week_field(field, options={})
+          @template.week_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -125,6 +125,10 @@ module Padrino
           @template.datetime_local_field_tag field_name(field), default_options(field, options)
         end
 
+        def date_field(field, options={})
+          @template.date_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -117,6 +117,10 @@ module Padrino
           @template.image_submit_tag source, options
         end
 
+        def datetime_field(field, options={})
+          @template.datetime_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -121,6 +121,10 @@ module Padrino
           @template.datetime_field_tag field_name(field), default_options(field, options)
         end
 
+        def datetime_local_field(field, options={})
+          @template.datetime_local_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -141,6 +141,10 @@ module Padrino
           @template.time_field_tag field_name(field), default_options(field, options)
         end
 
+        def color_field(field, options={})
+          @template.color_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -129,6 +129,10 @@ module Padrino
           @template.date_field_tag field_name(field), default_options(field, options)
         end
 
+        def month_field(field, options={})
+          @template.month_field_tag field_name(field), default_options(field, options)
+        end
+
         ##
         # Supports nested fields for a child model within a form.
         # f.fields_for :addresses

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -674,6 +674,32 @@ module Padrino
         input_tag(:"datetime-local", options)
       end
 
+      ##
+      # Constructs a date tag from the given options.
+      #
+      # @example
+      #   date_field_tag('date_with_min_max', :min => DateTime.new(1993, 2, 24),
+      #                                       :max => DateTime.new(2000, 4, 1))
+      #   date_field_tag('date_with_value', :value => DateTime.new(2000, 4, 1))
+      #
+      # @param [String] name
+      #   The name of the date field.
+      # @param [Hash] options
+      #   The html options for the date field.
+      # @option options [DateTime, String] :min
+      #  The min date time of the date field.
+      # @option options [DateTime, String] :max
+      #  The max date time of the date field.
+      # @option options [DateTime, String] :value
+      #  The value of the date field. See examples for details.
+      # @return [String] The html date field
+      #
+      def date_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options = convert_attributes_into_datetime("%Y-%m-%d", options)
+        input_tag(:date, options)
+      end
+
       private
 
       ##

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -700,6 +700,32 @@ module Padrino
         input_tag(:date, options)
       end
 
+      ##
+      # Constructs a month tag from the given options.
+      #
+      # @example
+      #   month_field_tag('month_with_min_max', :min => DateTime.new(1993, 2, 24),
+      #                                         :max => DateTime.new(2000, 4, 1))
+      #   month_field_tag('month_with_value', :value => DateTime.new(2000, 4, 1))
+      #
+      # @param [String] name
+      #   The name of the month field.
+      # @param [Hash] options
+      #   The html options for the month field.
+      # @option options [DateTime, String] :min
+      #  The min month time of the month field.
+      # @option options [DateTime, String] :max
+      #  The max month time of the month field.
+      # @option options [DateTime, String] :value
+      #  The value of the month field. See examples for details.
+      # @return [String] The html month field
+      #
+      def month_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options = convert_attributes_into_datetime("%Y-%m", options)
+        input_tag(:month, options)
+      end
+
       private
 
       ##

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -752,6 +752,32 @@ module Padrino
         input_tag(:week, options)
       end
 
+      ##
+      # Constructs a time tag from the given options.
+      #
+      # @example
+      #   time_field_tag('time_with_min_max', :max => Time.new(1993, 2, 24, 1, 19, 12),
+      #                                       :min => Time.new(2008, 6, 21, 13, 30, 0))
+      #   time_field_tag('time_with_value', :value => Time.new(2008, 6, 21, 13, 30, 0))
+      #
+      # @param [String] name
+      #   The name of the time field.
+      # @param [Hash] options
+      #   The html options for the time field.
+      # @option options [Time, DateTime, String] :min
+      #  The min time of the time field.
+      # @option options [Time, DateTime, String] :max
+      #  The max time of the time field.
+      # @option options [Time, DateTime, String] :value
+      #  The value of the time field. See examples for details.
+      # @return [String] The html time field
+      #
+      def time_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options = convert_attributes_into_datetime("%T.%L", options)
+        input_tag(:time, options)
+      end
+
       private
 
       ##

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -644,7 +644,7 @@ module Padrino
       #
       def datetime_field_tag(name, options = {})
         options = { :name => name }.update(options)
-        options = convert_attributes_into_datetime_rfc3339(options)
+        options = convert_attributes_into_datetime("%Y-%m-%dT%T.%L%z", options)
         input_tag(:datetime, options)
       end
 
@@ -670,7 +670,7 @@ module Padrino
       #
       def datetime_local_field_tag(name, options = {})
         options = { :name => name }.update(options)
-        options = convert_attributes_into_datetime_rfc3339(options)
+        options = convert_attributes_into_datetime("%Y-%m-%dT%T", options)
         input_tag(:"datetime-local", options)
       end
 
@@ -706,10 +706,10 @@ module Padrino
       ##
       # Converts special attributes into datetime format strings that conforms to RFC 3399.
       #
-      def convert_attributes_into_datetime_rfc3339(options)
+      def convert_attributes_into_datetime(format, options)
         DATETIME_ATTRIBUTES.each_with_object(options) do |attribute|
           value = datetime_value(options[attribute])
-          options[attribute] = value.rfc3339 if value.respond_to?(:rfc3339)
+          options[attribute] = value.strftime(format) if value.respond_to?(:strftime)
         end
       end
     end

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -621,6 +621,7 @@ module Padrino
       end
 
       DATETIME_ATTRIBUTES = [:value, :max, :min].freeze
+      COLOR_CODE_REGEXP   = /\A#([0-9a-fA-F]{3}){1,2}\z/.freeze
 
       ##
       # Constructs a datetime tag from the given options.
@@ -778,6 +779,26 @@ module Padrino
         input_tag(:time, options)
       end
 
+      ##
+      # Constructs a color tag from the given options.
+      #
+      # @example
+      #   color_field_tag('color', :value => "#ff0000")
+      #   color_field_tag('color', :value => "#f00")
+      #
+      # @param [String] name
+      #   The name of the color field.
+      # @param [Hash] options
+      #   The html options for the color field.
+      # @option options [String] :value
+      #  The value of the color field. See examples for details.
+      #
+      def color_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options[:value] = adjust_color(options[:value])
+        input_tag(:color, options)
+      end
+
       private
 
       ##
@@ -814,6 +835,22 @@ module Padrino
         DATETIME_ATTRIBUTES.each_with_object(options) do |attribute|
           value = datetime_value(options[attribute])
           options[attribute] = value.strftime(format) if value.respond_to?(:strftime)
+        end
+      end
+
+      ##
+      # Adjusts color code for the given color.
+      #
+      # @example
+      #   adust_color("#000")    #=> "#000000"
+      #   adust_color("#ff0000") #=> "#ff0000"
+      #   adust_color("#foobar") #=> "#000000"
+      #
+      def adjust_color(color)
+        return "#000000" unless color =~ COLOR_CODE_REGEXP
+        return color if (color_size = color.size) == 7
+        color.slice(1, color_size - 1).each_char.with_object("#") do |chr, obj|
+          obj << chr * 2
         end
       end
     end

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -620,6 +620,35 @@ module Padrino
         input_tag(:range, options)
       end
 
+      ##
+      # Constructs a datetime tag from the given options.
+      #
+      # @example
+      #   datetime_field_tag('datetime_with_min_max', :min => DateTime.new(1993, 2, 24, 12, 30, 45),
+      #                                               :max => DateTime.new(2000, 4, 1, 12, 0, 0))
+      #   datetime_field_tag('datetime_with_value', :value => DateTime.new(2000, 4, 1, 12, 0, 0))
+      #
+      # @param [String] name
+      #   The name of the datetime field.
+      # @param [Hash] options
+      #   The html options for the datetime field.
+      # @option options [DateTime, String] :min
+      #  The min date time of the datetime field.
+      # @option options [DateTime, String] :max
+      #  The max date time of the datetime field.
+      # @option options [DateTime, String] :value
+      #  The value of the datetime field. See examples for details.
+      # @return [String] The html datetime field
+      #
+      def datetime_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        [:max, :min, :value].each do |attribute|
+          value = datetime_value(options[attribute])
+          options[attribute] = value.rfc3339 if value.respond_to?(:rfc3339)
+        end
+        input_tag(:datetime, options)
+      end
+
       private
 
       ##
@@ -633,6 +662,20 @@ module Padrino
         builder_class = options.delete(:builder) || default_builder
         builder_class = "Padrino::Helpers::FormBuilder::#{builder_class}".constantize if builder_class.is_a?(String)
         builder_class.new(self, object, options)
+      end
+
+      ##
+      # Converts value into DateTime.
+      #
+      # @example
+      #   datetime_value('1993-02-24T12:30:45') #=> #<DateTime: 1993-02-24T12:30:45+00:00>
+      #
+      def datetime_value(value)
+        if value.kind_of?(String)
+          DateTime.parse(value) rescue nil
+        else
+          value
+        end
       end
     end
   end

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -726,6 +726,32 @@ module Padrino
         input_tag(:month, options)
       end
 
+      ##
+      # Constructs a week tag from the given options.
+      #
+      # @example
+      #   week_field_tag('week_with_min_max', :min => DateTime.new(1993, 2, 24),
+      #                                       :max => DateTime.new(2000, 4, 1))
+      #   week_field_tag('week_with_value', :value => DateTime.new(2000, 4, 1))
+      #
+      # @param [String] name
+      #   The name of the week field.
+      # @param [Hash] options
+      #   The html options for the week field.
+      # @option options [DateTime, String] :min
+      #  The min week time of the week field.
+      # @option options [DateTime, String] :max
+      #  The max week time of the week field.
+      # @option options [DateTime, String] :value
+      #  The value of the week field. See examples for details.
+      # @return [String] The html week field
+      #
+      def week_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options = convert_attributes_into_datetime("%Y-W%W", options)
+        input_tag(:week, options)
+      end
+
       private
 
       ##

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -620,6 +620,8 @@ module Padrino
         input_tag(:range, options)
       end
 
+      DATETIME_ATTRIBUTES = [:value, :max, :min].freeze
+
       ##
       # Constructs a datetime tag from the given options.
       #
@@ -642,11 +644,34 @@ module Padrino
       #
       def datetime_field_tag(name, options = {})
         options = { :name => name }.update(options)
-        [:max, :min, :value].each do |attribute|
-          value = datetime_value(options[attribute])
-          options[attribute] = value.rfc3339 if value.respond_to?(:rfc3339)
-        end
+        options = convert_attributes_into_datetime_rfc3339(options)
         input_tag(:datetime, options)
+      end
+
+      ##
+      # Constructs a datetime-local tag from the given options.
+      #
+      # @example
+      #   datetime_local_field_tag('datetime_local_with_min_max', :min => DateTime.new(1993, 2, 24, 12, 30, 45),
+      #                                                           :max => DateTime.new(2000, 4, 1, 12, 0, 0))
+      #   datetime_local_field_tag('datetime_local_with_value', :value => DateTime.new(2000, 4, 1, 12, 0, 0))
+      #
+      # @param [String] name
+      #   The name of the datetime local field.
+      # @param [Hash] options
+      #   The html options for the datetime-local field.
+      # @option options [DateTime, String] :min
+      #  The min date time of the datetime-local field.
+      # @option options [DateTime, String] :max
+      #  The max date time of the datetime-local field.
+      # @option options [DateTime, String] :value
+      #  The value of the datetime field. See examples for details.
+      # @return [String] The html datetime-local field
+      #
+      def datetime_local_field_tag(name, options = {})
+        options = { :name => name }.update(options)
+        options = convert_attributes_into_datetime_rfc3339(options)
+        input_tag(:"datetime-local", options)
       end
 
       private
@@ -675,6 +700,16 @@ module Padrino
           DateTime.parse(value) rescue nil
         else
           value
+        end
+      end
+
+      ##
+      # Converts special attributes into datetime format strings that conforms to RFC 3399.
+      #
+      def convert_attributes_into_datetime_rfc3339(options)
+        DATETIME_ATTRIBUTES.each_with_object(options) do |attribute|
+          value = datetime_value(options[attribute])
+          options[attribute] = value.rfc3339 if value.respond_to?(:rfc3339)
         end
       end
     end

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -54,6 +54,10 @@
     <%= f.label :datetime %>
     <%= f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0) %>
   </p>
+  <p>
+    <%= f.label :datetime_local %>
+    <%= f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -74,6 +74,10 @@
     <%= f.label :time %>
     <%= f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0) %>
   </p>
+  <p>
+    <%= f.label :color %>
+    <%= f.color_field :color, :value => "#f00" %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -58,6 +58,10 @@
     <%= f.label :datetime_local %>
     <%= f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0) %>
   </p>
+  <p>
+    <%= f.label :date %>
+    <%= f.date_field :date, :max => DateTime.new(2000, 4, 1) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -70,6 +70,10 @@
     <%= f.label :week %>
     <%= f.week_field :week, :max => DateTime.new(2000, 4, 1) %>
   </p>
+  <p>
+    <%= f.label :time %>
+    <%= f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -66,6 +66,10 @@
     <%= f.label :month %>
     <%= f.month_field :month, :max => DateTime.new(2000, 4, 1) %>
   </p>
+  <p>
+    <%= f.label :week %>
+    <%= f.week_field :week, :max => DateTime.new(2000, 4, 1) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -62,6 +62,10 @@
     <%= f.label :date %>
     <%= f.date_field :date, :max => DateTime.new(2000, 4, 1) %>
   </p>
+  <p>
+    <%= f.label :month %>
+    <%= f.month_field :month, :max => DateTime.new(2000, 4, 1) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.erb
@@ -50,6 +50,10 @@
     <%= f.label :remember_me %>
     <%= f.check_box :remember_me, :value => '1' %>
   </p>
+  <p>
+    <%= f.label :datetime %>
+    <%= f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0) %>
+  </p>
   <p><%= f.submit "Create", :class => 'success', :id => 'demo-button' %></p>
   <p><%= f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button' %></p>
 <% end %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -54,6 +54,9 @@
     = f.label :week
     = f.week_field :week, :max => DateTime.new(2000, 4, 1)
   %p
+    = f.label :time
+    = f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -57,6 +57,10 @@
     = f.label :time
     = f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0)
   %p
+    = f.label :color
+    = f.color_field :color, :value => "#f00"
+  </p>
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -45,6 +45,9 @@
     = f.label :datetime_local
     = f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
   %p
+    = f.label :date
+    = f.date_field :date, :max => DateTime.new(2000, 4, 1)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -42,6 +42,9 @@
     = f.label :datetime
     = f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
   %p
+    = f.label :datetime_local
+    = f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -39,6 +39,9 @@
     = f.label :remember_me
     = f.check_box :remember_me, :value => "1"
   %p
+    = f.label :datetime
+    = f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -48,6 +48,9 @@
     = f.label :date
     = f.date_field :date, :max => DateTime.new(2000, 4, 1)
   %p
+    = f.label :month
+    = f.month_field :month, :max => DateTime.new(2000, 4, 1)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.haml
@@ -51,6 +51,9 @@
     = f.label :month
     = f.month_field :month, :max => DateTime.new(2000, 4, 1)
   %p
+    = f.label :week
+    = f.week_field :week, :max => DateTime.new(2000, 4, 1)
+  %p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   %p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -42,6 +42,9 @@
     = f.label :datetime
     = f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
   p
+    = f.label :datetime_local
+    = f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -54,6 +54,9 @@
     = f.label :week
     = f.week_field :week, :max => DateTime.new(2000, 4, 1)
   p
+    = f.label :time
+    = f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -45,6 +45,9 @@
     = f.label :datetime_local
     = f.datetime_local_field :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
   p
+    = f.label :date
+    = f.date_field :date, :max => DateTime.new(2000, 4, 1)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -48,6 +48,9 @@
     = f.label :date
     = f.date_field :date, :max => DateTime.new(2000, 4, 1)
   p
+    = f.label :month
+    = f.month_field :month, :max => DateTime.new(2000, 4, 1)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -39,6 +39,9 @@
     = f.label :remember_me
     = f.check_box :remember_me, :value => "1"
   p
+    = f.label :datetime
+    = f.datetime_field :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -51,6 +51,9 @@
     = f.label :month
     = f.month_field :month, :max => DateTime.new(2000, 4, 1)
   p
+    = f.label :week
+    = f.week_field :week, :max => DateTime.new(2000, 4, 1)
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_for.slim
@@ -57,6 +57,9 @@
     = f.label :time
     = f.time_field :time, :max => Time.new(2008, 6, 21, 13, 30, 0)
   p
+    = f.label :color
+    = f.color_field :color, :value => "#f00"
+  p
     = f.submit "Create", :class => 'success', :id => 'demo-button'
   p
     = f.image_submit "buttons/post.png", :class => 'success', :id => 'image-button'

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -86,6 +86,9 @@
     <p>
       <%= datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0) %>
     </p>
+    <p>
+      <%= datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -83,6 +83,9 @@
       <%= range_field_tag('ranger_with_min_max', :min => 1, :max => 50) %>
       <%= range_field_tag('ranger_with_range', :range => 1..5) %>
     </p>
+    <p>
+      <%= datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -95,6 +95,9 @@
     <p>
       <%= month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
     </p>
+    <p>
+      <%= week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -92,6 +92,9 @@
     <p>
       <%= date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
     </p>
+    <p>
+      <%= month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -98,6 +98,9 @@
     <p>
       <%= week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
     </p>
+    <p>
+      <%= time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -101,6 +101,9 @@
     <p>
       <%= time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0) %>
     </p>
+    <p>
+      <%= color_field_tag :color, :value => "#f00" %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.erb
@@ -89,6 +89,9 @@
     <p>
       <%= datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0) %>
     </p>
+    <p>
+      <%= date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1) %>
+    </p>
   <% end %>
   <% field_set_tag(:class => 'buttons') do %>
     <%= submit_tag "Login" %>

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -75,6 +75,8 @@
       = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
     %p
       = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    %p
+      = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -79,6 +79,8 @@
       = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     %p
       = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    %p
+      = time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -69,6 +69,8 @@
     %p
       = range_field_tag('ranger_with_min_max', :min => 1, :max => 50)
       = range_field_tag('ranger_with_range', :range => 1..5)
+    %p
+      = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -81,6 +81,8 @@
       = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     %p
       = time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0)
+    %p
+      = color_field_tag :color, :value => "#f00"
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -77,6 +77,8 @@
       = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     %p
       = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    %p
+      = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -71,6 +71,8 @@
       = range_field_tag('ranger_with_range', :range => 1..5)
     %p
       = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
+    %p
+      = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.haml
@@ -73,6 +73,8 @@
       = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
     %p
       = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
+    %p
+      = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"
     = button_tag "Cancel"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -71,6 +71,8 @@
       = range_field_tag('ranger_with_range', :range => 1..5)
     p
       = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
+    p
+      = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -69,6 +69,8 @@
     p
       = range_field_tag('ranger_with_min_max', :min => 1, :max => 50)
       = range_field_tag('ranger_with_range', :range => 1..5)
+    p
+      = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -73,6 +73,8 @@
       = datetime_field_tag :datetime, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
     p
       = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
+    p
+      = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -77,6 +77,8 @@
       = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     p
       = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    p
+      = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -81,6 +81,8 @@
       = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     p
       = time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0)
+    p
+      = color_field_tag :color, :value => "#f00"
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -75,6 +75,8 @@
       = datetime_local_field_tag :datetime_local, :max => DateTime.new(2000, 4, 1, 12, 0, 0), :min => DateTime.new(1993, 2, 24, 12, 30, 45), :value => DateTime.new(2000, 4, 1, 12, 0, 0)
     p
       = date_field_tag :date, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    p
+      = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
+++ b/padrino-helpers/test/fixtures/markup_app/views/form_tag.slim
@@ -79,6 +79,8 @@
       = month_field_tag :month, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
     p
       = week_field_tag :week, :max => DateTime.new(2000, 4, 1), :min => DateTime.new(1993, 2, 24), :value => DateTime.new(2000, 4, 1)
+    p
+      = time_field_tag :time, :max => Time.new(2008, 6, 21, 13, 30, 0), :min => Time.new(1993, 2, 24, 1, 19, 12), :value => Time.new(2008, 6, 21, 13, 30, 0)
 
   = field_set_tag(:class => 'buttons') do
     = submit_tag "Login"

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1285,4 +1285,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
     end
   end
+
+  describe 'for #date_field method' do
+    it 'should display correct date field html' do
+      actual_html = standard_builder.date_field(:date)
+      assert_has_tag('input[type=date]', :id => 'user_date', :name => 'user[date]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = standard_builder.date_field(:date, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_date',
+        :max => "2000-04-01",
+        :min => "1993-02-24",
+        :value => "2000-04-01"
+      }
+      assert_has_tag('input[type=date]', expected) { actual_html }
+    end
+
+    it 'should display correct date field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+    end
+
+    it 'should display correct date field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+    end
+
+    it 'should display correct date field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1321,4 +1321,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
     end
   end
+
+  describe 'for #month_field method' do
+    it 'should display correct month field html' do
+      actual_html = standard_builder.month_field(:month)
+      assert_has_tag('input[type=month]', :id => 'user_month', :name => 'user[month]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = standard_builder.month_field(:month, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_month',
+        :max => "2000-04",
+        :min => "1993-02",
+        :value => "2000-04"
+      }
+      assert_has_tag('input[type=month]', expected) { actual_html }
+    end
+
+    it 'should display correct month field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+    end
+
+    it 'should display correct month field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+    end
+
+    it 'should display correct month field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1357,4 +1357,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
     end
   end
+
+  describe 'for #week_field method' do
+    it 'should display correct week field html' do
+      actual_html = standard_builder.week_field(:week)
+      assert_has_tag('input[type=week]', :id => 'user_week', :name => 'user[week]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = standard_builder.week_field(:week, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_week',
+        :max => "2000-W13",
+        :min => "1993-W08",
+        :value => "2000-W13"
+      }
+      assert_has_tag('input[type=week]', expected) { actual_html }
+    end
+
+    it 'should display correct week field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+    end
+
+    it 'should display correct week field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+    end
+
+    it 'should display correct week field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1249,4 +1249,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
     end
   end
+
+  describe 'for #datetime_local_field method' do
+    it 'should display correct datetime-local field html' do
+      actual_html = standard_builder.datetime_local_field(:datetime_local)
+      assert_has_tag('input[type=datetime-local]', :id => 'user_datetime_local', :name => 'user[datetime_local]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = DateTime.new(2000, 4, 1, 12, 0, 0)
+      min = DateTime.new(1993, 2, 24, 12, 30, 45)
+      value = DateTime.new(2000, 4, 1, 12, 0, 0)
+      actual_html = standard_builder.datetime_local_field(:datetime_local, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_datetime_local',
+        :max => "2000-04-01T12:00:00+00:00",
+        :min => "1993-02-24T12:30:45+00:00",
+        :value => "2000-04-01T12:00:00+00:00"
+      }
+      assert_has_tag('input[type=datetime-local]', expected) { actual_html }
+    end
+
+    it 'should display correct datetime-local field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+    end
+
+    it 'should display correct datetime-local field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+    end
+
+    it 'should display correct datetime-local field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1227,26 +1227,26 @@ describe "FormBuilder" do
       actual_html = standard_builder.datetime_field(:datetime, :max => max, :min => min, :value => value)
       expected = {
         :id => 'user_datetime',
-        :max => "2000-04-01T12:00:00+00:00",
-        :min => "1993-02-24T12:30:45+00:00",
-        :value => "2000-04-01T12:00:00+00:00"
+        :max => "2000-04-01T12:00:00.000+0000",
+        :min => "1993-02-24T12:30:45.000+0000",
+        :value => "2000-04-01T12:00:00.000+0000"
       }
       assert_has_tag('input[type=datetime]', expected) { actual_html }
     end
 
     it 'should display correct datetime field in haml' do
       visit '/haml/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
 
     it 'should display correct datetime field in erb' do
       visit '/erb/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
 
     it 'should display correct datetime field in slim' do
       visit '/slim/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
   end
 
@@ -1263,9 +1263,9 @@ describe "FormBuilder" do
       actual_html = standard_builder.datetime_local_field(:datetime_local, :max => max, :min => min, :value => value)
       expected = {
         :id => 'user_datetime_local',
-        :max => "2000-04-01T12:00:00+00:00",
-        :min => "1993-02-24T12:30:45+00:00",
-        :value => "2000-04-01T12:00:00+00:00"
+        :max => "2000-04-01T12:00:00",
+        :min => "1993-02-24T12:30:45",
+        :value => "2000-04-01T12:00:00"
       }
       assert_has_tag('input[type=datetime-local]', expected) { actual_html }
     end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1393,4 +1393,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
     end
   end
+
+  describe 'for #time_field method' do
+    it 'should display correct time field html' do
+      actual_html = standard_builder.time_field(:time)
+      assert_has_tag('input[type=time]', :id => 'user_time', :name => 'user[time]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = Time.new(2008, 6, 21, 13, 30, 0)
+      min = Time.new(1993, 2, 24, 1, 19, 12)
+      value = Time.new(2008, 6, 21, 13, 30, 0)
+      actual_html = standard_builder.time_field(:time, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_time',
+        :max => "13:30:00.000",
+        :min => "01:19:12.000",
+        :value => "13:30:00.000"
+      }
+      assert_has_tag('input[type=time]', expected) { actual_html }
+    end
+
+    it 'should display correct time field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+    end
+
+    it 'should display correct time field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+    end
+
+    it 'should display correct time field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1429,4 +1429,26 @@ describe "FormBuilder" do
       assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
     end
   end
+
+  describe 'for #color_field method' do
+    it 'should display correct color field html' do
+      actual_html = standard_builder.color_field(:color)
+      assert_has_tag('input[type=color]', :id => 'user_color', :name => 'user[color]') { actual_html }
+    end
+
+    it 'should display correct color field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+    end
+
+    it 'should display correct color field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+    end
+
+    it 'should display correct color field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -1213,4 +1213,40 @@ describe "FormBuilder" do
       assert_have_selector '#demo2 p input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
   end
+
+  describe 'for #datetime_field method' do
+    it 'should display correct datetime field html' do
+      actual_html = standard_builder.datetime_field(:datetime)
+      assert_has_tag('input[type=datetime]', :id => 'user_datetime', :name => 'user[datetime]') { actual_html }
+    end
+
+    it 'should format DateTime to correct value if min and max and value options exist' do
+      max = DateTime.new(2000, 4, 1, 12, 0, 0)
+      min = DateTime.new(1993, 2, 24, 12, 30, 45)
+      value = DateTime.new(2000, 4, 1, 12, 0, 0)
+      actual_html = standard_builder.datetime_field(:datetime, :max => max, :min => min, :value => value)
+      expected = {
+        :id => 'user_datetime',
+        :max => "2000-04-01T12:00:00+00:00",
+        :min => "1993-02-24T12:30:45+00:00",
+        :value => "2000-04-01T12:00:00+00:00"
+      }
+      assert_has_tag('input[type=datetime]', expected) { actual_html }
+    end
+
+    it 'should display correct datetime field in haml' do
+      visit '/haml/form_for'
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+    end
+
+    it 'should display correct datetime field in erb' do
+      visit '/erb/form_for'
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+    end
+
+    it 'should display correct datetime field in slim' do
+      visit '/slim/form_for'
+      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00+00:00"
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1141,4 +1141,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #date_field_tag' do
+    before do
+      @expected = {
+        :name => 'date',
+        :max => "2000-04-01",
+        :min => "1993-02-24",
+        :value => "2000-04-01"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = date_field_tag('date', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with date' do
+      actual_html = date_field_tag('date')
+      assert_has_tag('input[type="date"]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as date option value' do
+      actual_html = date_field_tag('date', :value => '1993-02-24')
+      assert_has_tag('input[type="date"]', :value => "1993-02-24") { actual_html }
+    end
+
+    it 'should display correct date_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct date_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct date_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1229,4 +1229,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #week_field_tag' do
+    before do
+      @expected = {
+        :name => 'week',
+        :max => "2000-W13",
+        :min => "1993-W08",
+        :value => "2000-W13"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = week_field_tag('week', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with week' do
+      actual_html = week_field_tag('week')
+      assert_has_tag('input[type="week"]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as week option value' do
+      actual_html = week_field_tag('week', :value => '1993-02-24')
+      assert_has_tag('input[type="week"]', :value => "1993-W08") { actual_html }
+    end
+
+    it 'should display correct week_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct week_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct week_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1273,4 +1273,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #time_field_tag' do
+    before do
+      @expected = {
+        :name => 'time',
+        :max => "13:30:00.000",
+        :min => "01:19:12.000",
+        :value => "13:30:00.000"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = Time.new(2008, 6, 21, 13, 30, 0)
+      min = Time.new(1993, 2, 24, 1, 19, 12)
+      value = Time.new(2008, 6, 21, 13, 30, 0)
+      actual_html = time_field_tag('time', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with time' do
+      actual_html = time_field_tag('time')
+      assert_has_tag('input[type="time"]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as time option value' do
+      actual_html = time_field_tag('time', :value => '1993-02-24 01:19:12')
+      assert_has_tag('input[type="time"]', :value => "01:19:12.000") { actual_html }
+    end
+
+    it 'should display correct time_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct time_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct time_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1058,9 +1058,9 @@ describe "FormHelpers" do
     before do
       @expected = {
         :name => 'datetime',
-        :max => "2000-04-01T12:00:00+00:00",
-        :min => "1993-02-24T12:30:45+00:00",
-        :value => "2000-04-01T12:00:00+00:00"
+        :max => "2000-04-01T12:00:00.000+0000",
+        :min => "1993-02-24T12:30:45.000+0000",
+        :value => "2000-04-01T12:00:00.000+0000"
       }
     end
 
@@ -1079,7 +1079,7 @@ describe "FormHelpers" do
 
     it 'should create an input tag when the format string passed as datetime option value' do
       actual_html = datetime_field_tag('datetime', :value => '1993-02-24T12:30:45+00:00')
-      assert_has_tag('input[type=datetime]', :value => "1993-02-24T12:30:45+00:00") { actual_html }
+      assert_has_tag('input[type=datetime]', :value => "1993-02-24T12:30:45.000+0000") { actual_html }
     end
 
     it 'should display correct datetime_field_tag in erb' do
@@ -1102,9 +1102,9 @@ describe "FormHelpers" do
     before do
       @expected = {
         :name => 'datetime_local',
-        :max => "2000-04-01T12:00:00+00:00",
-        :min => "1993-02-24T12:30:45+00:00",
-        :value => "2000-04-01T12:00:00+00:00"
+        :max => "2000-04-01T12:00:00",
+        :min => "1993-02-24T12:30:45",
+        :value => "2000-04-01T12:00:00"
       }
     end
 
@@ -1122,8 +1122,8 @@ describe "FormHelpers" do
     end
 
     it 'should create an input tag when the format string passed as datetime-local option value' do
-      actual_html = datetime_local_field_tag('datetime_local', :value => '1993-02-24T12:30:45+00:00')
-      assert_has_tag('input[type="datetime-local"]', :value => "1993-02-24T12:30:45+00:00") { actual_html }
+      actual_html = datetime_local_field_tag('datetime_local', :value => '1993-02-24T12:30:45')
+      assert_has_tag('input[type="datetime-local"]', :value => "1993-02-24T12:30:45") { actual_html }
     end
 
     it 'should display correct datetime_local_field_tag in erb' do

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1053,4 +1053,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
     end
   end
+
+  describe 'for #datetime_field_tag' do
+    before do
+      @expected = {
+        :name => 'datetime',
+        :max => "2000-04-01T12:00:00+00:00",
+        :min => "1993-02-24T12:30:45+00:00",
+        :value => "2000-04-01T12:00:00+00:00"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = DateTime.new(2000, 4, 1, 12, 0, 0)
+      min = DateTime.new(1993, 2, 24, 12, 30, 45)
+      value = DateTime.new(2000, 4, 1, 12, 0, 0)
+      actual_html = datetime_field_tag('datetime', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with datetime' do
+      actual_html = datetime_field_tag('datetime')
+      assert_has_tag('input[type=datetime]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as datetime option value' do
+      actual_html = datetime_field_tag('datetime', :value => '1993-02-24T12:30:45+00:00')
+      assert_has_tag('input[type=datetime]', :value => "1993-02-24T12:30:45+00:00") { actual_html }
+    end
+
+    it 'should display correct datetime_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct datetime_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct datetime_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1317,4 +1317,38 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #color_field_tag' do
+    before do
+      @expected = {
+        :name => 'color',
+        :value => '#ff0000'
+      }
+    end
+
+    it 'should create an input tag with value option' do
+      actual_html = color_field_tag('color', :value => "#ff0000")
+      assert_has_tag('input[type="color"]', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with short color code' do
+      actual_html = color_field_tag('color', :value => "#f00")
+      assert_has_tag('input[type="color"]', @expected) { actual_html }
+    end
+
+    it 'should display correct color_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct color_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct color_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1185,4 +1185,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #month_field_tag' do
+    before do
+      @expected = {
+        :name => 'month',
+        :max => "2000-04",
+        :min => "1993-02",
+        :value => "2000-04"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = DateTime.new(2000, 4, 1)
+      min = DateTime.new(1993, 2, 24)
+      value = DateTime.new(2000, 4, 1)
+      actual_html = month_field_tag('month', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with month' do
+      actual_html = month_field_tag('month')
+      assert_has_tag('input[type="month"]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as month option value' do
+      actual_html = month_field_tag('month', :value => '1993-02-24')
+      assert_has_tag('input[type="month"]', :value => "1993-02") { actual_html }
+    end
+
+    it 'should display correct month_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct month_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct month_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -1097,4 +1097,48 @@ describe "FormHelpers" do
       assert_have_selector 'input', @expected
     end
   end
+
+  describe 'for #datetime_local_field_tag' do
+    before do
+      @expected = {
+        :name => 'datetime_local',
+        :max => "2000-04-01T12:00:00+00:00",
+        :min => "1993-02-24T12:30:45+00:00",
+        :value => "2000-04-01T12:00:00+00:00"
+      }
+    end
+
+    it 'should create an input tag with min and max and value options' do
+      max = DateTime.new(2000, 4, 1, 12, 0, 0)
+      min = DateTime.new(1993, 2, 24, 12, 30, 45)
+      value = DateTime.new(2000, 4, 1, 12, 0, 0)
+      actual_html = datetime_local_field_tag('datetime_local', :max => max, :min => min, :value => value)
+      assert_has_tag('input', @expected) { actual_html }
+    end
+
+    it 'should create an input tag with datetime-local' do
+      actual_html = datetime_local_field_tag('datetime_local')
+      assert_has_tag('input[type="datetime-local"]') { actual_html }
+    end
+
+    it 'should create an input tag when the format string passed as datetime-local option value' do
+      actual_html = datetime_local_field_tag('datetime_local', :value => '1993-02-24T12:30:45+00:00')
+      assert_has_tag('input[type="datetime-local"]', :value => "1993-02-24T12:30:45+00:00") { actual_html }
+    end
+
+    it 'should display correct datetime_local_field_tag in erb' do
+      visit '/erb/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct datetime_local_field_tag in haml' do
+      visit '/haml/form_tag'
+      assert_have_selector 'input', @expected
+    end
+
+    it 'should display correct datetime_local_field_tag in slim' do
+      visit '/slim/form_tag'
+      assert_have_selector 'input', @expected
+    end
+  end
 end


### PR DESCRIPTION
I’ve implemented missing helpers about the input element. 
A few helpers haven’t been able to be used on some browsers, but I believe that they’ll be implemented soon.
Also, [the datetime issue](https://github.com/padrino/padrino-framework/issues/1808) can be closed by merging this PR.

Could you review these commits?
Thanks!