### PR TITLE
Alias db:migrate:down and db:migrate:up

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/datamapper.rb
@@ -86,6 +86,8 @@ if PadrinoTasks.load?(:datamapper, defined?(DataMapper))
     task :setup => [:create, :migrate, :seed]
   end
 
+  task 'db:migrate:down' => 'dm:migrate:down'
+  task 'db:migrate:up' => 'dm:migrate:up'
   task 'db:migrate' => 'dm:migrate'
   task 'db:create'  => 'dm:create'
   task 'db:drop'    => 'dm:drop'


### PR DESCRIPTION
The up/down migration tasks should also be aliased, for deploy tools such as capistrano, mina, etc.