### PR TITLE
add project component initializers

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -377,9 +377,9 @@ WARNING
       #
       def initializer(name, data=nil)
         @_init_name, @_init_data = name, data
-        register = data.present? ? "    register #{name.to_s.underscore.camelize}Initializer\n" : "    register #{name}\n"
+        register = data ? "    register #{name.to_s.underscore.camelize}Initializer\n" : "    register #{name}\n"
         inject_into_file destination_root("/app/app.rb"), register, :after => "Padrino::Application\n"
-        template "templates/initializer.rb.tt", destination_root("/lib/#{name}_initializer.rb") if data.present?
+        template "templates/initializer.rb.tt", destination_root("/config/initializers/#{name}.rb") if data
       end
 
       ##

--- a/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/stylesheets/compass.rb
@@ -1,10 +1,7 @@
 COMPASS_INIT = <<-COMPASS unless defined?(COMPASS_INIT)
-# Enables support for Compass, a stylesheet authoring framework based on SASS.
-# See http://compass-style.org/ for more details.
-# Store Compass/SASS files (by default) within 'app/stylesheets'.
-
-module CompassInitializer
-  def self.registered(app)
+    # Enables support for Compass, a stylesheet authoring framework based on SASS.
+    # See http://compass-style.org/ for more details.
+    # Store Compass/SASS files (by default) within 'app/stylesheets'.
     require 'sass/plugin/rack'
 
     Compass.configuration do |config|
@@ -22,18 +19,10 @@ module CompassInitializer
     Compass.handle_configuration_change!
 
     app.use Sass::Plugin::Rack
-  end
-end
 COMPASS
-
-COMPASS_REGISTER = <<-COMPASSR unless defined?(COMPASS_REGISTER)
-    register CompassInitializer\n
-COMPASSR
 
 def setup_stylesheet
   require_dependencies 'compass-blueprint'
-  create_file destination_root('/lib/compass_plugin.rb'), COMPASS_INIT
-  inject_into_file destination_root('/app/app.rb'), COMPASS_REGISTER, :after => "register Padrino::Helpers\n"
-
+  initializer :compass, COMPASS_INIT.chomp
   directory "components/stylesheets/compass/", destination_root('/app/stylesheets')
 end

--- a/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project/config/boot.rb
@@ -35,7 +35,14 @@ Bundler.require(:default, RACK_ENV)
 # end
 
 ##
+# Require initializers before all other dependencies.
+# Dependencies from 'config' folder are NOT re-required on reload.
+#
+Padrino.dependency_paths.unshift Padrino.root('config/initializers/*.rb')
+
+##
 # Add your before (RE)load hooks here
+# These hooks are run before any dependencies are required.
 #
 Padrino.before_load do
 end

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -92,7 +92,7 @@ class MiniTest::Spec
   # expects_initializer :test, "# Example"
   def expects_initializer(name, body,options={})
     #options.reverse_merge!(:root => "/tmp/sample_project")
-    path = File.join(options[:root],'lib',"#{name}_initializer.rb")
+    path = File.join(options[:root],'config/initializers',"#{name}.rb")
     instance = mock
     instance.expects(:invoke!).at_least_once
     include_text = "    register #{name.to_s.camelize}Initializer\n"

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -648,7 +648,7 @@ describe "ProjectGenerator" do
     it 'should properly generate for sass' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=haml','--script=none','--stylesheet=sass') }
       assert_match_in_file(/gem 'sass'/, "#{@apptmp}/sample_project/Gemfile")
-      assert_match_in_file(/module SassInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/lib/sass_initializer.rb")
+      assert_match_in_file(/module SassInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/config/initializers/sass.rb")
       assert_match_in_file(/register SassInitializer/m, "#{@apptmp}/sample_project/app/app.rb")
       assert_dir_exists("#{@apptmp}/sample_project/app/stylesheets")
     end
@@ -656,7 +656,7 @@ describe "ProjectGenerator" do
     it 'should properly generate for less' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=haml','--script=none','--stylesheet=less') }
       assert_match_in_file(/gem 'rack-less'/, "#{@apptmp}/sample_project/Gemfile")
-      assert_match_in_file(/module LessInitializer.*Rack::Less/m, "#{@apptmp}/sample_project/lib/less_initializer.rb")
+      assert_match_in_file(/module LessInitializer.*Rack::Less/m, "#{@apptmp}/sample_project/config/initializers/less.rb")
       assert_match_in_file(/register LessInitializer/m, "#{@apptmp}/sample_project/app/app.rb")
       assert_dir_exists("#{@apptmp}/sample_project/app/stylesheets")
     end
@@ -664,8 +664,8 @@ describe "ProjectGenerator" do
     it 'should properly generate for compass' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=haml','--script=none','--stylesheet=compass') }
       assert_match_in_file(/gem 'compass-blueprint'/, "#{@apptmp}/sample_project/Gemfile")
-      assert_match_in_file(/Compass.configure_sass_plugin\!/, "#{@apptmp}/sample_project/lib/compass_plugin.rb")
-      assert_match_in_file(/module CompassInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/lib/compass_plugin.rb")
+      assert_match_in_file(/Compass.configure_sass_plugin\!/, "#{@apptmp}/sample_project/config/initializers/compass.rb")
+      assert_match_in_file(/module CompassInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/config/initializers/compass.rb")
       assert_match_in_file(/register CompassInitializer/m, "#{@apptmp}/sample_project/app/app.rb")
 
       assert_file_exists("#{@apptmp}/sample_project/app/stylesheets/application.scss")
@@ -675,8 +675,8 @@ describe "ProjectGenerator" do
     it 'should properly generate for scss' do
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=haml','--script=none','--stylesheet=scss') }
       assert_match_in_file(/gem 'haml'/, "#{@apptmp}/sample_project/Gemfile")
-      assert_match_in_file(/module ScssInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/lib/scss_initializer.rb")
-      assert_match_in_file(/Sass::Plugin.options\[:syntax\] = :scss/m, "#{@apptmp}/sample_project/lib/scss_initializer.rb")
+      assert_match_in_file(/module ScssInitializer.*Sass::Plugin::Rack/m, "#{@apptmp}/sample_project/config/initializers/scss.rb")
+      assert_match_in_file(/Sass::Plugin.options\[:syntax\] = :scss/m, "#{@apptmp}/sample_project/config/initializers/scss.rb")
       assert_match_in_file(/register ScssInitializer/m, "#{@apptmp}/sample_project/app/app.rb")
       assert_dir_exists("#{@apptmp}/sample_project/app/stylesheets")
     end


### PR DESCRIPTION
This PR adds the code that requires `config/initializers/*.rb` before any other project files.

Right now the structure of an initializer (like Sass) is this:

```ruby
# code run once after Padrino.before_load before Padrino.after_load
# good place to define some plugin-related constants
module CertainInitializer
  def self.registered(app)
    # code run on application `register CertainInitializer`
    # this code is run every time `app.rb` is reloaded
  end
end
```

The second part involving `self.registered` could be safely reloaded if we want but this would require placing initializers in `lib/plugins` folder. If we do this we would not have any more 'run-once' code and it would probably be not an initializer by itself any more.

What would be more useful for development: a run-once initializer (in `config`) or a reloadable plugin (in `lib`)?

Reference: #1926