### PR TITLE
Place upper limit on activesupport version

### DIFF
--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   end
   s.add_dependency("mustermann19")
   s.add_dependency("thor", "~> 0.18")
-  s.add_dependency("activesupport", ">= 3.1")
+  s.add_dependency("activesupport", [">= 3.1", "< 5.0"])
   s.add_dependency("rack-protection", ">= 1.5.0")
 end

--- a/padrino-support/padrino-support.gemspec
+++ b/padrino-support/padrino-support.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
 
-  s.add_dependency("activesupport", ">= 3.1")
+  s.add_dependency("activesupport", [">= 3.1", "< 5.0"])
 end


### PR DESCRIPTION
ActiveSupport 5 has been released, and it breaks the build in older
ruby versions (it requires ruby >= 2.2.2)