### PR TITLE
Match plugin names with dashes

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/plugin.rb
+++ b/padrino-gen/lib/padrino-gen/generators/plugin.rb
@@ -55,7 +55,7 @@ module Padrino
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           http.start do
             http.request_get(uri.path) do |res|
-              plugins = res.body.scan(%r{/plugins/(\w+)_plugin.rb}).uniq
+              plugins = res.body.scan(%r{/plugins/(\w+-\w+)_plugin.rb}).uniq
             end
           end
           say "Available plugins:", :green


### PR DESCRIPTION
I was cleaning up the plugins under <https://github.com/padrino/padrino-recipes/tree/master/plugins> and found that the `twitter-login` plugin is not listed when running listing all plugins:

```sh
wm@wm ~ » padrino g plugin -l
Available plugins:
  - ["960"]
  - ["access"]
  - ["ar_permalink_i18n"]
  - ["ar_permalink"]
  - ["ar_textile"]
  - ["ar_translate"]
  - ["auto_locale"]
  - ["barista"]
  - ["better_errors"]
  - ["blueprint"]
  - ["bootstrap"]
  - ["bug"]
  - ["camorra"]
  - ["carrierwave"]
  - ["codehighlighter"]
  - ["coderay"]
  - ["coffee"]
  - ["deflect"]
  - ["disqus"]
  - ["dreamhost"]
  - ["exception_notifier"]
  - ["factory_girl"]
  - ["flash_session"]
  - ["fontawesome"]
  - ["googleanalytics"]
  - ["heroku"]
  - ["hoptoad"]
  - ["jammit"]
  - ["letter_opener"]
  - ["maintenance"]
  - ["omniauth"]
  - ["openid"]
  - ["payment"]
  - ["pry_byebug"]
  - ["pry_debugger"]
  - ["raphaeljs"]
  - ["raphy_charts"]
  - ["recaptcha"]
  - ["resque"]
  - ["rewrite"]
  - ["secure_only"]
  - ["tripoli"]
  - ["vcr"]
  - ["watchr"]
  - ["will_paginate"]
```

It turns out, that the regex getting the plugin names is not allowing dashes in names:

Here is what I mean:

Behavior before:

```ruby
"tree/master/plugins/twitter-login_plugin.rb".scan(%r{/plugins/(\w+)_plugin.rb})
=> []
```

Behavior now:
```ruby
>> "tree/master/plugins/twitter-login_plugin.rb".scan(%r{/plugins/(\w+-\w+)_plugin.rb})
=> [["twitter-login"]]
```

I tried to write a test for this issue, but found in too hard to test `thor` actions.

Cheers Matthias