### PR TITLE
Use Module#name instead of Module#to_s, fixes #2026

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -74,7 +74,8 @@ module Padrino
     #
     def lock!
       klasses = Storage.send(:object_classes) do |klass|
-        klass._orig_klass_name.split('::').first
+        original_klass_name = klass._orig_klass_name
+        original_klass_name.split('::').first if original_klass_name
       end
       klasses |= Padrino.mounted_apps.map(&:app_class)
       exclude_constants.merge(klasses)

--- a/padrino-support/lib/padrino-support.rb
+++ b/padrino-support/lib/padrino-support.rb
@@ -30,5 +30,5 @@ end
 # In reloader for accessing class_name Foo._orig_klass_name
 #
 class Module
-  alias :_orig_klass_name :to_s
+  alias :_orig_klass_name :name
 end


### PR DESCRIPTION
#2026 
In Ruby-2.3, `Module#_orig_klass_name` will call `ActiveRecord::Base#inspect` on handling `Delayed::Backend::ActiveRecord::Job`.
We can avoid calling that by using `Module#name` instead.

If this approach is reasonable, we should backport this branch into 0.12.x branch.