### PR TITLE
Misc fixes

### DIFF
--- a/padrino-docs/pages/agnostic.md
+++ b/padrino-docs/pages/agnostic.md
@@ -14,7 +14,7 @@ The available components and their defaults are listed below:
 |orm|none|mongoid, ripple, activerecord, sequel, mongomapper, minirecord, ohm, mongomatic, dynamoid,
 couchrest, datamapper|
 |script|none|rightjs, extcore, dojo, prototype, jquery, mootools|
-|renderer|slim|slim, haml, erb|
+|renderer|none|slim, haml, erb|
 |test|none|rspec, cucumber, minitest, steak, shoulda, riot, bacon|
 |stylesheet|none|compass, sass, scss, less|
 |mock|none|rr, mocha|

--- a/padrino-docs/pages/agnostic.md
+++ b/padrino-docs/pages/agnostic.md
@@ -14,8 +14,8 @@ The available components and their defaults are listed below:
 |orm|none|mongoid, ripple, activerecord, sequel, mongomapper, minirecord, ohm, mongomatic, dynamoid,
 couchrest, datamapper|
 |script|none|rightjs, extcore, dojo, prototype, jquery, mootools|
-|renderer|haml|slim, haml, liquid, erb|
-|test|rspec|rspec, cucumber, minitest, steak, shoulda, riot, bacon|
+|renderer|slim|slim, haml, erb|
+|test|none|rspec, cucumber, minitest, steak, shoulda, riot, bacon|
 |stylesheet|none|compass, sass, scss, less|
 |mock|none|rr, mocha|
 

--- a/padrino-docs/pages/agnostic.md
+++ b/padrino-docs/pages/agnostic.md
@@ -11,11 +11,12 @@ The available components and their defaults are listed below:
 
 |Component|Default|Options|
 |:--------|:------|:------|
-|orm|none|mongomapper, mongoid, activerecord, datamapper, sequel, couchrest|
-|script|none|prototype, rightjs, jquery, mootools, extcore|
-|renderer|haml|erb, haml|
-|test|rspec|bacon, shoulda, cucumber, testspec, riot, rspec|
-|stylesheet|none|less, sass|
+|orm|none|mongoid, ripple, activerecord, sequel, mongomapper, minirecord, ohm, mongomatic, dynamoid,
+couchrest, datamapper|
+|script|none|rightjs, extcore, dojo, prototype, jquery, mootools|
+|renderer|haml|slim, haml, liquid, erb|
+|test|rspec|rspec, cucumber, minitest, steak, shoulda, riot, bacon|
+|stylesheet|none|compass, sass, scss, less|
 |mock|none|rr, mocha|
 
 Just create the project with the usual generator command and pass in your preferred components!

--- a/padrino-docs/pages/comprehensive.md
+++ b/padrino-docs/pages/comprehensive.md
@@ -7,17 +7,17 @@ title: Comprehensive
 
 Building on our experience in developing web applications, we designed a framework that meets all the requirements for creating a top notch web application in a *clean*, *concise* and *simple environment*, with minimal *deadline* delays.
 
-We provide you with the following out of the box:
+Out of the box we give you the following:
 
 ||
 |**Agnostic:**|Full support for many popular testing, templating, mocking, and database libraries.|
-|**Generators:**|Create Padrino applications, models, controllers, admin.|
-|**Mountable:**|Unlike other ruby frameworks, principally designed for mounting multiple apps.|
-|**Routing:**|Full url named routes, named params, respond\_to support, before/after filter support.|
+|**Generators:**|Create Padrino applications, mailers, controllers, helpers, models, migrations and Rake tasks|
+|**Mountable:**|Unlike other Ruby frameworks, Padrino is designed for mounting multiple apps.|
+|**Routing:**|Full URL named routes, named params, respond\_to support, before/after filter support.|
 |**Helpers:**|Different helpers for generating tags, forms, links, images, and more.|
 |**Mailer:**|Fast and simple support for delivering emails.|
 |**Caching:**|Simple route and fragment caching to easily speed up your web requests.|
