### PR TITLE
Don't set a value attribute on label tags

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -33,6 +33,8 @@ module Padrino
         def label(field, options={}, &block)
           options[:id] ||= nil
           options[:caption] ||= I18n.t("#{model_name}.attributes.#{field}", :count => 1, :default => field.to_s.humanize, :scope => :models) + ': '
+          # Prevent default_options from adding a value attribute to label
+          options[:value] = nil
           @template.label_tag(field_id(field), default_options(field, options), &block)
         end
 


### PR DESCRIPTION
A value attribute on a label tag is invalid. 

Not the biggest fan of the fix but since the function is already modifying the caller's hash it's the least invasive option...