### PR TITLE
Method mistake

### DIFF
--- a/padrino-docs/guides/blog-tutorial.md
+++ b/padrino-docs/guides/blog-tutorial.md
@@ -204,7 +204,7 @@ We’ll want to attached some of the standard routes (:index and :show) to the c
     # app/controllers/posts.rb
     SampleBlog::App.controllers :posts do
       get :index do
-        @posts = Post.all(:order => 'created_at desc')
+        @posts = Post.all
         render 'posts/index'
       end
       

--- a/padrino-docs/guides/blog-tutorial.md
+++ b/padrino-docs/guides/blog-tutorial.md
@@ -204,7 +204,7 @@ We’ll want to attached some of the standard routes (:index and :show) to the c
     # app/controllers/posts.rb
     SampleBlog::App.controllers :posts do
       get :index do
-        @posts = Post.all
+        @posts = Post.order(created_at: :desc)
         render 'posts/index'
       end
       


### PR DESCRIPTION
In the latest ActiveRecord. There is no arguments for the method 'all'.
I have just follow the docs like @posts = Post.all(:order => "created_at DESC"). There is a exception that wrong number of arguments (1 for 0) of the method 'all'.