### PR TITLE
Do not override access control object when Padrino::Admin::AccessControl is registered in multiple apps

### DIFF
--- a/padrino-admin/lib/padrino-admin/access_control.rb
+++ b/padrino-admin/lib/padrino-admin/access_control.rb
@@ -20,16 +20,14 @@ module Padrino
           app.helpers Padrino::Admin::Helpers::ViewHelpers
           app.before { login_required }
           app.class_eval do
+            class << self
+              attr_accessor :access_control
+            end
             def access_control
-              @@access_control
-            end
-            def self.access_control
-              @@access_control
-            end
-            def self.access_control=(control)
-              @@access_control = control
+              self.class.access_control
             end
           end
+
           app.send(:access_control=, Padrino::Admin::AccessControl::Base.new)
         end
         alias :included :registered


### PR DESCRIPTION
Since 0.13.2 When Padrino::Admin::AccessControl registered in multiple apps, they all share the same AccessControl::Base object instance, based on app loading order.

Such behavior looks incorrect, because access rules are defined per app, and paths are being checked relative to specific app mount point.

This patch fixes this problem.