### PR TITLE
Follow Sinatra's charset mechanics

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -731,7 +731,7 @@ module Padrino
 
           accept_format = CONTENT_TYPE_ALIASES[type] || type
           if types.include?(accept_format)
-            content_type(accept_format || :html, :charset => 'utf-8')
+            content_type(accept_format || :html)
           else
             catch_all ? true : halt(406)
           end
@@ -751,7 +751,7 @@ module Padrino
         mime_types = types.map{ |type| mime_type(CONTENT_TYPE_ALIASES[type] || type) }
         condition do
           halt 406 unless mime_types.include?(request.media_type)
-          content_type(mime_symbol(request.media_type), :charset => 'utf-8')
+          content_type(mime_symbol(request.media_type))
         end
       end
 
@@ -894,7 +894,6 @@ module Padrino
       #
       def content_type(type=nil, params={})
         return @_content_type unless type
-        params.delete(:charset) if type == :json
         super(type, params)
         @_content_type = type
       end
@@ -904,7 +903,7 @@ module Padrino
       def provides_any?(formats)
         accepted_format = formats.first
         type = accepted_format ? mime_symbol(accepted_format) : :html
-        content_type(CONTENT_TYPE_ALIASES[type] || type, :charset => 'utf-8')
+        content_type(CONTENT_TYPE_ALIASES[type] || type)
       end
 
       def provides_format?(types, format)
@@ -914,7 +913,7 @@ module Padrino
           halt 406 if settings.respond_to?(:treat_format_as_accept) && settings.treat_format_as_accept
           false
         else
-          content_type(format || :html, :charset => 'utf-8')
+          content_type(format || :html)
         end
       end
 

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -766,10 +766,25 @@ describe "Routing" do
     assert_equal 'application/json', response["Content-Type"]
     get "/a.foo"
     assert_equal "foo", body
-    assert_equal 'application/foo;charset=utf-8', response["Content-Type"]
+    assert_equal 'application/foo', response["Content-Type"]
     get "/a"
     assert_equal "html", body
     assert_equal 'text/html;charset=utf-8', response["Content-Type"]
+  end
+
+  it 'should not drop json charset' do
+    mock_app do
+      get '/' do
+        content_type :json, :charset => 'utf-16'
+      end
+      get '/a' do
+        content_type :json, 'charset' => 'utf-16'
+      end
+    end
+    get '/'
+    assert_equal 'application/json;charset=utf-16', response["Content-Type"]
+    get '/a'
+    assert_equal 'application/json;charset=utf-16', response["Content-Type"]
   end
 
   it 'should use controllers' do


### PR DESCRIPTION
Padrino should follow Sinatra's charset policy and should not put utf-8 everywhere.

Fixes #1950

refs:
https://github.com/sinatra/sinatra/blob/d682c705858e23f28af74e16a6d00dc68feba35d/lib/sinatra/base.rb#L326
https://github.com/sinatra/sinatra/blob/d682c705858e23f28af74e16a6d00dc68feba35d/lib/sinatra/base.rb#L1840-L1841