### PR TITLE
Check key existence on caching, fixes #1916

### DIFF
--- a/padrino-cache/lib/padrino-cache/helpers/cache_object.rb
+++ b/padrino-cache/lib/padrino-cache/helpers/cache_object.rb
@@ -5,7 +5,8 @@ module Padrino
         def cache_object(key, opts = {})
           if settings.caching?
             began_at = Time.now
-            if value = settings.cache[key.to_s]
+            if settings.cache.key?(key.to_s)
+              value = settings.cache[key.to_s]
               logger.debug "GET Object", began_at, key.to_s if defined?(logger)
             else
               value = yield

--- a/padrino-cache/lib/padrino-cache/helpers/fragment.rb
+++ b/padrino-cache/lib/padrino-cache/helpers/fragment.rb
@@ -51,9 +51,10 @@ module Padrino
         def cache(key, opts = {}, &block)
           if settings.caching?
             began_at = Time.now
-            if value = settings.cache[key.to_s]
+            if settings.cache.key?(key.to_s)
+              value = settings.cache[key.to_s]
               logger.debug "GET Fragment", began_at, key.to_s if defined?(logger)
-              concat_content(value.html_safe)
+              concat_content(value.to_s.html_safe)
             else
               value = capture_html(&block)
               settings.cache.store(key.to_s, value, opts)

--- a/padrino-cache/test/test_padrino_cache.rb
+++ b/padrino-cache/test/test_padrino_cache.rb
@@ -479,4 +479,31 @@ describe "PadrinoCache" do
     end
     assert_kind_of Moneta::Adapters::Memory, adapter
   end
+
+  it "should check key existence" do
+    count1, count2 = 0, 0
+    mock_app do
+      register Padrino::Cache
+      enable :caching
+      get "/" do
+        cache(:foo) do
+          count1 += 1
+          nil
+        end
+        count1.inspect
+      end
+
+      get "/object" do
+        cache_object(:bar) do
+          count2 += 1
+          nil
+        end
+        count2.inspect
+      end
+    end
+    2.times { get "/" }
+    assert_equal "1", body
+    2.times { get "/object" }
+    assert_equal "1", body
+  end
 end


### PR DESCRIPTION
ref #1916 
That makes sense, and I also think that approach should be reasonable.
This commit leads to suprise  padrino-cache users, so this shouldn't be backported to the 0.12 branch.