### PR TITLE
Fix documentation example for tag method

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/tag_helpers.rb
@@ -226,7 +226,7 @@ module Padrino
       #   tag :img, :src => 'images/pony.jpg', :alt => 'My Little Pony'
       #   # => <img src="images/pony.jpg" alt="My Little Pony" />
       #
-      #   tag :img, :src => 'sinatra.jpg, :data => { :nsfw => false, :geo => [34.087, -118.407] }
+      #   tag :img, :src => 'sinatra.jpg', :data => { :nsfw => false, :geo => [34.087, -118.407] }
       #   # => <img src="sinatra.jpg" data-nsfw="false" data-geo="34.087 -118.407" />
       #
       def tag(name, options = nil, open = false)


### PR DESCRIPTION
Minor fix for tag-helpers.rb for the documentation for the tag method.

As seen here: https://www.padrinorb.com/api/Padrino/Helpers/TagHelpers.html#tag-instance_method