### PR TITLE
fix #1785 for ERB and Erubis

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/output_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers.rb
@@ -80,7 +80,7 @@ module Padrino
       #
       def concat_content(text="")
         if handler = find_proper_handler
-          handler.concat_to_template(text)
+          handler.concat_to_template(text, binding)
         else
           text
         end

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/abstract_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/abstract_handler.rb
@@ -46,7 +46,7 @@ module Padrino
         # @example
         #   @handler.concat_to_template("This will be output to the template buffer")
         #
-        def concat_to_template(text="")
+        def concat_to_template(text="", context=nil)
           text
         end
 

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
@@ -8,7 +8,8 @@ module Padrino
         ##
         # Outputs the given text to the templates buffer directly.
         #
-        def concat_to_template(text="")
+        def concat_to_template(text="", context=nil)
+          return text if context && context.eval("@__in_ruby_literal")
           output_buffer << text
           nil
         end

--- a/padrino-helpers/lib/padrino/rendering/erb_template.rb
+++ b/padrino-helpers/lib/padrino/rendering/erb_template.rb
@@ -1,6 +1,18 @@
 module Padrino
   module Rendering
     class SafeERB < ::ERB
+      class Compiler < ::ERB::Compiler
+        def add_insert_cmd(out, content)
+          out.push("@__in_ruby_literal = true")
+          super
+          out.push("@__in_ruby_literal = false")
+        end
+      end
+
+      def make_compiler(trim_mode)
+        Compiler.new(trim_mode)
+      end
+
       def set_eoutvar(compiler, eoutvar = '_erbout')
         compiler.put_cmd = "#{eoutvar}.safe_concat"
         compiler.insert_cmd = "#{eoutvar}.concat"

--- a/padrino-helpers/lib/padrino/rendering/erubis_template.rb
+++ b/padrino-helpers/lib/padrino/rendering/erubis_template.rb
@@ -7,7 +7,7 @@ module Padrino
     # @api private
     module SafeBufferEnhancer
       def add_expr_literal(src, code)
-        src << " #{@bufvar}.concat((" << code << ').to_s);'
+        src << " @__in_ruby_literal = true; #{@bufvar}.concat((" << code << ').to_s); @__in_ruby_literal = false;'
       end
 
       def add_stmt(src, code)

--- a/padrino-helpers/test/test_render_helpers.rb
+++ b/padrino-helpers/test/test_render_helpers.rb
@@ -216,7 +216,6 @@ describe "RenderHelpers" do
   describe 'rendering with helpers that use render' do
     %W{erb haml slim}.each do |engine|
       it "should work with #{engine}" do
-        skip
         visit "/double_dive_#{engine}"
         assert_have_selector '.outer .wrapper form .inner .core'
       end


### PR DESCRIPTION
Please review.

Also it would be great if we could avoid passing context binding to `#concat_to_template`.