### PR TITLE
More inteligent running of test tasks

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/bacon.rb
@@ -33,22 +33,6 @@ describe "!PATH!" do
 end
 TEST
 
-BACON_RAKE = (<<-TEST).gsub(/^ {10}/, '') unless defined?(BACON_RAKE)
-require 'rake/testtask'
-
-test_tasks = Dir['test/*/'].map { |d| File.basename(d) }
-
-test_tasks.each do |folder|
-  Rake::TestTask.new("test:\#{folder}") do |test|
-    test.pattern = "test/\#{folder}/**/*_test.rb"
-    test.verbose = true
-  end
-end
-
-desc "Run application test suite"
-task 'test' => test_tasks.map { |f| "test:\#{f}" }
-TEST
-
 BACON_MODEL_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(BACON_MODEL_TEST)
 require File.expand_path(File.dirname(__FILE__) + '!PATH!/test_config.rb')
 
@@ -79,7 +63,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'bacon', :group => 'test'
   insert_test_suite_setup BACON_SETUP, :path => 'test/test_config.rb'
-  create_file destination_root("test/test.rake"), BACON_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:test)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path)

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/cucumber.rb
@@ -82,5 +82,5 @@ def setup_test
   create_file destination_root("cucumber.yml"), CUCUMBER_YML
   require_dependencies 'rspec', :group => 'test'
   insert_test_suite_setup RSPEC_SETUP, :path => "spec/spec_helper.rb"
-  create_file destination_root("spec/spec.rake"), RSPEC_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:spec)\n", :before => 'PadrinoTasks.init')
 end

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
@@ -22,22 +22,6 @@ class MiniTest::Spec
 end
 TEST
 
-MINITEST_RAKE = (<<-TEST).gsub(/^ {10}/, '') unless defined?(MINITEST_RAKE)
-require 'rake/testtask'
-
-test_tasks = Dir['test/*/'].map { |d| File.basename(d) }
-
-test_tasks.each do |folder|
-  Rake::TestTask.new("test:\#{folder}") do |test|
-    test.pattern = "test/\#{folder}/**/*_test.rb"
-    test.verbose = true
-  end
-end
-
-desc "Run application test suite"
-task 'test' => test_tasks.map { |f| "test:\#{f}" }
-TEST
-
 MINITEST_CONTROLLER_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(MINITEST_CONTROLLER_TEST)
 require File.expand_path(File.dirname(__FILE__) + '/../../test_config.rb')
 
@@ -86,7 +70,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'minitest', :require => 'minitest/autorun', :group => 'test'
   insert_test_suite_setup MINITEST_SETUP
-  create_file destination_root("test/test.rake"), MINITEST_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:test)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path)

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/riot.rb
@@ -45,22 +45,6 @@ context "!PATH!" do
 end
 TEST
 
-RIOT_RAKE = (<<-TEST).gsub(/^ {10}/, '') unless defined?(RIOT_RAKE)
-require 'rake/testtask'
-
-test_tasks = Dir['test/*/'].map { |d| File.basename(d) }
-
-test_tasks.each do |folder|
-  Rake::TestTask.new("test:\#{folder}") do |test|
-    test.pattern = "test/\#{folder}/**/*_test.rb"
-    test.verbose = true
-  end
-end
-
-desc "Run application test suite"
-task 'test' => test_tasks.map { |f| "test:\#{f}" }
-TEST
-
 RIOT_MODEL_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(RIOT_MODEL_TEST)
 require File.expand_path(File.dirname(__FILE__) + '!PATH!/test_config.rb')
 
@@ -93,7 +77,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'riot', :group => 'test'
   insert_test_suite_setup RIOT_SETUP
-  create_file destination_root("test/test.rake"), RIOT_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:test)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path)

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -38,29 +38,6 @@ RSpec.describe "!PATH!" do
 end
 TEST
 
-RSPEC_RAKE = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_RAKE)
-begin
-  require 'rspec/core/rake_task'
-
-  spec_tasks = Dir['spec/*/'].each_with_object([]) do |d, result|
-    result << File.basename(d) unless Dir["\#{d}*"].empty?
-  end
-
-  spec_tasks.each do |folder|
-    desc "Run the spec suite in \#{folder}"
-    RSpec::Core::RakeTask.new("spec:\#{folder}") do |t|
-      t.pattern = "./spec/\#{folder}/**/*_spec.rb"
-      t.rspec_opts = "--color"
-    end
-  end
-
-  desc "Run complete application spec suite"
-  task 'spec' => spec_tasks.map { |f| "spec:\#{f}" }
-rescue LoadError
-  puts "RSpec is not part of this bundle, skip specs."
-end
-TEST
-
 RSPEC_MODEL_TEST = (<<-TEST).gsub(/^ {12}/, '') unless defined?(RSPEC_MODEL_TEST)
 require 'spec_helper'
 
