### PR TITLE
Only output a warning message if the spec task is invoked.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/rspec.rb
@@ -57,7 +57,9 @@ begin
   desc "Run complete application spec suite"
   task 'spec' => spec_tasks.map { |f| "spec:\#{f}" }
 rescue LoadError
-  puts "RSpec is not part of this bundle, skip specs."
+  task :spec do
+    puts "RSpec is not part of this bundle, skip specs."
+  end
 end
 TEST
 


### PR DESCRIPTION
This prevents the warning message from being printed when rake tasks are loaded. Excess output is a problem when invoking rake tasks from cronjobs. Any output from a cronjob gets logged and emailed.