### PR TITLE
remove ActiveSupport dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source 'https://rubygems.org'
 
 if ENV["AS_VERSION"]
   gem 'activesupport', "~> #{ENV['AS_VERSION']}"
-else
-  if RUBY_VERSION < "2.2.2"
-    gem 'activesupport', "< 5.0.0", :group => :development
-  end
 end
 
 if ENV["SINATRA_VERSION"]

--- a/padrino-admin/lib/padrino-admin/generators/templates/app.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/app.rb.tt
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/string/inflections'
 
 module <%= @app_name %>
   class <%= @admin_name %> < Padrino::Application

--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency("sinatra", ">= 1.4.6")
   s.add_dependency("mustermann19")
   s.add_dependency("thor", "~> 0.18")
-  s.add_dependency("activesupport", ">= 3.1")
   s.add_dependency("rack-protection", ">= 1.5.0")
 end

--- a/padrino-support/lib/padrino-support.rb
+++ b/padrino-support/lib/padrino-support.rb
@@ -1,28 +1,10 @@
 ##
-# This file loads certain extensions required by Padrino from ActiveSupport.
+# This file loads certain extensions required by Padrino.
 #
-
-# Remove these on 0.14:
-require 'active_support/core_ext/string/output_safety'      # SafeBuffer and html_safe
-require 'active_support/core_ext/object/blank'              # present?
-require 'active_support/core_ext/hash/keys'                 # symbolize_keys
-require 'active_support/core_ext/hash/indifferent_access'   # params[:foo]
-require 'active_support/core_ext/hash/reverse_merge'        # reverse_merge
-require 'active_support/core_ext/module/aliasing'           # alias_method_chain
-require 'active_support/core_ext/array/extract_options'     # Array#extract_options!
-require 'active_support/core_ext/hash/slice'                # slice
-begin
-  require 'active_support/core_ext/object/deep_dup' # AS 4.1
-rescue LoadError
-  require 'active_support/core_ext/hash/deep_dup' # AS >= 3.1
-end
-
-
 require 'padrino-support/core_ext/string/colorize'
 require 'padrino-support/core_ext/object_space'
 require 'padrino-support/file_set'
 require 'padrino-support/utils'
-
 
 ##
 # Loads our locale configuration files

--- a/padrino-support/padrino-support.gemspec
+++ b/padrino-support/padrino-support.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
-
-  s.add_dependency("activesupport", ">= 3.1")
 end


### PR DESCRIPTION
480f60bd finally moved activesupport to padrino-admin generator

A bit of discussion lost here: da9b80f732a5951e6541cc46dd2267809f513d30

This PR is only to be reviewed and not to be merged until a couple of bugfix releases in 0.13 branch. I think it can be merged to version 0.14.