@@ -89,7 +66,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'rspec', :group => 'test'
   insert_test_suite_setup RSPEC_SETUP, :path => "spec/spec_helper.rb"
-  create_file destination_root("spec/spec.rake"), RSPEC_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:spec)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path)

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/shoulda.rb
@@ -40,22 +40,6 @@ class !NAME!ControllerTest < Test::Unit::TestCase
 end
 TEST
 
-SHOULDA_RAKE = (<<-TEST).gsub(/^ {10}/, '') unless defined?(SHOULDA_RAKE)
-require 'rake/testtask'
-
-test_tasks = Dir['test/*/'].map { |d| File.basename(d) }
-
-test_tasks.each do |folder|
-  Rake::TestTask.new("test:\#{folder}") do |test|
-    test.pattern = "test/\#{folder}/**/*_test.rb"
-    test.verbose = true
-  end
-end
-
-desc "Run application test suite"
-task 'test' => test_tasks.map { |f| "test:\#{f}" }
-TEST
-
 SHOULDA_MODEL_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(SHOULDA_MODEL_TEST)
 require File.expand_path(File.dirname(__FILE__) + '!PATH!/test_config.rb')
 
@@ -90,7 +74,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'shoulda', :group => 'test'
   insert_test_suite_setup SHOULDA_SETUP
-  create_file destination_root("test/test.rake"), SHOULDA_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:test)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path = nil)

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/steak.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/steak.rb
@@ -46,22 +46,6 @@ feature "!PATH!" do
 end
 TEST
 
-STEAK_RAKE = (<<-TEST).gsub(/^ {12}/, '') unless defined?(STEAK_RAKE)
-require 'rspec/core/rake_task'
-
-spec_tasks = Dir['spec/*/'].map { |d| File.basename(d) }
-
-spec_tasks.each do |folder|
-  RSpec::Core::RakeTask.new("spec:\#{folder}") do |t|
-    t.pattern = "./spec/\#{folder}/**/*_spec.rb"
-    t.rspec_opts = %w(-fs --color)
-  end
-end
-
-desc "Run complete application spec suite"
-task 'spec' => spec_tasks.map { |f| "spec:\#{f}" }
-TEST
-
 STEAK_MODEL_TEST = (<<-TEST).gsub(/^ {12}/, '') unless defined?(STEAK_MODEL_TEST)
 require 'spec_helper'
 
@@ -87,7 +71,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'steak', :group => 'test'
   insert_test_suite_setup STEAK_SETUP, :path => "spec/spec_helper.rb"
-  create_file destination_root("spec/spec.rake"), STEAK_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:spec)\n", :before => 'PadrinoTasks.init')
 end
 
 # Generates a controller test given the controllers name

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/testunit.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/testunit.rb
@@ -22,22 +22,6 @@ class Test::Unit::TestCase
 end
 TEST
 
-TESTUNIT_RAKE = (<<-TEST).gsub(/^ {10}/, '') unless defined?(TESTUNIT_RAKE)
-require 'rake/testtask'
-
-test_tasks = Dir['test/*/'].map { |d| File.basename(d) }
-
-test_tasks.each do |folder|
-  Rake::TestTask.new("test:\#{folder}") do |test|
-    test.pattern = "test/\#{folder}/**/*_test.rb"
-    test.verbose = true
-  end
-end
-
-desc "Run application test suite"
-task 'test' => test_tasks.map { |f| "test:\#{f}" }
-TEST
-
 TESTUNIT_CONTROLLER_TEST = (<<-TEST).gsub(/^ {10}/, '') unless defined?(TESTUNIT_CONTROLLER_TEST)
 require File.expand_path(File.dirname(__FILE__) + '/../../test_config.rb')
 
@@ -86,7 +70,7 @@ def setup_test
   require_dependencies 'rack-test', :require => 'rack/test', :group => 'test'
   require_dependencies 'test-unit', :require => 'test/unit', :group => 'test'
   insert_test_suite_setup TESTUNIT_SETUP
