### PR TITLE
Enable reloading of custom dependencies as per the guide

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -221,7 +221,9 @@ module Padrino
     #
     def files_for_rotation
       files = Set.new
-      files += Dir.glob("#{Padrino.root}/{lib,models,shared}/**/*.rb")
+      Padrino.dependency_paths.each do |path|
+        files += Dir.glob(path)
+      end
       reloadable_apps.each do |app|
         files << app.app_file
         files += Dir.glob(app.app_obj.prerequisites)

--- a/padrino-core/test/fixtures/apps/custom_dependencies/custom_dependencies.rb
+++ b/padrino-core/test/fixtures/apps/custom_dependencies/custom_dependencies.rb
@@ -1,0 +1,11 @@
+PADRINO_ROOT = File.dirname(__FILE__) unless defined? PADRINO_ROOT
+
+class CustomDependencies < Padrino::Application
+  set :reload, true
+end
+
+CustomDependencies.controllers do
+  get "/" do
+    "foo"
+  end
+end

--- a/padrino-core/test/test_reloader_system.rb
+++ b/padrino-core/test/test_reloader_system.rb
@@ -2,6 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/helper')
 require File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/kiq')
 require File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/system')
 require File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/static')
+require File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/custom_dependencies/custom_dependencies')
 
 describe "SystemReloader" do
   describe 'for wierd and difficult reload events' do
@@ -118,6 +119,25 @@ describe "SystemReloader" do
       get '/'
       FileUtils.touch File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/stealthy/helpers/stealthy_class_helpers.rb')
       Padrino.reload!
+    end
+  end
+
+  describe 'reloading custom dependencies' do
+    let(:custom_dependency_path) { File.dirname(__FILE__) + '/fixtures/apps/custom_dependencies/my_dependencies' }
+    let(:custom_dependency) { File.join(custom_dependency_path, 'my_dependency.rb') }
+
+    before do
+      @app = CustomDependencies
+      Padrino.clear!
+      Padrino.mount(CustomDependencies).to("/")
+      Padrino.dependency_paths << custom_dependency_path + '/*.rb'
+      Padrino.load!
+      get '/'
+    end
+
+    it 'should discover changed dependencies' do
+      FileUtils.touch(custom_dependency)
+      assert Padrino::Reloader.changed?, 'Change to custom dependency has not been recognised'
     end
   end
 end


### PR DESCRIPTION
As explained in #1920 the method in the guides for adding custom dependency paths to reload doesn't currently work as expected.

This PR makes use of both the default dependency paths and the custom dependency paths in the reloader.