### PR TITLE
Don't set a value attribute on label tags

### DIFF
--- a/padrino-helpers/lib/padrino-helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers.rb
@@ -6,7 +6,6 @@ require 'active_support/core_ext/string/conversions'  # to_date
 require 'active_support/option_merger'                # with_options
 require 'active_support/core_ext/object/with_options' # with_options
 require 'active_support/inflector'                    # humanize
-require 'active_support/core_ext/hash/except'         # Hash#except
 require 'padrino/rendering'
 
 FileSet.glob_require('padrino-helpers/**/*.rb', __FILE__)

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -37,7 +37,9 @@ module Padrino
         def label(field, options={}, &block)
           options[:id] ||= nil
           options[:caption] ||= I18n.t("#{model_name}.attributes.#{field}", :count => 1, :default => field.to_s.humanize, :scope => :models) + ': '
-          @template.label_tag(field_id(field), default_options(field, options).except(:value), &block)
+          defaults = default_options(field, options)
+          defaults.delete(:value)
+          @template.label_tag(field_id(field), defaults, &block)
         end
 
         def hidden_field(field, options={})
@@ -110,7 +112,9 @@ module Padrino
 
         def file_field(field, options={})
           self.multipart = true
-          @template.file_field_tag field_name(field), default_options(field, options).except(:value)
+          defaults = default_options(field, options)
+          defaults.delete(:value)
+          @template.file_field_tag field_name(field), defaults
         end
 
         def submit(*args)

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -37,7 +37,7 @@ module Padrino
         def label(field, options={}, &block)
           options[:id] ||= nil
           options[:caption] ||= I18n.t("#{model_name}.attributes.#{field}", :count => 1, :default => field.to_s.humanize, :scope => :models) + ': '
-          @template.label_tag(field_id(field), default_options(field, options), &block)
+          @template.label_tag(field_id(field), default_options(field, options).except(:value), &block)
         end
 
         def hidden_field(field, options={})

--- a/padrino-helpers/lib/padrino-helpers/form_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_helpers.rb
@@ -45,7 +45,9 @@ module Padrino
         instance = builder_instance(object, options)
         # this can erect instance.multipart flag if the block calls instance.file_field
         html = capture_html(instance, &block)
-        options = { :multipart => instance.multipart }.update(options.except(:namespace, :as))
+        options = { :multipart => instance.multipart }.update(options)
+        options.delete(:as)
+        options.delete(:namespace)
         form_tag(url, options) { html }
       end
 


### PR DESCRIPTION
A value attribute on a label tag is invalid.

Not the biggest fan of the fix but since the function is already modifying the caller's hash ~~it's the least invasive option...~~ **UPDATE** just used `#update` instead of adding `:value => nil` to the caller's hash.