-  create_file destination_root("test/test.rake"), TESTUNIT_RAKE
+  inject_into_file(destination_root('Rakefile'), "PadrinoTasks.use(:test)\n", :before => 'PadrinoTasks.init')
 end
 
 def generate_controller_test(name, path)

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/spec.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/spec.rb
@@ -1,0 +1,30 @@
+if PadrinoTasks.load?(:spec, false)
+  require 'rspec/core/rake_task'
+  require 'padrino-gen/padrino-tasks/test-helpers'
+
+  app_tasks = Padrino::Generators::TestHelpers.app_tasks(Padrino::Generators::TestHelpers.spec_glob)
+  app_tasks.each do |app, tests|
+    tests.each do |name, folder|
+      desc "Run specs in #{folder}"
+      RSpec::Core::RakeTask.new("spec:#{name}") do |t|
+        t.pattern = Padrino::Generators::TestHelpers.spec_glob(folder)
+        t.verbose = true
+      end
+    end
+
+    next unless app && app != 'app'
+
+    desc "Run all the specs for the #{app} app"
+    RSpec::Core::RakeTask.new("spec:#{app}") do |t|
+      t.pattern = Padrino::Generators::TestHelpers.spec_glob("spec/#{app}")
+      t.verbose = true
+    end
+  end
+
+  desc 'Run application test suite'
+  RSpec::Core::RakeTask.new do |t|
+    t.verbose = true
+  end
+
+  task :default => 'spec'
+end

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/test-helpers.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/test-helpers.rb
@@ -1,0 +1,36 @@
+module Padrino
+  module Generators
+    module TestHelpers
+      def self.spec_glob(root = 'spec')
+        "#{root}/**/*_spec.rb"
+      end
+
+      def self.test_glob(root = 'test')
+        "#{root}/**/*_test.rb"
+      end
+
+      def self.app_tasks(glob)
+        app_tasks = Hash.new { |apps, name| apps[name] = [] }
+
+        Dir[glob].each do |path|
+          dirs = path.split('/')
+          app = nil
+          if dirs[2].end_with?('.rb') && File.file?(path)
+            app = 'app'
+            name = dirs[1]
+          else
+            app = dirs[1]
+            name = app == 'app' ? dirs[2] : "#{dirs[1]}:#{dirs[2]}"
+          end
+
+          test = [ name, File.dirname(path) ]
+          next if app_tasks[app].include?(test)
+
+          app_tasks[app] << test
+        end
+
+        app_tasks
+      end
+    end
+  end
+end

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/test.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/test.rb
@@ -1,0 +1,31 @@
+if PadrinoTasks.load?(:test, false)
+  require 'rake/testtask'
+  require 'padrino-gen/padrino-tasks/test-helpers'
+
+  app_tasks = Padrino::Generators::TestHelpers.app_tasks(Padrino::Generators::TestHelpers.test_glob)
+  app_tasks.each do |app, tests|
+    tests.each do |name, folder|
+      Rake::TestTask.new("test:#{name}") do |t|
+        t.description = "Run tests in #{folder}"
+        t.pattern = Padrino::Generators::TestHelpers.test_glob(folder)
+        t.verbose = true
+      end
+    end
+
+    next unless app && app != 'app'
+
+    Rake::TestTask.new("test:#{app}") do |t|
+      t.description = "Run all the tests for the #{app} app"
+      t.pattern = Padrino::Generators::TestHelpers.test_glob("test/#{app}")
+      t.verbose = true
+    end
+  end
+
+  Rake::TestTask.new do |t|
+    t.description = 'Run application test suite'
+    t.pattern = Padrino::Generators::TestHelpers.test_glob
+    t.verbose = true
+  end
+
+  task :default => 'test'
+end

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -541,9 +541,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'bacon'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/Bacon::Context/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/Rake::TestTask.new\("test:\#/,"#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/task 'test' => test_tasks/,"#{@apptmp}/sample_project/test/test.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:test\)/,"#{@apptmp}/sample_project/Rakefile")
     end
 
     it 'should properly generate for riot' do
@@ -558,9 +557,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/Riot::Situation/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/Riot::Context/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/SampleProject::App\.tap/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/Rake::TestTask\.new\("test:\#/,"#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/task 'test' => test_tasks/,"#{@apptmp}/sample_project/test/test.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:test\)/,"#{@apptmp}/sample_project/Rakefile")
     end
 
     it 'should properly generate for rspec' do
@@ -572,9 +570,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'rspec'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/spec/spec_helper.rb")
       assert_match_in_file(/RSpec.configure/, "#{@apptmp}/sample_project/spec/spec_helper.rb")
-      assert_file_exists("#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/RSpec::Core::RakeTask\.new\("spec:\#/,"#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/task 'spec' => spec_tasks/,"#{@apptmp}/sample_project/spec/spec.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:spec\)/,"#{@apptmp}/sample_project/Rakefile")
     end
 
     it 'should properly generate for shoulda' do
@@ -586,9 +583,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'shoulda'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/Test::Unit::TestCase/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/Rake::TestTask\.new\("test:\#/,"#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/task 'test' => test_tasks/,"#{@apptmp}/sample_project/test/test.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:test\)/,"#{@apptmp}/sample_project/Rakefile")
     end
 
     it 'should properly generate for steak' do
@@ -600,9 +596,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'steak'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/spec/spec_helper.rb")
       assert_match_in_file(/RSpec.configure/, "#{@apptmp}/sample_project/spec/spec_helper.rb")
-      assert_file_exists("#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/RSpec::Core::RakeTask\.new\("spec:\#/,"#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/task 'spec' => spec_tasks/,"#{@apptmp}/sample_project/spec/spec.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:spec\)/,"#{@apptmp}/sample_project/Rakefile")
     end
 
     it 'should properly generate for minitest' do
@@ -616,9 +611,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/MiniTest::Spec/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/SampleProject::App\.tap/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/Rake::TestTask\.new\("test:\#/,"#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/task 'test' => test_tasks/,"#{@apptmp}/sample_project/test/test.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:test\)/,"#{@apptmp}/sample_project/Rakefile")
     end # minitest
 
     it 'should properly generate for cucumber' do
@@ -635,9 +629,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/RSpec.configure/, "#{@apptmp}/sample_project/spec/spec_helper.rb")
       assert_match_in_file(/Capybara.app = /, "#{@apptmp}/sample_project/features/support/env.rb")
       assert_match_in_file(/World\(Cucumber::Web::URLs\)/, "#{@apptmp}/sample_project/features/support/url.rb")
-      assert_file_exists("#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/RSpec::Core::RakeTask\.new\("spec:\#/,"#{@apptmp}/sample_project/spec/spec.rake")
-      assert_match_in_file(/task 'spec' => spec_tasks/,"#{@apptmp}/sample_project/spec/spec.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:spec\)/,"#{@apptmp}/sample_project/Rakefile")
       assert_file_exists("#{@apptmp}/sample_project/features/support/env.rb")
       assert_file_exists("#{@apptmp}/sample_project/features/add.feature")
       assert_file_exists("#{@apptmp}/sample_project/features/step_definitions/add_steps.rb")
@@ -762,8 +755,8 @@ describe "ProjectGenerator" do
       assert_match_in_file(/:group => 'test'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/gem 'test-unit'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
-      assert_match_in_file(/task 'test' => test_tasks/,"#{@apptmp}/sample_project/test/test.rake")
+      assert_file_exists("#{@apptmp}/sample_project/Rakefile")
+      assert_match_in_file(/PadrinoTasks.use\(:test\)/,"#{@apptmp}/sample_project/Rakefile")
       assert_match_in_file(/Dir\[File\.expand_path\(File\.dirname\(__FILE__\) \+ "\/\.\.\/app\/helpers\.rb"\)\]\.each\(&method\(:require\)\)/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/class ControllerTest < Test::Unit::TestCase/, "#{@apptmp}/sample_project/test/app/controllers/controllers_test.rb")
       assert_match_in_file(/class SampleProject::App::HelperTest < Test::Unit::TestCase/, "#{@apptmp}/sample_project/test/app/helpers/helpers_test.rb")


### PR DESCRIPTION
Related to #1937 and #1979.

Let me know what you think. I do have some issues with things [like this](https://github.com/sshaw/padrino-framework/commit/5819dc59e4fc1a99b7ce50355d706f5653fcb3c7#diff-f49a3333f04dffd6f9f9323eceee4151R1).  I Just piggybacked on it as  poor man's way to avoid two sets of test tasks but, in the case of the DB tasks, why is it needed?

For minitest, since the spec format is being used (but also see #1828), I think the task should look for `*_spec.rb` files and maybe the same goes for bacon, but I left then as is to minimize and future impact. 

In summary:

This generates test tasks based on the presence of test files
and groups tasks by subapp (apps named "app" are ignored).

Previously, everything under the test directory was added
as an individual test task, which resulted in N invocations
of `rake test`, often times on directories that had no tests (e.g.,
support or factory files).

Additional changes, note that these should only affect new projects:

1. `{test,spec}/*.rake` is no longer generated. Instead, a modification to
the project's Rakefile is made to call `PadrinoTasks.use(:xxx)`. This
seems to be more in line with Padrino methodology (starting at v0.11 I
think).

2. The default rake task will be the test (or spec) task.