### PR TITLE
Basic project configuration engine

### DIFF
--- a/padrino-core/lib/padrino-core.rb
+++ b/padrino-core/lib/padrino-core.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'padrino-core/version'
 require 'padrino-support'
+require 'padrino-core/configuration'
 require 'padrino-core/application'
 
 require 'padrino-core/caller'
@@ -25,6 +26,7 @@ module Padrino
   class ApplicationLoadError < RuntimeError # @private
   end
 
+  extend Configuration
   extend Loader
 
   class << self

--- a/padrino-core/lib/padrino-core/configuration.rb
+++ b/padrino-core/lib/padrino-core/configuration.rb
@@ -1,0 +1,40 @@
+require 'ostruct'
+
+module Padrino
+  ##
+  # Padrino simple configuration module
+  #
+  module Configuration
+    ##
+    # Returns the configuration structure allowing to get and set it's values.
+    # Padrino.config is a simple Ruby OpenStruct object with no additional magic.
+    #
+    # Example:
+    #
+    #   Padrino.config.value1 = 42
+    #   exit if Padrino.config.exiting
+    #
+    def config
+      @config ||= OpenStruct.new
+    end
+
+    ##
+    # Allows to configure different environments differently. Requires a block.
+    #
+    # Example:
+    #
+    #   Padrino.configure :development do |config|
+    #     config.value2 = 'only development'
+    #   end
+    #   Padrino.configure :development, :production do |config|
+    #     config.value2 = 'both development and production'
+    #   end
+    #   Padrino.configure do |config|
+    #     config.value2 = 'any environment'
+    #   end
+    #
+    def configure(*environments)
+      yield(config) if environments.empty? || environments.include?(Padrino.env)
+    end
+  end
+end

--- a/padrino-core/test/test_configuration.rb
+++ b/padrino-core/test/test_configuration.rb
@@ -3,14 +3,14 @@ require File.expand_path(File.dirname(__FILE__) + '/helper')
 describe "PadrinoConfiguration" do
   it 'should be able to store values' do
     Padrino.config.val1 = 12345
-    assert_equal 12345, Padrino.config['val1']
+    assert_equal 12345, Padrino.config.val1
   end
 
   it 'should be able to configure with block' do
     Padrino.configure do |config|
       config.val2 = 54321
     end
-    assert_equal 54321, Padrino.config['val2']
+    assert_equal 54321, Padrino.config.val2
   end
 
   it 'should be able to configure with block' do

--- a/padrino-core/test/test_configuration.rb
+++ b/padrino-core/test/test_configuration.rb
@@ -1,0 +1,27 @@
+describe "PadrinoConfiguration" do
+  it 'should be able to store values' do
+    Padrino.config.val1 = 12345
+    assert_equal 12345, Padrino.config['val1']
+  end
+
+  it 'should be able to configure with block' do
+    Padrino.configure do |config|
+      config.val2 = 54321
+    end
+    assert_equal 54321, Padrino.config['val2']
+  end
+
+  it 'should be able to configure with block' do
+    Padrino.configure :test do |config|
+      config.test1 = 54321
+    end
+    Padrino.configure :development do |config|
+      config.test1 = 12345
+    end
+    Padrino.configure :test, :development do |config|
+      config.both1 = 54321
+    end
+    assert_equal 54321, Padrino.config.test1
+    assert_equal 54321, Padrino.config.both1
+  end
+end

--- a/padrino-core/test/test_configuration.rb
+++ b/padrino-core/test/test_configuration.rb
@@ -1,3 +1,5 @@
+require File.expand_path(File.dirname(__FILE__) + '/helper')
+
 describe "PadrinoConfiguration" do
   it 'should be able to store values' do
     Padrino.config.val1 = 12345


### PR DESCRIPTION
ref #1832

I retracted from the idea of configuring Padrino modules by calling their fields as it would overly complicate the implementation and repeat the existing fine gems like https://github.com/beatrichartz/configurations and https://github.com/markbates/configatron.

The configuration now only supports very basic OpenStruct syntax with an environment filter. Just Ruby, no magic, no DSL:

```ruby
Padrino.config.value1 = 42

Padrino.configure :development do |config|
  config.value2 = 'only development'
end

Padrino.configure :development, :production do |config|
  config.value2 = 'both development and production'
end

Padrino.configure do |config|
  config.value2 = 'any environment'
end
```

I think this implementation covers the basic needs of configuring a project while not bloating it and leaving space for more comprehensive solutions.