-|**Admin:**|Built-in admin interface (akin to Django) with authentication.|
+|**Admin:**|Built-in admin interface (akin to Django Admin) with authentication.|
 |**Logging:**|Provides a unified logger that can interact with your ORM or any library of your choice.|
 |**Reloading:**|Automatically reloads server code during development.|
 |**Localization:**|Full support for I18n localization.|

--- a/padrino-docs/pages/drop-in-admin.md
+++ b/padrino-docs/pages/drop-in-admin.md
@@ -8,9 +8,9 @@ title: Drop-in Admin
 Padrino is shipped with a slick and beautiful administration interface, with the following features:
 
 ||
-|Orm Agnostic|Adapters for datamapper, sequel, activerecord, mongomapper, mongoid, couchrest|
+|Orm Agnostic|Adapters for Active Record, MiniRecord, DataMapper, CouchRest, Mongoid, MongoMapper, Sequel, Ohm and Dynamoid|
 |Authentication|User authentication and authorization management|
-|Template Agnostic|ERB and Haml rendering support|
+|Template Agnostic|Slim, Haml and ERB rendering support|
 |Scaffold|You can create a new "admin interface" by providing a single Model|
 |MultiLanguage|Translated into 10 languages including English, German and Russian|
 

--- a/padrino-docs/pages/drop-in-admin.md
+++ b/padrino-docs/pages/drop-in-admin.md
@@ -5,20 +5,19 @@ email: nesquena@gmail.com
 title: Drop-in Admin
 ---
 
-Padrino ships with an Admin Interface that includes the following features:
+Padrino is shipped with a slick and beautiful administration interface, with the following features:
 
 ||
-|Orm Agnostic|Adapters for datamapper, activerecord, sequel, mongomapper, mongoid|
-|Authentication|Account authentication support and permission management|
-|Template Agnostic|View support for Erb and Haml rendering engines|
-|Scaffold|Create a model “admin interface” by invoking a command|
-|MultiLanguage|Translated into 10 languages including English, Spanish, and Italian|
+|Orm Agnostic|Adapters for datamapper, sequel, activerecord, mongomapper, mongoid, couchrest|
+|Authentication|User authentication and authorization management|
+|Template Agnostic|ERB and Haml rendering support|
+|Scaffold|You can create a new "admin interface" by providing a single Model|
+|MultiLanguage|Translated into 10 languages including English, German and Russian|
 
 Example:
 
-    $ padrino-gen project cool --orm activerecord
+    $ padrino-gen project cool -d datamapper
     $ cd cool
-    $ padrino-gen admin
-    $ padrino-gen admin_page post
+    $ padrino g admin
 
-For usage information, check out our detailed [admin guide](/guides/padrino-admin).
+For more information, check out our detailed [Padrino Admin guide](/guides/padrino-admin).

--- a/padrino-docs/pages/lightweight.md
+++ b/padrino-docs/pages/lightweight.md
@@ -16,4 +16,4 @@ Padrino strives to adhere to the following basic principles:
 -   Creative
 -   Concise
 
-This framework can be used with ease for web development for a project of any size from your lightweight json web service to a large full-stack web application!
+This framework can be used with ease for web development for a project of any size from your lightweight JSON web service to a large full-stack web application!


### PR DESCRIPTION
I have updated (hopefully) a few parts of the website.

Questions remaining:
1. Do we need `pages/faq.md`?
2. I believe that `pages/comprehensive.md` should be reworded or even rewritten. The wording in the table doesn't flow well.
3. I believe that `pages/drop-in-admin.md` could be replaced by a direct link to the Padrino Admin guide or there could be some way to reuse that part in the guide itself.
4. Is Padrino Admin ORM agnostic the same way Padrino is (ie. are ORM adapters available for Padrino available for Padrino Admin as well?)