### PR TITLE
sample benchmark test of padrino core

### DIFF
--- a/padrino-performance/Rakefile
+++ b/padrino-performance/Rakefile
@@ -1,1 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../gem_rake_helper')
+
+Rake::TestTask.new(:bench) do |test|
+  test.libs << 'test'
+  test.test_files = Dir['test/**/bench_*.rb']
+end

--- a/padrino-performance/test/bench_core.rb
+++ b/padrino-performance/test/bench_core.rb
@@ -6,7 +6,7 @@ require 'minitest/autorun'
 require 'minitest/benchmark'
 require 'rack/test'
 
-class Minitest::Benchmark
+class Padrino::BenchSpec < Minitest::BenchSpec
   def self.bench_range
     [20, 80, 320, 1280]
   end
@@ -28,9 +28,11 @@ class Minitest::Benchmark
   def app
     Rack::Lint.new(@app)
   end
+
+  Minitest::Spec.register_spec_type(/^Padrino .* Performance$/, Padrino::BenchSpec)
 end
 
-describe 'Padrino Core Benchmark' do
+describe 'Padrino Core Performance' do
   before do
     Padrino.clear!
 

--- a/padrino-performance/test/bench_core.rb
+++ b/padrino-performance/test/bench_core.rb
@@ -1,0 +1,85 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'padrino-core'
+
+require 'minitest/autorun'
+require 'minitest/benchmark'
+require 'rack/test'
+
+class Minitest::Benchmark
+  def self.bench_range
+    [20, 80, 320, 1280]
+  end
+
+  def self.io
+    $stdout
+  end
+
+  def result_code
+    ''
+  end
+
+  include Rack::Test::Methods
+
+  def mock_app(base=Padrino::Application, &block)
+    @app = Sinatra.new(base, &block)
+  end
+
+  def app
+    Rack::Lint.new(@app)
+  end
+end
+
+describe 'Padrino Core Benchmark' do
+  before do
+    Padrino.clear!
+
+    paths = (1..100).map{ rand(36**8).to_s(36) }
+
+    mock_app do
+      get("/foo") { "okey" }
+
+      paths.each do |p|
+        get("/#{p}") { p.to_s }
+      end
+    end
+
+    get '/'
+
+    @paths = paths
+  end
+
+  bench_performance_linear 'calling one path', 0.99 do |n|
+    n.times do
+      get '/foo'
+    end
+  end
+
+  bench_performance_linear 'calling 404', 0.99 do |n|
+    n.times do
+      get "/#{@paths.sample}_not_found"
+    end
+  end
+
+  bench_performance_linear 'clean sample', 0.99 do |n|
+    n.times{ @paths.sample }
+  end
+
+  bench_performance_linear 'calling sample', 0.99 do |n|
+    n.times do
+      get "/#{@paths.sample}"
+    end
+  end
+
+  bench_performance_linear 'calling params', 0.99 do |n|
+    n.times do
+      get "/foo?foo=bar&zoo=#{@paths.sample}"
+    end
+  end
+
+  bench_performance_linear 'sample and params', 0.99 do |n|
+    n.times do
+      get "/#{@paths.sample}?foo=bar&zoo=#{@paths.sample}"
+    end
+  end
+end

--- a/padrino-performance/test/bench_core.rb
+++ b/padrino-performance/test/bench_core.rb
@@ -22,7 +22,7 @@ class Padrino::BenchSpec < Minitest::BenchSpec
   end
 
   def app
-    Rack::Lint.new(@app)
+    @app
   end
 
   def self.bench_performance_any(name, &work)
@@ -102,8 +102,6 @@ describe 'Padrino Mounter Performance' do
 
     @paths = paths = (1..100).map{ rand(36**8).to_s(36) }
 
-    test_app = TestApp.dup
-
     paths.each do |p|
       Padrino.mount(TestApp).to("/#{p}")
     end
@@ -112,8 +110,7 @@ describe 'Padrino Mounter Performance' do
   bench_performance_any 'mounted sample' do |n|
     request = Rack::MockRequest.new(Padrino.application)
     n.times do
-      response = request.get("/#{@paths.sample}")
-      assert_equal 200, response.status
+      request.get("/#{@paths.sample}")
     end
   end
 end


### PR DESCRIPTION
I put together a minitest benchmark to test padrino core and router. It runs 5\*1700 (5\*[20, 80, 320, 1280]) gets on a mock app, reports run time and asserts the run time increases linearly.

I'm not confident of the coding style and mechanics of benchmarking so any tips on this are appreciated.

Usage:

```
cd padrino-performance
rake bench
```

Output:

```
$ rake bench
Run options: --seed 57255

# Running:

bench_calling_one_path   0.011407        0.042323        0.185717        0.749593
bench_calling_404        0.013586        0.044794        0.197194        0.817511
bench_clean_sample       0.000015        0.000017        0.000042        0.000138
bench_calling_sample     0.014299        0.049364        0.216520        0.872963
bench_calling_params     0.014462        0.047417        0.212122        0.857239
bench_sample_and_params  0.017245        0.061315        0.235988        0.969470


Finished in 9.440125s, 0.6356 runs/s, 0.6356 assertions/s.

6 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```
