### PR TITLE
add absolute_url to app method, add :base_url setting, fixes #1829

### DIFF
--- a/padrino-core/lib/padrino-core/application/application_setup.rb
+++ b/padrino-core/lib/padrino-core/application/application_setup.rb
@@ -62,6 +62,7 @@ module Padrino
         set :uri_root,      '/'
         set :public_folder, proc { Padrino.root('public', uri_root) }
         set :images_path,   proc { File.join(public_folder, 'images') }
+        set :base_url,      'http://localhost'
       end
 
       def default_security

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -344,6 +344,14 @@ module Padrino
       end
       alias :url_for :url
 
+      ##
+      # Returns absolute url. By default adds 'http://localhost' before generated url.
+      # To change that `set :base_url, 'http://example.com'` in your app.
+      #
+      def absolute_url(*args)
+        base_url + url(*args)
+      end
+
       def get(path, *args, &block)
         conditions = @conditions.dup
         route('GET', path, *args, &block)

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2325,4 +2325,18 @@ describe "Routing" do
     assert ok?
     assert_equal 'bar', body
   end
+
+  it 'should generate urls and absolute urls' do
+    mock_app do
+      get(:index) { settings.url(:index) }
+      get(:absolute) { settings.absolute_url(:absolute) }
+    end
+    get '/'
+    assert_equal '/', body
+    get '/absolute'
+    assert_equal 'http://localhost/absolute', body
+    @app.set :base_url, 'http://example.com'
+    get '/absolute'
+    assert_equal 'http://example.com/absolute', body
+  end
 end


### PR DESCRIPTION
Setting :base_url conforms with [Rack Request base_url method](https://github.com/rack/rack/blob/d68b93a9922b8bbfd76d5c7bcf5b63f2aec8f36f/lib/rack/request.rb#L323)

If an app sets this option, it can return absolute urls in environments lacking HTTP requests (mailer, rake tasks).

```ruby
class Admin < Padrino::Application
  set :base_url, 'http://example.com'
  get(:index) { }
end

Admin.absolute_url(:index) # => 'http://example.com/'
```

By default `:base_url` is `'http://localhost'`

ref #1829