### PR TITLE
Prevent overwriting params by given query

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -983,7 +983,12 @@ module Padrino
         @route = request.route_obj = route
         captured_params = captures_from_params(params)
 
-        @params.merge!(params) { |key, original, newval| original } unless params.empty?
+        # Should not overwrite params by given query
+        @params.merge!(params) do |key, original, newval|
+          key = key.to_sym
+          @route.significant_variable_names.include?(key) ? newval : original
+        end unless params.empty?
+
         @params[:format] = params[:format] if params[:format]
         @params[:captures] = captured_params if !captured_params.empty? && route.path.is_a?(Regexp)
 

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -539,7 +539,7 @@ module Padrino
           route.default_values = defaults if defaults
         end
         options.delete_if do |option, captures|
-          if route.significant_variable_names.include?(option)
+          if route.significant_variable_names.include?(option.to_s)
             route.capture[option] = Array(captures).first
             true
           end
@@ -985,7 +985,6 @@ module Padrino
 
         # Should not overwrite params by given query
         @params.merge!(params) do |key, original, newval|
-          key = key.to_sym
           @route.significant_variable_names.include?(key) ? newval : original
         end unless params.empty?
 

--- a/padrino-core/lib/padrino-core/path_router/route.rb
+++ b/padrino-core/lib/padrino-core/path_router/route.rb
@@ -63,9 +63,9 @@ module Padrino
       def significant_variable_names
         @significant_variable_names ||=
           if @path.is_a?(String)
-            @path.scan(SIGNIFICANT_VARIABLES_REGEX).map{ |p| p.last.to_sym }
+            @path.scan(SIGNIFICANT_VARIABLES_REGEX).map(&:last)
           elsif @path.is_a?(Regexp) and @path.respond_to?(:named_captures)
-            @path.named_captures.keys.map(&:to_sym)
+            @path.named_captures.keys
           else
             []
           end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2403,4 +2403,14 @@ describe "Routing" do
     get '/update/1?product[title]=test'
     assert_equal 'test==test', body
   end
+
+  it "prevent overwriting params by given query" do
+    mock_app do
+      get '/prohibit/:id' do
+        params[:id]
+      end
+    end
+    get '/prohibit/123?id=456'
+    assert_equal '123', body
+  end
 end


### PR DESCRIPTION
The behavior seems not to overwrite params by given query until 0.13.0.beta2
I think this behavior is a bug, so fixed.
/cc @padrino/core-members  Thoughts?