### PR TITLE
Update padrino-mailer.gemspec

### DIFF
--- a/padrino-mailer/padrino-mailer.gemspec
+++ b/padrino-mailer/padrino-mailer.gemspec
@@ -24,6 +24,10 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-core", Padrino.version)
-  s.add_dependency("mime-types", "< 3")
+  if RUBY_VERSION >= "2.0"
+    s.add_dependency("mime-types")
+  else
+    s.add_dependency("mime-types", "< 3")
+  end
   s.add_dependency("mail", "~> 2.5")
 end


### PR DESCRIPTION
Allow support for mime-types 3+ if Ruby >= 2.0. Inspiration from Mechanize 2.7.5 gemspec