### PR TITLE
Retire webrat and nokogiri from helper tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ before_install:
 install:
   - bundle update
 rvm:
+  - rbx-2
+  - jruby
+  - jruby-head
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2.2
   - 2.3.1
-  - rbx-2
-  - jruby-9.0.5.0
   - ruby-head
-  - jruby-head
 notifications:
   irc: 'irc.freenode.org#padrino'
   recipients:
@@ -40,8 +40,6 @@ matrix:
       env: STDLIB_ERB=true
     - rvm: 2.1
       env: AS_VERSION=3.2
-    - rvm: jruby
-      env: AS_VERSION=4.2
   allow_failures:
     - rvm: jruby-9.0.5.0
     - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development do
   gem "yard",      ">= 0.7.2"
   gem "rack-test", "~> 0.6.3"
   gem "fakeweb",   ">= 1.2.8"
-  gem "webrat",    ">= 0.5.1"
+  gem "oga",       "~> 2.5"
   gem "haml",      ">= 4.0.5"
   gem "liquid",    ">= 2.1.2"
   if ENV['STDLIB_ERB']

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ if ENV["AS_VERSION"]
   gem 'activesupport', "~> #{ENV['AS_VERSION']}"
 else
   if RUBY_VERSION < "2.2.2"
-    gem 'activesupport', "< 5.0.0", :platform => :mri, :group => :development
+    gem 'activesupport', "< 5.0.0", :group => :development
   end
 end
 

--- a/padrino-admin/test/fixtures/sequel.rb
+++ b/padrino-admin/test/fixtures/sequel.rb
@@ -1,5 +1,6 @@
 require 'digest/sha1'
 require 'sequel'
+require 'sequel/extensions/migration'
 
 Sequel::Model.plugin(:schema)
 
@@ -12,7 +13,6 @@ Sequel::Model.db =
     Sequel.sqlite(":memory:")
   end
 
-Sequel.extension :migration
 migration = Sequel.migration do
   up do
     create_table :accounts do

--- a/padrino-helpers/test/helper.rb
+++ b/padrino-helpers/test/helper.rb
@@ -4,7 +4,6 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require 'mocha/setup'
 require 'rack/test'
-require 'webrat'
 require 'builder'
 require 'padrino-helpers'
 require 'padrino/rendering'
@@ -13,18 +12,14 @@ require 'tilt/builder'
 
 require 'ext/minitest-spec'
 require 'ext/rack-test-methods'
+require 'padrino/test-methods'
 
 class MiniTest::Spec
   include Padrino::Helpers::OutputHelpers
   include Padrino::Helpers::TagHelpers
   include Padrino::Helpers::AssetTagHelpers
   include Rack::Test::Methods
-  include Webrat::Methods
-  include Webrat::Matchers
-
-  Webrat.configure do |config|
-    config.mode = :rack
-  end
+  include Padrino::TestMethods
 
   def stop_time_for_test
     time = Time.now
@@ -78,13 +73,5 @@ class MiniTest::Spec
 
   def app
     Rack::Lint.new(@app)
-  end
-end
-
-module Webrat
-  module Logging
-    def logger # @private
-      @logger = nil
-    end
   end
 end

--- a/padrino-helpers/test/test_asset_tag_helpers.rb
+++ b/padrino-helpers/test/test_asset_tag_helpers.rb
@@ -14,107 +14,109 @@ describe "AssetTagHelpers" do
 
   describe 'for #flash_tag method' do
     it 'should display flash with no given attributes' do
-      assert_has_tag('div.notice', :content => "Demo notice") { flash_tag(:notice) }
+      assert_html_has_tag(flash_tag(:notice), 'div.notice', :content => "Demo notice")
     end
     it 'should display flash with given attributes' do
       actual_html = flash_tag(:notice, :class => 'notice', :id => 'notice-area')
-      assert_has_tag('div.notice#notice-area', :content => "Demo notice") { actual_html }
+      assert_html_has_tag(actual_html, 'div.notice#notice-area', :content => "Demo notice")
     end
     it 'should display multiple flash tags with given attributes' do
       flash[:error] = 'wrong'
       flash[:success] = 'okey'
       actual_html = flash_tag(:success, :warning, :error, :id => 'area')
-      assert_has_tag('div.success#area', :content => flash[:success]) { actual_html }
-      assert_has_tag('div.error#area', :content => flash[:error]) { actual_html }
-      assert_has_no_tag('div.warning') { actual_html }
+      assert_html_has_tag(actual_html, 'div.success#area', :content => flash[:success])
+      assert_html_has_tag(actual_html, 'div.error#area', :content => flash[:error])
+      assert_html_has_no_tag(actual_html, 'div.warning')
     end
   end
 
   describe 'for #link_to method' do
     it 'should display link element with no given attributes' do
-      assert_has_tag('a', :content => "Sign up", :href => '/register') { link_to('Sign up', '/register') }
+      assert_html_has_tag(link_to('Sign up', '/register'), 'a', :content => "Sign up", :href => '/register')
     end
 
     it 'should display link element with given attributes' do
       actual_html = link_to('Sign up', '/register', :class => 'first', :id => 'linky')
-      assert_has_tag('a#linky.first', :content => "Sign up", :href => '/register') { actual_html }
+      assert_html_has_tag(actual_html, 'a#linky.first', :content => "Sign up", :href => '/register')
     end
 
     it 'should display link element with void url and options' do
       actual_link = link_to('Sign up', :class => "test")
-      assert_has_tag('a', :content => "Sign up", :href => '#', :class => 'test') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :content => "Sign up", :href => '#', :class => 'test')
     end
 
     it 'should display link element with remote option' do
       actual_link = link_to('Sign up', '/register', :remote => true)
-      assert_has_tag('a', :content => "Sign up", :href => '/register', 'data-remote' => 'true') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :content => "Sign up", :href => '/register', 'data-remote' => 'true')
     end
 
     it 'should display link element with method option' do
       actual_link = link_to('Sign up', '/register', :method => :delete)
-      assert_has_tag('a', :content => "Sign up", :href => '/register', 'data-method' => 'delete', :rel => 'nofollow') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :content => "Sign up", :href => '/register', 'data-method' => 'delete', :rel => 'nofollow')
     end
 
     it 'should display link element with confirm option' do
       actual_link = link_to('Sign up', '/register', :confirm => "Are you sure?")
-      assert_has_tag('a', :content => "Sign up", :href => '/register', 'data-confirm' => 'Are you sure?') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :content => "Sign up", :href => '/register', 'data-confirm' => 'Are you sure?')
     end
 
     it 'should display link element with ruby block' do
       actual_link = link_to('/register', :class => 'first', :id => 'binky') { "Sign up" }
-      assert_has_tag('a#binky.first', :content => "Sign up", :href => '/register') { actual_link }
+      assert_html_has_tag(actual_link, 'a#binky.first', :content => "Sign up", :href => '/register')
     end
 
     it 'should escape the link text' do
       actual_link = link_to('/register', :class => 'first', :id => 'binky') { "<&>" }
-      assert_has_tag('a#binky.first', :href => '/register') { actual_link }
+      assert_html_has_tag(actual_link, 'a#binky.first', :href => '/register')
       assert_match "&lt;&amp;&gt;", actual_link
     end
 
     it 'should escape the link href' do
       actual_link = link_to('Sign up', '/register new%20user')
-      assert_has_tag('a', :href => '/register%20new%20user') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :href => '/register%20new%20user')
     end
 
     it 'should not escape image_tag' do
       actual_link = link_to(image_tag("/my/fancy/image.png"), :class => 'first', :id => 'binky')
-      assert_has_tag('img', :src => "/my/fancy/image.png") { actual_link }
+      assert_html_has_tag(actual_link, 'img', :src => "/my/fancy/image.png")
     end
 
     it 'should render alt text by default' do
       actual_tag = image_tag("/my/fancy/image.png")
-      assert_has_tag('img', :src => "/my/fancy/image.png", :alt => "Image") { actual_tag }
+      assert_html_has_tag(actual_tag, 'img', :src => "/my/fancy/image.png", :alt => "Image")
+    end
 
+    it 'should render humanized alt text' do
       actual_tag = image_tag("/my/fancy/image_white.png")
-      assert_has_tag('img', :src => "/my/fancy/image_white.png", :alt => "Image white") { actual_tag }
+      assert_html_has_tag(actual_tag, 'img', :src => "/my/fancy/image_white.png", :alt => "Image white")
     end
 
     it 'should remove hash value from src path' do
       actual_tag = image_tag("/my/fancy/sprite-47bce5c74f589f4867dbd57e9ca9f808.png")
-      assert_has_tag('img', :src => "/my/fancy/sprite-47bce5c74f589f4867dbd57e9ca9f808.png", :alt => "Sprite") { actual_tag }
+      assert_html_has_tag(actual_tag, 'img', :src => "/my/fancy/sprite-47bce5c74f589f4867dbd57e9ca9f808.png", :alt => "Sprite")
     end
 
     it 'should display link block element in haml' do
-      visit '/haml/link_to'
-      assert_have_selector :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
-      assert_have_selector :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
+      get "/haml/link_to"
+      assert_response_has_tag :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
+      assert_response_has_tag :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
     end
 
     it 'should display link block element in erb' do
-      visit '/erb/link_to'
-      assert_have_selector :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
-      assert_have_selector :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
+      get "/erb/link_to"
+      assert_response_has_tag :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
+      assert_response_has_tag :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
     end
 
     it 'should display link block element in slim' do
-      visit '/slim/link_to'
-      assert_have_selector :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
-      assert_have_selector :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
+      get "/slim/link_to"
+      assert_response_has_tag :a, :content => "Test 1 No Block", :href => '/test1', :class => 'test', :id => 'test1'
+      assert_response_has_tag :a, :content => "Test 2 With Block", :href => '/test2', :class => 'test', :id => 'test2'
     end
 
     it 'should not double-escape' do
       actual_link = link_to('test escape', '?a=1&b=2')
-      assert_has_tag('a', :href => '?a=1&b=2') { actual_link }
+      assert_html_has_tag(actual_link, 'a', :href => '?a=1&b=2')
       assert_match %r{&amp;}, actual_link
       refute_match %r{&amp;amp;}, actual_link
     end
@@ -128,17 +130,17 @@ describe "AssetTagHelpers" do
   describe 'for #mail_to method' do
     it 'should display link element for mail to no caption' do
       actual_html = mail_to('test@demo.com')
-      assert_has_tag(:a, :href => "mailto:test@demo.com", :content => 'test@demo.com') { actual_html }
+      assert_html_has_tag(actual_html, :a, :href => "mailto:test@demo.com", :content => 'test@demo.com')
     end
 
     it 'should display link element for mail to with caption' do
       actual_html = mail_to('test@demo.com', "My Email", :class => 'demo')
-      assert_has_tag(:a, :href => "mailto:test@demo.com", :content => 'My Email', :class => 'demo') { actual_html }
+      assert_html_has_tag(actual_html, :a, :href => "mailto:test@demo.com", :content => 'My Email', :class => 'demo')
     end
 
     it 'should display link element for mail to with caption and mail options' do
       actual_html = mail_to('test@demo.com', "My Email", :subject => 'demo test', :class => 'demo', :cc => 'foo@test.com')
-      assert_has_tag(:a, :class => 'demo') { actual_html }
+      assert_html_has_tag(actual_html, :a, :class => 'demo')
       assert_match %r{mailto\:test\@demo.com\?}, actual_html
       assert_match %r{cc=foo\@test\.com}, actual_html
       assert_match %r{subject\=demo\%20test}, actual_html
@@ -152,92 +154,87 @@ describe "AssetTagHelpers" do
 
     it 'should not double-escape ampersands in query' do
       actual_html = mail_to('to@demo.com', "Email", :bcc => 'bcc@test.com', :subject => 'Hi there')
-      assert_has_tag(:a, :href => 'mailto:to@demo.com?bcc=bcc@test.com&subject=Hi%20there', :content => 'Email') { actual_html }
+      assert_html_has_tag(actual_html, :a, :href => 'mailto:to@demo.com?bcc=bcc@test.com&subject=Hi%20there', :content => 'Email')
       assert_match %r{&amp;}, actual_html
       refute_match %r{&amp;amp;}, actual_html
     end
 
     it 'should display mail link element in haml' do
-      visit '/haml/mail_to'
-      assert_have_selector 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
-      assert_have_selector 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
+      get "/haml/mail_to"
+      assert_response_has_tag 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
+      assert_response_has_tag 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
     end
 
     it 'should display mail link element in erb' do
-      visit '/erb/mail_to'
-      assert_have_selector 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
-      assert_have_selector 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
+      get "/erb/mail_to"
+      assert_response_has_tag 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
+      assert_response_has_tag 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
     end
 
     it 'should display mail link element in slim' do
-      visit '/slim/mail_to'
-      assert_have_selector 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
-      assert_have_selector 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
+      get "/slim/mail_to"
+      assert_response_has_tag 'p.simple a', :href => 'mailto:test@demo.com', :content => 'test@demo.com'
+      assert_response_has_tag 'p.captioned a', :href => 'mailto:test@demo.com', :content => 'Click my Email'
     end
   end
 
   describe 'for #meta_tag method' do
     it 'should display meta tag with given content and name' do
       actual_html = meta_tag("weblog,news", :name => "keywords")
-      assert_has_tag("meta", :name => "keywords", "content" => "weblog,news") { actual_html }
+      assert_html_has_tag(actual_html, "meta", :name => "keywords", :content => "weblog,news")
     end
 
     it 'should display meta tag with given content and http-equiv' do
       actual_html = meta_tag("text/html; charset=UTF-8", :"http-equiv" => "Content-Type")
-      assert_has_tag("meta", :"http-equiv" => "Content-Type", "content" => "text/html; charset=UTF-8") { actual_html }
+      assert_html_has_tag(actual_html, "meta", :"http-equiv" => "Content-Type", :content => "text/html; charset=UTF-8")
     end
 
     it 'should display meta tag element in haml' do
-      visit '/haml/meta_tag'
-      assert_have_selector 'meta', "content" => "weblog,news", :name => "keywords"
-      assert_have_selector 'meta', "content" => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
+      get "/haml/meta_tag"
+      assert_response_has_tag 'meta', :content => "weblog,news", :name => "keywords"
+      assert_response_has_tag 'meta', :content => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
     end
 
     it 'should display meta tag element in erb' do
-      visit '/erb/meta_tag'
-      assert_have_selector 'meta', "content" => "weblog,news", :name => "keywords"
-      assert_have_selector 'meta', "content" => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
+      get "/erb/meta_tag"
+      assert_response_has_tag 'meta', :content => "weblog,news", :name => "keywords"
+      assert_response_has_tag 'meta', :content => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
     end
 
     it 'should display meta tag element in slim' do
-      visit '/slim/meta_tag'
-      assert_have_selector 'meta', "content" => "weblog,news", :name => "keywords"
-      assert_have_selector 'meta', "content" => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
+      get "/slim/meta_tag"
+      assert_response_has_tag 'meta', :content => "weblog,news", :name => "keywords"
+      assert_response_has_tag 'meta', :content => "text/html; charset=UTF-8", :"http-equiv" => "Content-Type"
     end
   end
 
   describe 'for #image_tag method' do
     it 'should display image tag absolute link with no options' do
-      time = stop_time_for_test
-      assert_has_tag('img', :src => "/absolute/pic.gif") { image_tag('/absolute/pic.gif') }
+      assert_html_has_tag(image_tag('/absolute/pic.gif'), 'img', :src => "/absolute/pic.gif")
     end
 
     it 'should display image tag relative link with specified uri root' do
       time = stop_time_for_test
       self.class.stubs(:uri_root).returns("/blog")
-      assert_has_tag('img', :src => "/blog/images/relative/pic.gif?#{time.to_i}") { image_tag('relative/pic.gif') }
+      assert_html_has_tag(image_tag('relative/pic.gif'), 'img', :src => "/blog/images/relative/pic.gif?#{time.to_i}")
     end
 
     it 'should display image tag relative link with options' do
       time = stop_time_for_test
-      assert_has_tag('img.photo', :src => "/images/relative/pic.gif?#{time.to_i}") {
-        image_tag('relative/pic.gif', :class => 'photo') }
+      assert_html_has_tag(image_tag('relative/pic.gif', :class => 'photo'), 'img.photo', :src => "/images/relative/pic.gif?#{time.to_i}")
     end
 
     it 'should display image tag uri link with options' do
-      time = stop_time_for_test
-      assert_has_tag('img.photo', :src => "http://demo.org/pic.gif") { image_tag('http://demo.org/pic.gif', :class => 'photo') }
+      assert_html_has_tag(image_tag('http://demo.org/pic.gif', :class => 'photo'), 'img.photo', :src => "http://demo.org/pic.gif")
     end
 
     it 'should display image tag relative link with incorrect spacing' do
       time = stop_time_for_test
-      assert_has_tag('img.photo', :src => "/images/%20relative/%20pic.gif%20%20?#{time.to_i}") {
-        image_tag(' relative/ pic.gif  ', :class => 'photo')
-      }
+      assert_html_has_tag(image_tag(' relative/ pic.gif  ', :class => 'photo'), 'img.photo', :src => "/images/%20relative/%20pic.gif%20%20?#{time.to_i}")
     end
 
     it 'should not use a timestamp if stamp setting is false' do
-      assert_has_tag('img', :src => "/absolute/pic.gif") { image_tag('/absolute/pic.gif') }
+      assert_html_has_tag(image_tag('/absolute/pic.gif'), 'img', :src => "/absolute/pic.gif")
     end
 
     it 'should have xhtml convention tag' do
@@ -250,7 +247,7 @@ describe "AssetTagHelpers" do
       time = stop_time_for_test
       actual_html = stylesheet_link_tag('style')
       expected_options = { :rel => "stylesheet", :type => "text/css" }
-      assert_has_tag('link', expected_options.merge(:href => "/stylesheets/style.css?#{time.to_i}")) { actual_html }
+      assert_html_has_tag(actual_html, 'link', expected_options.merge(:href => "/stylesheets/style.css?#{time.to_i}"))
       assert actual_html.html_safe?
     end
 
@@ -258,14 +255,14 @@ describe "AssetTagHelpers" do
       time = stop_time_for_test
       expected_options = { :rel => "stylesheet", :type => "text/css" }
       actual_html = stylesheet_link_tag('example/demo/style')
-      assert_has_tag('link', expected_options.merge(:href => "/stylesheets/example/demo/style.css?#{time.to_i}")) { actual_html }
+      assert_html_has_tag(actual_html, 'link', expected_options.merge(:href => "/stylesheets/example/demo/style.css?#{time.to_i}"))
     end
 
     it 'should display stylesheet link item with absolute path' do
       time = stop_time_for_test
       expected_options = { :rel => "stylesheet", :type => "text/css" }
       actual_html = stylesheet_link_tag('/css/style')
-      assert_has_tag('link', expected_options.merge(:href => "/css/style.css")) { actual_html }
+      assert_html_has_tag(actual_html, 'link', expected_options.merge(:href => "/css/style.css"))
     end
 
     it 'should display stylesheet link item with uri root' do
@@ -273,27 +270,27 @@ describe "AssetTagHelpers" do
       time = stop_time_for_test
       expected_options = { :rel => "stylesheet", :type => "text/css" }
       actual_html = stylesheet_link_tag('style')
-      assert_has_tag('link', expected_options.merge(:href => "/blog/stylesheets/style.css?#{time.to_i}")) { actual_html }
+      assert_html_has_tag(actual_html, 'link', expected_options.merge(:href => "/blog/stylesheets/style.css?#{time.to_i}"))
     end
 
     it 'should display stylesheet link items' do
       time = stop_time_for_test
       actual_html = stylesheet_link_tag('style', 'layout.css', 'http://google.com/style.css')
-      assert_has_tag('link', :rel => "stylesheet", :type => "text/css", :count => 3) { actual_html }
-      assert_has_tag('link', :href => "/stylesheets/style.css?#{time.to_i}") { actual_html }
-      assert_has_tag('link', :href => "/stylesheets/layout.css?#{time.to_i}") { actual_html }
-      assert_has_tag('link', :href => "http://google.com/style.css") { actual_html }
+      assert_html_has_tag(actual_html, 'link', :rel => "stylesheet", :type => "text/css", :count => 3)
+      assert_html_has_tag(actual_html, 'link', :href => "/stylesheets/style.css?#{time.to_i}")
+      assert_html_has_tag(actual_html, 'link', :href => "/stylesheets/layout.css?#{time.to_i}")
+      assert_html_has_tag(actual_html, 'link', :href => "http://google.com/style.css")
       assert_equal actual_html, stylesheet_link_tag(['style', 'layout.css', 'http://google.com/style.css'])
     end
 
     it 'should not use a timestamp if stamp setting is false' do
       self.class.expects(:asset_stamp).returns(false)
       expected_options = { :rel => "stylesheet", :type => "text/css" }
-      assert_has_tag('link', expected_options.merge(:href => "/stylesheets/style.css")) { stylesheet_link_tag('style') }
+      assert_html_has_tag(stylesheet_link_tag('style'), 'link', expected_options.merge(:href => "/stylesheets/style.css"))
     end
 
     it 'should display stylesheet link used custom options' do
-      assert_has_tag('link', :rel => 'stylesheet', :media => 'screen') { stylesheet_link_tag('style', :media => 'screen') }
+      assert_html_has_tag(stylesheet_link_tag('style', :media => 'screen'), 'link', :rel => 'stylesheet', :media => 'screen')
     end
   end
 
@@ -301,7 +298,7 @@ describe "AssetTagHelpers" do
     it 'should display javascript item' do
       time = stop_time_for_test
       actual_html = javascript_include_tag('application')
-      assert_has_tag('script', :src => "/javascripts/application.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/application.js?#{time.to_i}", :type => "text/javascript")
       assert actual_html.html_safe?
     end
 
@@ -310,60 +307,58 @@ describe "AssetTagHelpers" do
       self.class.stubs(:js_asset_folder).returns('js')
       assert_equal 'js', asset_folder_name(:js)
       actual_html = javascript_include_tag('application')
-      assert_has_tag('script', :src => "/js/application.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/js/application.js?#{time.to_i}", :type => "text/javascript")
     end
 
     it 'should display javascript item for long relative path' do
       time = stop_time_for_test
       actual_html = javascript_include_tag('example/demo/application')
-      assert_has_tag('script', :src => "/javascripts/example/demo/application.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/example/demo/application.js?#{time.to_i}", :type => "text/javascript")
     end
 
     it 'should display javascript item for path containing js' do
       time = stop_time_for_test
       actual_html = javascript_include_tag 'test/jquery.json'
-      assert_has_tag('script', :src => "/javascripts/test/jquery.json?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/test/jquery.json?#{time.to_i}", :type => "text/javascript")
     end
 
     it 'should display javascript item for path containing period' do
       time = stop_time_for_test
       actual_html = javascript_include_tag 'test/jquery.min'
-      assert_has_tag('script', :src => "/javascripts/test/jquery.min.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/test/jquery.min.js?#{time.to_i}", :type => "text/javascript")
     end
 
     it 'should display javascript item with absolute path' do
-      time = stop_time_for_test
       actual_html = javascript_include_tag('/js/application')
-      assert_has_tag('script', :src => "/js/application.js", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/js/application.js", :type => "text/javascript")
     end
 
     it 'should display javascript item with uri root' do
       self.class.stubs(:uri_root).returns("/blog")
       time = stop_time_for_test
       actual_html = javascript_include_tag('application')
-      assert_has_tag('script', :src => "/blog/javascripts/application.js?#{time.to_i}", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/blog/javascripts/application.js?#{time.to_i}", :type => "text/javascript")
     end
 
     it 'should not append extension to absolute paths' do
-      time = stop_time_for_test
       actual_html = javascript_include_tag('https://maps.googleapis.com/maps/api/js?key=value&sensor=false')
-      assert_has_tag('script', :src => "https://maps.googleapis.com/maps/api/js?key=value&sensor=false") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "https://maps.googleapis.com/maps/api/js?key=value&sensor=false")
     end
 
     it 'should display javascript items' do
       time = stop_time_for_test
       actual_html = javascript_include_tag('application', 'base.js', 'http://google.com/lib.js')
-      assert_has_tag('script', :type => "text/javascript", :count => 3) { actual_html }
-      assert_has_tag('script', :src => "/javascripts/application.js?#{time.to_i}") { actual_html }
-      assert_has_tag('script', :src => "/javascripts/base.js?#{time.to_i}") { actual_html }
-      assert_has_tag('script', :src => "http://google.com/lib.js") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :type => "text/javascript", :count => 3)
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/application.js?#{time.to_i}")
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/base.js?#{time.to_i}")
+      assert_html_has_tag(actual_html, 'script', :src => "http://google.com/lib.js")
       assert_equal actual_html, javascript_include_tag(['application', 'base.js', 'http://google.com/lib.js'])
     end
 
     it 'should not use a timestamp if stamp setting is false' do
       self.class.expects(:asset_stamp).returns(false)
       actual_html = javascript_include_tag('application')
-      assert_has_tag('script', :src => "/javascripts/application.js", :type => "text/javascript") { actual_html }
+      assert_html_has_tag(actual_html, 'script', :src => "/javascripts/application.js", :type => "text/javascript")
     end
   end
 
@@ -371,33 +366,33 @@ describe "AssetTagHelpers" do
     it 'should display favicon' do
       time = stop_time_for_test
       actual_html = favicon_tag('icons/favicon.png')
-      assert_has_tag('link', :rel => 'icon', :type => 'image/png', :href => "/images/icons/favicon.png?#{time.to_i}") { actual_html }
+      assert_html_has_tag(actual_html, 'link', :rel => 'icon', :type => 'image/png', :href => "/images/icons/favicon.png?#{time.to_i}")
     end
 
     it 'should match type with file ext' do
       time = stop_time_for_test
       actual_html = favicon_tag('favicon.ico')
-      assert_has_tag('link', :rel => 'icon', :type => 'image/ico', :href => "/images/favicon.ico?#{time.to_i}") { actual_html }
+      assert_html_has_tag(actual_html, 'link', :rel => 'icon', :type => 'image/ico', :href => "/images/favicon.ico?#{time.to_i}")
     end
 
     it 'should allow option overrides' do
       time = stop_time_for_test
       actual_html = favicon_tag('favicon.png', :type => 'image/ico')
-      assert_has_tag('link', :rel => 'icon', :type => 'image/ico', :href => "/images/favicon.png?#{time.to_i}") { actual_html }
+      assert_html_has_tag(actual_html, 'link', :rel => 'icon', :type => 'image/ico', :href => "/images/favicon.png?#{time.to_i}")
     end
   end
 
   describe 'for #feed_tag method' do
     it 'should generate correctly link tag for rss' do
-      assert_has_tag('link', :type => 'application/rss+xml', :rel => 'alternate', :href => "/blog/post.rss", :title => 'rss') { feed_tag :rss, "/blog/post.rss" }
+      assert_html_has_tag(feed_tag(:rss, "/blog/post.rss"), 'link', :type => 'application/rss+xml', :rel => 'alternate', :href => "/blog/post.rss", :title => 'rss')
     end
 
     it 'should generate correctly link tag for atom' do
-      assert_has_tag('link', :type => 'application/atom+xml', :rel => 'alternate', :href => "/blog/post.atom", :title => 'atom') { feed_tag :atom, "/blog/post.atom" }
+      assert_html_has_tag(feed_tag(:atom, "/blog/post.atom"), 'link', :type => 'application/atom+xml', :rel => 'alternate', :href => "/blog/post.atom", :title => 'atom')
     end
 
     it 'should override options' do
-      assert_has_tag('link', :type => 'my-type', :rel => 'my-rel', :href => "/blog/post.rss", :title => 'my-title') { feed_tag :rss, "/blog/post.rss", :type => "my-type", :rel => "my-rel", :title => "my-title" }
+      assert_html_has_tag(feed_tag(:rss, "/blog/post.rss", :type => "my-type", :rel => "my-rel", :title => "my-title"), 'link', :type => 'my-type', :rel => 'my-rel', :href => "/blog/post.rss", :title => 'my-title')
     end
   end
 

--- a/padrino-helpers/test/test_form_builder.rb
+++ b/padrino-helpers/test/test_form_builder.rb
@@ -31,33 +31,33 @@ describe "FormBuilder" do
   describe 'for #form_for method' do
     it 'should display correct form html' do
       actual_html = form_for(@user, '/register', :id => 'register', :"accept-charset" => "UTF-8", :method => 'post') { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :id => 'register', :method => 'post', :content => "Demo") { actual_html }
-      assert_has_tag('form input[type=hidden]', :name => '_method', :count => 0) { actual_html } # no method action field
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :id => 'register', :method => 'post', :content => "Demo")
+      assert_html_has_tag(actual_html, 'form input[type=hidden]', :name => '_method', :count => 0) # no method action field
     end
 
     it 'should display correct form html with fake object' do
       actual_html = form_for(:markup_user, '/register', :id => 'register', :"accept-charset" => "UTF-8", :method => 'post') { |f| f.text_field :username }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :id => 'register', :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'text', :name => 'markup_user[username]') { actual_html }
-      assert_has_tag('form input[type=hidden]', :name => '_method', :count => 0) { actual_html } # no method action field
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :id => 'register', :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'text', :name => 'markup_user[username]')
+      assert_html_has_tag(actual_html, 'form input[type=hidden]', :name => '_method', :count => 0) # no method action field
     end
 
     it 'should display correct form html for namespaced object' do
       actual_html = form_for(Outer::UserAccount.new, '/register', :"accept-charset" => "UTF-8", :method => 'post') { |f| f.text_field :username }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'text', :name => 'outer_user_account[username]') { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'text', :name => 'outer_user_account[username]')
     end
 
     it 'should display form specifying default builder setting' do
       self.expects(:settings).returns(stub(:default_builder => 'FakeFormBuilder', :protect_from_csrf => false)).at_least_once
       actual_html = form_for(@user, '/register', :id => 'register', :"accept-charset" => "UTF-8", :method => 'post') { |f| f.foo_field }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :method => 'post') { actual_html }
-      assert_has_tag('span', :content => "bar") { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :method => 'post')
+      assert_html_has_tag(actual_html, 'span', :content => "bar")
     end
 
     it 'should display correct form html with remote option' do
       actual_html = form_for(@user, '/update', :"accept-charset" => "UTF-8", :remote => true) { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/update', :method => 'post', "data-remote" => 'true') { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/update', :method => 'post', "data-remote" => 'true')
     end
 
     it 'should display correct form html with namespace option' do
@@ -65,9 +65,9 @@ describe "FormBuilder" do
         f.text_field(:first_name) << f.fields_for(:role_types) { |role| role.text_field(:name) }
       end
 
-      assert_has_no_tag(:form, :namespace => 'foo') { actual_html }
-      assert_has_tag(:input, :type => 'text', :name => 'user[first_name]', :id => 'foo_user_first_name') { actual_html }
-      assert_has_tag(:input, :type => 'text', :name => 'user[role_types_attributes][0][name]', :id => 'foo_user_role_types_attributes_0_name') { actual_html }
+      assert_html_has_no_tag(actual_html, :form, :namespace => 'foo')
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'user[first_name]', :id => 'foo_user_first_name')
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'user[role_types_attributes][0][name]', :id => 'foo_user_role_types_attributes_0_name')
     end
 
     it 'should display correct form html with :as option' do
@@ -75,32 +75,32 @@ describe "FormBuilder" do
         f.text_field(:first_name) << f.fields_for(:role_types) { |role| role.text_field(:name) }
       end
 
-      assert_has_no_tag(:form, :as => 'customer') { actual_html }
-      assert_has_tag(:input, :type => 'text', :name => 'customer[first_name]', :id => 'customer_first_name') { actual_html }
-      assert_has_tag(:input, :type => 'text', :name => 'customer[role_types_attributes][0][name]', :id => 'customer_role_types_attributes_0_name') { actual_html }
+      assert_html_has_no_tag(actual_html, :form, :as => 'customer')
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'customer[first_name]', :id => 'customer_first_name')
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'customer[role_types_attributes][0][name]', :id => 'customer_role_types_attributes_0_name')
     end
 
     it 'should display correct form html with remote option and method put' do
       actual_html = form_for(@user, '/update', :"accept-charset" => "UTF-8", :remote => true, :method => 'put') { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :method => 'post', "data-remote" => 'true') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'put') { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :method => 'post', "data-remote" => 'true')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'put')
     end
 
     it 'should display correct form html with method :put' do
       actual_html = form_for(@user, '/update', :"accept-charset" => "UTF-8", :method => 'put') { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/update', :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'put') { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/update', :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'put')
     end
 
     it 'should display correct form html with method :delete' do
       actual_html = form_for(@user, '/destroy', :"accept-charset" => "UTF-8", :method => 'delete') { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/destroy', :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'delete') { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/destroy', :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'delete')
     end
 
     it 'should display correct form html with multipart' do
       actual_html = form_for(@user, '/register', :"accept-charset" => "UTF-8", :multipart => true) { "Demo" }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data") { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data")
     end
 
     it 'should support changing form builder type' do
@@ -110,7 +110,7 @@ describe "FormBuilder" do
 
     it 'should support using default standard builder' do
       actual_html = form_for(@user, '/register') { |f| f.text_field_block(:name) }
-      assert_has_tag('form p input[type=text]') { actual_html }
+      assert_html_has_tag(actual_html, 'form p input[type=text]')
     end
 
     it 'should display fail for form with nil object' do
@@ -118,49 +118,49 @@ describe "FormBuilder" do
     end
 
     it 'should display correct form in haml' do
-      visit '/haml/form_for'
-      assert_have_selector :form, :action => '/demo', :id => 'demo'
-      assert_have_selector :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
-      assert_have_selector :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      get "/haml/form_for"
+      assert_response_has_tag :form, :action => '/demo', :id => 'demo'
+      assert_response_has_tag :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
+      assert_response_has_tag :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
+      assert_response_has_tag :input, :name => 'authenticity_token'
     end
 
     it 'should display correct form in erb' do
-      visit '/erb/form_for'
-      assert_have_selector :form, :action => '/demo', :id => 'demo'
-      assert_have_selector :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
-      assert_have_selector :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      get "/erb/form_for"
+      assert_response_has_tag :form, :action => '/demo', :id => 'demo'
+      assert_response_has_tag :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
+      assert_response_has_tag :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
+      assert_response_has_tag :input, :name => 'authenticity_token'
     end
 
     it 'should display correct form in slim' do
-      visit '/slim/form_for'
-      assert_have_selector :form, :action => '/demo', :id => 'demo'
-      assert_have_selector :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
-      assert_have_selector :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
-      assert_have_selector :input, :name => 'authenticity_token'
+      get "/slim/form_for"
+      assert_response_has_tag :form, :action => '/demo', :id => 'demo'
+      assert_response_has_tag :form, :action => '/another_demo', :id => 'demo2', :method => 'get'
+      assert_response_has_tag :form, :action => '/third_demo', :id => 'demo3', :method => 'get'
+      assert_response_has_tag :input, :name => 'authenticity_token'
     end
 
     it 'should have a class of "invalid" for fields with errors' do
       actual_html = form_for(@user, '/register') {|f| f.text_field(:email) }
-      assert_has_tag(:input, :type => 'text', :name => 'user[email]', :id => 'user_email', :class => 'invalid') {actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'user[email]', :id => 'user_email', :class => 'invalid')
     end
 
     it 'should not have a class of "invalid" for fields with no errors' do
       actual_html = form_for(@user, '/register') {|f| f.text_field(:first_name) }
-      assert_has_no_tag(:input, :type => 'text', :name => 'user[first_name]', :id => 'user_first_name', :class => 'invalid') {actual_html }
+      assert_html_has_no_tag(actual_html, :input, :type => 'text', :name => 'user[first_name]', :id => 'user_first_name', :class => 'invalid')
     end
   end
 
   describe 'for #fields_for method' do
     it 'should display correct fields html' do
       actual_html = fields_for(@user) { |f| f.text_field(:first_name) }
-      assert_has_tag(:input, :type => 'text', :name => 'user[first_name]', :id => 'user_first_name') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'user[first_name]', :id => 'user_first_name')
     end
 
     it 'should display correct fields html with symbol object' do
       actual_html = fields_for(:markup_user) { |f| f.text_field(:first_name) }
-      assert_has_tag(:input, :type => 'text', :name => 'markup_user[first_name]', :id => 'markup_user_first_name') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'text', :name => 'markup_user[first_name]', :id => 'markup_user_first_name')
     end
 
     it 'should display fail for nil object' do
@@ -178,27 +178,27 @@ describe "FormBuilder" do
     end
 
     it 'should display correct simple fields in haml' do
-      visit '/haml/fields_for'
-      assert_have_selector :form, :action => '/demo1', :id => 'demo-fields-for'
-      assert_have_selector '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
+      get "/haml/fields_for"
+      assert_response_has_tag :form, :action => '/demo1', :id => 'demo-fields-for'
+      assert_response_has_tag '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
     end
 
     it 'should display correct simple fields in erb' do
-      visit '/erb/fields_for'
-      assert_have_selector :form, :action => '/demo1', :id => 'demo-fields-for'
-      assert_have_selector '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
+      get "/erb/fields_for"
+      assert_response_has_tag :form, :action => '/demo1', :id => 'demo-fields-for'
+      assert_response_has_tag '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
     end
 
     it 'should display correct simple fields in slim' do
-      visit '/slim/fields_for'
-      assert_have_selector :form, :action => '/demo1', :id => 'demo-fields-for'
-      assert_have_selector '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
-      assert_have_selector '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
+      get "/slim/fields_for"
+      assert_response_has_tag :form, :action => '/demo1', :id => 'demo-fields-for'
+      assert_response_has_tag '#demo-fields-for input', :type => 'text', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_edit]', :value => '1', :checked => 'checked'
+      assert_response_has_tag '#demo-fields-for input', :type => 'checkbox', :name => 'permission[can_delete]'
     end
   end
 
@@ -214,50 +214,50 @@ describe "FormBuilder" do
 
     it 'should display correct form html with valid record' do
       actual_html = standard_builder.error_messages(:header_message => "Demo form cannot be saved", :style => "foo:bar", :class => "mine")
-      assert_has_tag('#field-errors h2', :content => "Demo form cannot be saved") { actual_html }
-      assert_has_tag('#field-errors ul li', :content => "B must be valid") { actual_html }
-      assert_has_tag('#field-errors ul li', :content => "A must be present") { actual_html }
-      assert_has_tag('#field-errors', :style => "foo:bar") { actual_html }
-      assert_has_tag('#field-errors', :class => "mine") { actual_html }
+      assert_html_has_tag(actual_html, '#field-errors h2', :content => "Demo form cannot be saved")
+      assert_html_has_tag(actual_html, '#field-errors ul li', :content => "B must be valid")
+      assert_html_has_tag(actual_html, '#field-errors ul li', :content => "A must be present")
+      assert_html_has_tag(actual_html, '#field-errors', :style => "foo:bar")
+      assert_html_has_tag(actual_html, '#field-errors', :class => "mine")
     end
 
     it 'should display correct form in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Fake must be valid"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Second must be present"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Third must be a number"
-      assert_have_selector '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Second must be present"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Third must be a number"
-      assert_have_selector '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Fake must be valid"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Second must be present"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Third must be a number"
+      assert_response_has_tag '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Third must be a number"
+      assert_response_has_tag '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
     end
 
     it 'should display correct form in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Fake must be valid"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Second must be present"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Third must be a number"
-      assert_have_selector '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Second must be present"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Third must be a number"
-      assert_have_selector '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Fake must be valid"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Second must be present"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Third must be a number"
+      assert_response_has_tag '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Third must be a number"
+      assert_response_has_tag '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
     end
 
     it 'should display correct form in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Fake must be valid"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Second must be present"
-      assert_have_selector '#demo div.field-errors ul li',  :content => "Third must be a number"
-      assert_have_selector '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Second must be present"
-      assert_have_selector '#demo2 div.field-errors ul li', :content => "Third must be a number"
-      assert_have_selector '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo div.field-errors h2',     :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Fake must be valid"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Second must be present"
+      assert_response_has_tag '#demo div.field-errors ul li',  :content => "Third must be a number"
+      assert_response_has_tag '#demo2 div.field-errors h2',    :content => "custom MarkupUser cannot be saved!"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag '#demo2 div.field-errors ul li', :content => "Third must be a number"
+      assert_response_has_tag '#demo input', :name => 'markup_user[email]', :class => 'string invalid'
     end
   end
 
@@ -269,431 +269,431 @@ describe "FormBuilder" do
 
     it 'should display error for specified invalid object' do
       actual_html = standard_builder(@user).error_message_on(:a, :prepend => "foo", :append => "bar")
-      assert_has_tag('span.error', :content => "foo must be present bar") { actual_html }
+      assert_html_has_tag(actual_html, 'span.error', :content => "foo must be present bar")
     end
 
     it 'should display error for specified invalid object not matching class name' do
       @bob = mock_model("User", :first_name => "Frank", :errors => { :foo => "must be bob" })
       actual_html = standard_builder(@bob).error_message_on(:foo, :prepend => "foo", :append => "bar")
-      assert_has_tag('span.error', :content => "foo must be bob bar") { actual_html }
+      assert_html_has_tag(actual_html, 'span.error', :content => "foo must be bob bar")
     end
   end
 
   describe 'for #label method' do
     it 'should display correct label html' do
       actual_html = standard_builder.label(:first_name, :class => 'large', :caption => "F. Name: ")
-      assert_has_tag('label', :class => 'large', :for => 'user_first_name', :content => "F. Name: ") { actual_html }
-      assert_has_no_tag('label#user_first_name') { actual_html }
+      assert_html_has_tag(actual_html, 'label', :class => 'large', :for => 'user_first_name', :content => "F. Name: ")
+      assert_html_has_no_tag(actual_html, 'label#user_first_name')
     end
 
     it 'should set specific content inside the label if a block was provided' do
       actual_html = standard_builder.label(:admin, :class => 'large') { input_tag :checkbox }
-      assert_has_tag('label', :class => 'large', :for => 'user_admin', :content => "Admin: ") { actual_html }
-      assert_has_tag('label input[type=checkbox]') { actual_html }
+      assert_html_has_tag(actual_html, 'label', :class => 'large', :for => 'user_admin', :content => "Admin: ")
+      assert_html_has_tag(actual_html, 'label input[type=checkbox]')
     end
 
     it 'should display correct label in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo label', :content => "Login: ", :class => 'user-label'
-      assert_have_selector '#demo label', :content => "About Me: "
-      assert_have_selector '#demo2 label', :content => "Nickname: ", :class => 'label'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo label', :content => "Login: ", :class => 'user-label'
+      assert_response_has_tag '#demo label', :content => "About Me: "
+      assert_response_has_tag '#demo2 label', :content => "Nickname: ", :class => 'label'
     end
 
     it 'should display correct label in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo label', :content => "Login: ", :class => 'user-label'
-      assert_have_selector '#demo label', :content => "About Me: "
-      assert_have_selector '#demo2 label', :content => "Nickname: ", :class => 'label'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo label', :content => "Login: ", :class => 'user-label'
+      assert_response_has_tag '#demo label', :content => "About Me: "
+      assert_response_has_tag '#demo2 label', :content => "Nickname: ", :class => 'label'
     end
 
     it 'should display correct label in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo label', :content => "Login: ", :class => 'user-label'
-      assert_have_selector '#demo label', :content => "About Me: "
-      assert_have_selector '#demo2 label', :content => "Nickname: ", :class => 'label'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo label', :content => "Login: ", :class => 'user-label'
+      assert_response_has_tag '#demo label', :content => "About Me: "
+      assert_response_has_tag '#demo2 label', :content => "Nickname: ", :class => 'label'
     end
   end
 
   describe 'for #hidden_field method' do
     it 'should display correct hidden field html' do
       actual_html = standard_builder.hidden_field(:session_id, :class => 'hidden')
-      assert_has_tag('input.hidden[type=hidden]', :value => "54", :id => 'user_session_id', :name => 'user[session_id]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.hidden[type=hidden]', :value => "54", :id => 'user_session_id', :name => 'user[session_id]')
     end
 
     it 'should display correct hidden field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
-      assert_have_selector '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
+      assert_response_has_tag '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
     end
 
     it 'should display correct hidden field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
-      assert_have_selector '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
+      assert_response_has_tag '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
     end
 
     it 'should display correct hidden field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
-      assert_have_selector '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=hidden]', :id => 'markup_user_session_id', :value => "45"
+      assert_response_has_tag '#demo2 input', :type => 'hidden', :name => 'markup_user[session_id]'
     end
   end
 
   describe 'for #text_field method' do
     it 'should display correct text field html' do
       actual_html = standard_builder.text_field(:first_name, :class => 'large')
-      assert_has_tag('input.large[type=text]', :value => "Joe", :id => 'user_first_name', :name => 'user[first_name]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=text]', :value => "Joe", :id => 'user_first_name', :name => 'user[first_name]')
     end
 
     it 'should display correct text field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
-      assert_have_selector '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
+      assert_response_has_tag '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
     end
 
     it 'should display correct text field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
-      assert_have_selector '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
+      assert_response_has_tag '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
     end
 
     it 'should display correct text field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
-      assert_have_selector '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.user-text[type=text]', :id => 'markup_user_username', :value => "John"
+      assert_response_has_tag '#demo2 input', :type => 'text', :class => 'input', :name => 'markup_user[username]'
     end
   end
 
   describe 'for #number_field method' do
     it 'should display correct number field html' do
       actual_html = standard_builder.number_field(:age, :class => 'numeric')
-      assert_has_tag('input.numeric[type=number]', :id => 'user_age', :name => 'user[age]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.numeric[type=number]', :id => 'user_age', :name => 'user[age]')
     end
 
     it 'should display correct number field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.numeric[type=number]', :id => 'markup_user_age'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.numeric[type=number]', :id => 'markup_user_age'
     end
 
     it 'should display correct number field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.numeric[type=number]', :id => 'markup_user_age'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.numeric[type=number]', :id => 'markup_user_age'
     end
 
     it 'should display correct number field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.numeric[type=number]', :id => 'markup_user_age'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.numeric[type=number]', :id => 'markup_user_age'
     end
   end
 
   describe 'for #telephone_field method' do
     it 'should display correct telephone field html' do
       actual_html = standard_builder.telephone_field(:telephone, :class => 'numeric')
-      assert_has_tag('input.numeric[type=tel]', :id => 'user_telephone', :name => 'user[telephone]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.numeric[type=tel]', :id => 'user_telephone', :name => 'user[telephone]')
     end
 
     it 'should display correct telephone field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
     end
 
     it 'should display correct telephone field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
     end
 
     it 'should display correct telephone field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.numeric[type=tel]', :id => 'markup_user_telephone'
     end
   end
 
   describe 'for #search_field method' do
     it 'should display correct search field html' do
       actual_html = standard_builder.search_field(:search, :class => 'string')
-      assert_has_tag('input.string[type=search]', :id => 'user_search', :name => 'user[search]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.string[type=search]', :id => 'user_search', :name => 'user[search]')
     end
 
     it 'should display correct search field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.string[type=search]', :id => 'markup_user_search'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.string[type=search]', :id => 'markup_user_search'
     end
 
     it 'should display correct search field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.string[type=search]', :id => 'markup_user_search'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.string[type=search]', :id => 'markup_user_search'
     end
 
     it 'should display correct search field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.string[type=search]', :id => 'markup_user_search'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.string[type=search]', :id => 'markup_user_search'
     end
   end
 
   describe 'for #email_field method' do
     it 'should display correct email field html' do
       actual_html = standard_builder.email_field(:email, :class => 'string')
-      assert_has_tag('input.string[type=email]', :id => 'user_email', :name => 'user[email]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.string[type=email]', :id => 'user_email', :name => 'user[email]')
     end
 
     it 'should display correct email field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.string[type=email]', :id => 'markup_user_email'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.string[type=email]', :id => 'markup_user_email'
     end
 
     it 'should display correct email field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.string[type=email]', :id => 'markup_user_email'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.string[type=email]', :id => 'markup_user_email'
     end
 
     it 'should display correct email field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.string[type=email]', :id => 'markup_user_email'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.string[type=email]', :id => 'markup_user_email'
     end
   end
 
   describe 'for #url_field method' do
     it 'should display correct url field html' do
       actual_html = standard_builder.url_field(:webpage, :class => 'string')
-      assert_has_tag('input.string[type=url]', :id => 'user_webpage', :name => 'user[webpage]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.string[type=url]', :id => 'user_webpage', :name => 'user[webpage]')
     end
 
     it 'should display correct url field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input.string[type=url]', :id => 'markup_user_webpage'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input.string[type=url]', :id => 'markup_user_webpage'
     end
 
     it 'should display correct url field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input.string[type=url]', :id => 'markup_user_webpage'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input.string[type=url]', :id => 'markup_user_webpage'
     end
 
     it 'should display correct url field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input.string[type=url]', :id => 'markup_user_webpage'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input.string[type=url]', :id => 'markup_user_webpage'
     end
   end
 
   describe 'for #check_box method' do
     it 'should display correct checkbox html' do
       actual_html = standard_builder.check_box(:confirm_destroy, :class => 'large')
-      assert_has_tag('input.large[type=checkbox]', :id => 'user_confirm_destroy', :name => 'user[confirm_destroy]') { actual_html }
-      assert_has_tag('input[type=hidden]', :name => 'user[confirm_destroy]', :value => '0') { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=checkbox]', :id => 'user_confirm_destroy', :name => 'user[confirm_destroy]')
+      assert_html_has_tag(actual_html, 'input[type=hidden]', :name => 'user[confirm_destroy]', :value => '0')
     end
 
     it 'should display correct checkbox html when checked' do
       actual_html = standard_builder.check_box(:confirm_destroy, :checked => true)
-      assert_has_tag('input[type=checkbox]', :checked => 'checked', :name => 'user[confirm_destroy]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=checkbox]', :checked => 'checked', :name => 'user[confirm_destroy]')
     end
 
     it 'should display correct checkbox html as checked when object value matches' do
       @user.stubs(:show_favorites => 'human')
       actual_html = standard_builder.check_box(:show_favorites, :value => 'human')
-      assert_has_tag('input[type=checkbox]', :checked => 'checked', :name => 'user[show_favorites]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=checkbox]', :checked => 'checked', :name => 'user[show_favorites]')
     end
 
     it 'should display correct checkbox html as checked when object value is true' do
       @user.stubs(:show_favorites => true)
       actual_html = standard_builder.check_box(:show_favorites, :value => '1')
-      assert_has_tag('input[type=checkbox]', :checked => 'checked', :name => 'user[show_favorites]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=checkbox]', :checked => 'checked', :name => 'user[show_favorites]')
     end
 
     it 'should display correct checkbox html as unchecked when object value does not match' do
       @user.stubs(:show_favorites => 'alien')
       actual_html = standard_builder.check_box(:show_favorites, :value => 'human')
-      assert_has_no_tag('input[type=checkbox]', :checked => 'checked') { actual_html }
+      assert_html_has_no_tag(actual_html, 'input[type=checkbox]', :checked => 'checked')
     end
 
     it 'should display correct checkbox html as unchecked when object value is false' do
       @user.stubs(:show_favorites => false)
       actual_html = standard_builder.check_box(:show_favorites, :value => '1')
-      assert_has_no_tag('input[type=checkbox]', :checked => 'checked') { actual_html }
+      assert_html_has_no_tag(actual_html, 'input[type=checkbox]', :checked => 'checked')
     end
 
     it 'should display correct unchecked hidden field when specified' do
       actual_html = standard_builder.check_box(:show_favorites, :value => 'female', :uncheck_value => 'false')
-      assert_has_tag('input[type=hidden]', :name => 'user[show_favorites]', :value => 'false') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=hidden]', :name => 'user[show_favorites]', :value => 'false')
     end
 
     it 'should display correct checkbox in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
     end
 
     it 'should display correct checkbox in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
     end
 
     it 'should display correct checkbox in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=checkbox]', :checked => 'checked', :id => 'markup_user_remember_me', :name => 'markup_user[remember_me]'
     end
   end
 
   describe 'for #check_box_group and #radio_button_group methods' do
     it 'should display checkbox group html' do
       checkboxes = standard_builder.check_box_group(:role, :collection => @user.role_types, :fields => [:name, :id], :selected => [2,3])
-      assert_has_tag('input[type=checkbox]', :value => '1') { checkboxes }
-      assert_has_no_tag('input[type=checkbox][checked]', :value => '1') { checkboxes }
-      assert_has_tag('input[type=checkbox]', :checked => 'checked', :value => '2') { checkboxes }
-      assert_has_tag('label[for=user_role_3] input[name="user[role][]"][value="3"][checked]') { checkboxes }
+      assert_html_has_tag(checkboxes, 'input[type=checkbox]', :value => '1')
+      assert_html_has_no_tag(checkboxes, 'input[type=checkbox][checked]', :value => '1')
+      assert_html_has_tag(checkboxes, 'input[type=checkbox]', :checked => 'checked', :value => '2')
+      assert_html_has_tag(checkboxes, 'label[for=user_role_3] input[name="user[role][]"][value="3"][checked]')
     end
 
     it 'should display checkbox group html and extract selected values from the object' do
       checkboxes = standard_builder.check_box_group(:roles, :collection => @user.role_types, :fields => [:name, :id])
-      assert_has_tag('input[type=checkbox][name="user[roles][]"][value="1"][checked]') { checkboxes }
-      assert_has_tag('input[type=checkbox][name="user[roles][]"][value="3"][checked]') { checkboxes }
-      assert_has_no_tag('input[type=checkbox][name="user[roles][]"][value="2"][checked]') { checkboxes }
+      assert_html_has_tag(checkboxes, 'input[type=checkbox][name="user[roles][]"][value="1"][checked]')
+      assert_html_has_tag(checkboxes, 'input[type=checkbox][name="user[roles][]"][value="3"][checked]')
+      assert_html_has_no_tag(checkboxes, 'input[type=checkbox][name="user[roles][]"][value="2"][checked]')
     end
 
     it 'should display radio group html' do
       radios = standard_builder.radio_button_group(:role, :options => %W(red yellow blue), :selected => 'yellow')
-      assert_has_tag('input[type=radio]', :value => 'red') { radios }
-      assert_has_no_tag('input[type=radio][checked]', :value => 'red') { radios }
-      assert_has_tag('input[type=radio]', :checked => 'checked', :value => 'yellow') { radios }
-      assert_has_tag('label[for=user_role_blue] input[name="user[role]"][value=blue]') { radios }
+      assert_html_has_tag(radios, 'input[type=radio]', :value => 'red')
+      assert_html_has_no_tag(radios, 'input[type=radio][checked]', :value => 'red')
+      assert_html_has_tag(radios, 'input[type=radio]', :checked => 'checked', :value => 'yellow')
+      assert_html_has_tag(radios, 'label[for=user_role_blue] input[name="user[role]"][value=blue]')
     end
 
     it 'should display radio group html and extract selected value from the object' do
       radios = standard_builder.radio_button_group(:role, :collection => @user.role_types)
-      assert_has_tag('input[type=radio][value="1"][checked]') { radios }
-      assert_has_no_tag('input[type=radio][value="2"][checked]') { radios }
+      assert_html_has_tag(radios, 'input[type=radio][value="1"][checked]')
+      assert_html_has_no_tag(radios, 'input[type=radio][value="2"][checked]')
     end
   end
 
   describe 'for #radio_button method' do
     it 'should display correct radio button html' do
       actual_html = standard_builder.radio_button(:gender, :value => 'male', :class => 'large')
-      assert_has_tag('input.large[type=radio]', :id => 'user_gender_male', :name => 'user[gender]', :value => 'male') { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=radio]', :id => 'user_gender_male', :name => 'user[gender]', :value => 'male')
     end
 
     it 'should display correct radio button html when checked' do
       actual_html = standard_builder.radio_button(:gender, :checked => true)
-      assert_has_tag('input[type=radio]', :checked => 'checked', :name => 'user[gender]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=radio]', :checked => 'checked', :name => 'user[gender]')
     end
 
     it 'should display correct radio button html as checked when object value matches' do
       @user.stubs(:gender => 'male')
       actual_html = standard_builder.radio_button(:gender, :value => 'male')
-      assert_has_tag('input[type=radio]', :checked => 'checked', :name => 'user[gender]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=radio]', :checked => 'checked', :name => 'user[gender]')
     end
 
     it 'should display correct radio button html as unchecked when object value does not match' do
       @user.stubs(:gender => 'male')
       actual_html = standard_builder.radio_button(:gender, :value => 'female')
-      assert_has_no_tag('input[type=radio]', :checked => 'checked') { actual_html }
+      assert_html_has_no_tag(actual_html, 'input[type=radio]', :checked => 'checked')
     end
 
     it 'should display correct radio button in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
-      assert_have_selector '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
+      assert_response_has_tag '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
     end
 
     it 'should display correct radio button in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
-      assert_have_selector '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
+      assert_response_has_tag '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
     end
 
     it 'should display correct radio button in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
-      assert_have_selector '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
-      assert_have_selector '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_male', :name => 'markup_user[gender]', :value => 'male'
+      assert_response_has_tag '#demo input[type=radio]', :id => 'markup_user_gender_female', :name => 'markup_user[gender]', :value => 'female'
+      assert_response_has_tag '#demo input[type=radio][checked=checked]', :id => 'markup_user_gender_male'
     end
   end
 
   describe 'for #text_area method' do
     it 'should display correct text_area html' do
       actual_html = standard_builder.text_area(:about, :class => 'large')
-      assert_has_tag('textarea.large', :id => 'user_about', :name => 'user[about]') { actual_html }
+      assert_html_has_tag(actual_html, 'textarea.large', :id => 'user_about', :name => 'user[about]')
     end
 
     it 'should display correct text_area html and content' do
       actual_html = standard_builder.text_area(:about, :value => "Demo", :rows => '5', :cols => '6')
-      assert_has_tag('textarea', :id => 'user_about', :content => 'Demo', :rows => '5', :cols => '6') { actual_html }
+      assert_html_has_tag(actual_html, 'textarea', :id => 'user_about', :content => 'Demo', :rows => '5', :cols => '6')
     end
 
     it 'should display correct text_area in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
 
     it 'should display correct text_area in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
 
     it 'should display correct text_area in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
   end
 
   describe 'for #password_field method' do
     it 'should display correct password_field html' do
       actual_html = standard_builder.password_field(:code, :class => 'large')
-      assert_has_tag('input.large[type=password]', :id => 'user_code', :name => 'user[code]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=password]', :id => 'user_code', :name => 'user[code]')
     end
 
     it 'should display correct password_field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
-      assert_have_selector '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
+      assert_response_has_tag '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
     end
 
     it 'should display correct password_field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
-      assert_have_selector '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
+      assert_response_has_tag '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
     end
 
     it 'should display correct password_field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
-      assert_have_selector '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input', :type => 'password', :class => 'user-password', :value => 'secret'
+      assert_response_has_tag '#demo2 input', :type => 'password', :class => 'input', :name => 'markup_user[code]'
     end
   end
 
   describe 'for #file_field method' do
     it 'should display correct file_field html' do
       actual_html = standard_builder.file_field(:photo, :class => 'large')
-      assert_has_tag('input.large[type=file]', :id => 'user_photo', :name => 'user[photo]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=file]', :id => 'user_photo', :name => 'user[photo]')
     end
 
     it 'should display correct file_field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
-      assert_have_selector '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      assert_response_has_tag '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
 
     it 'should display correct file_field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
-      assert_have_selector '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      assert_response_has_tag '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
 
     it 'should display correct file_field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
-      assert_have_selector '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo  input.user-photo', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      assert_response_has_tag '#demo2 input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
 
     it 'should display correct form html with multipart, even if no multipart option is specified' do
       actual_html = form_for(@user, '/register', :"accept-charset" => "UTF-8") { |f| f.file_field :photo }
-      assert_has_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data") { actual_html }
+      assert_html_has_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data")
     end
 
     it 'should display correct form html without multipart, if multipart option is specified false' do
       actual_html = form_for(@user, '/register', :"accept-charset" => "UTF-8", :multipart => false) { |f| f.file_field :photo }
-      assert_has_no_tag('form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data") { actual_html }
+      assert_html_has_no_tag(actual_html, 'form', :"accept-charset" => "UTF-8", :action => '/register', :enctype => "multipart/form-data")
     end
 
   end
@@ -701,28 +701,28 @@ describe "FormBuilder" do
   describe 'for #select method' do
     it 'should display correct select html' do
       actual_html = standard_builder.select(:state, :options => ['California', 'Texas', 'Wyoming'], :class => 'selecty')
-      assert_has_tag('select.selecty', :id => 'user_state', :name => 'user[state]') { actual_html }
-      assert_has_tag('select.selecty option', :count => 3) { actual_html }
-      assert_has_tag('select.selecty option', :value => 'California', :content => 'California') { actual_html }
-      assert_has_tag('select.selecty option', :value => 'Texas',      :content => 'Texas')      { actual_html }
-      assert_has_tag('select.selecty option', :value => 'Wyoming',    :content => 'Wyoming')    { actual_html }
+      assert_html_has_tag(actual_html, 'select.selecty', :id => 'user_state', :name => 'user[state]')
+      assert_html_has_tag(actual_html, 'select.selecty option', :count => 3)
+      assert_html_has_tag(actual_html, 'select.selecty option', :value => 'California', :content => 'California')
+      assert_html_has_tag(actual_html, 'select.selecty option', :value => 'Texas',      :content => 'Texas')
+      assert_html_has_tag(actual_html, 'select.selecty option', :value => 'Wyoming',    :content => 'Wyoming')
     end
 
     it 'should display correct select html with selected item if it matches value' do
       @user.stubs(:state => 'California')
       actual_html = standard_builder.select(:state, :options => ['California', 'Texas', 'Wyoming'])
-      assert_has_tag('select', :id => 'user_state', :name => 'user[state]') { actual_html }
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :value => 'California', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, 'select', :id => 'user_state', :name => 'user[state]')
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :value => 'California', :selected => 'selected')
     end
 
     it 'should display correct select html with selected item if it matches full value' do
       @user.stubs(:state => 'Cali')
       actual_html = standard_builder.select(:state, :options => ['Cali', 'California', 'Texas', 'Wyoming'])
-      assert_has_tag('select', :id => 'user_state', :name => 'user[state]') { actual_html }
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :value => 'Cali', :selected => 'selected') { actual_html }
-      assert_has_tag('select option', :value => 'California') { actual_html }
+      assert_html_has_tag(actual_html, 'select', :id => 'user_state', :name => 'user[state]')
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :value => 'Cali', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'select option', :value => 'California')
     end
 
     it 'should display correct select html with multiple selected items' do
@@ -730,92 +730,95 @@ describe "FormBuilder" do
       actual_html = standard_builder.select(
         :pickles, :options => [ ['Foo', 'foo'], ['Bar', 'bar'], ['Baz', 'baz'], ['Bar Buz', 'bar buz'] ]
       )
-      assert_has_tag('option', :value => 'foo', :content => 'Foo', :selected => 'selected')  { actual_html }
-      assert_has_tag('option', :value => 'bar', :content => 'Bar', :selected => 'selected')  { actual_html }
-      assert_has_tag('option', :value => 'baz', :content => 'Baz')  { actual_html }
-      assert_has_tag('option', :value => 'bar buz', :content => 'Bar Buz')  { actual_html }
+      assert_html_has_tag(actual_html, 'option', :value => 'foo', :content => 'Foo', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'option', :value => 'bar', :content => 'Bar', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'option', :value => 'baz', :content => 'Baz')
+      assert_html_has_tag(actual_html, 'option', :value => 'bar buz', :content => 'Bar Buz')
     end
 
-    it 'should display correct select html with include_blank' do
+    it 'should display correct select html with include_blank true' do
       actual_html = standard_builder.select(:state, :options => ['California', 'Texas', 'Wyoming'], :include_blank => true)
-      assert_has_tag('select', :id => 'user_state', :name => 'user[state]') { actual_html }
-      assert_has_tag('select option', :count => 4) { actual_html }
-      assert_has_tag('select option:first-child', :content => '') { actual_html }
-      assert_has_tag('select option:first-child', :value => '') { actual_html }
+      assert_html_has_tag(actual_html, 'select', :id => 'user_state', :name => 'user[state]')
+      assert_html_has_tag(actual_html, 'select option', :count => 4)
+      assert_html_has_tag(actual_html, 'select option:first-child', :content => '')
+      assert_html_has_tag(actual_html, 'select option:first-child', :value => '')
+    end
+
+    it 'should display correct select html with include_blank string' do
       actual_html = standard_builder.select(:state, :options => ['California', 'Texas', 'Wyoming'], :include_blank => 'Select')
-      assert_has_tag('select', :id => 'user_state', :name => 'user[state]') { actual_html }
-      assert_has_tag('select option', :count => 4) { actual_html }
-      assert_has_tag('select option:first-child', :content => 'Select') { actual_html }
-      assert_has_tag('select option:first-child', :value => '') { actual_html }
+      assert_html_has_tag(actual_html, 'select', :id => 'user_state', :name => 'user[state]')
+      assert_html_has_tag(actual_html, 'select option', :count => 4)
+      assert_html_has_tag(actual_html, 'select option:first-child', :content => 'Select')
+      assert_html_has_tag(actual_html, 'select option:first-child', :value => '')
     end
 
     it 'should display correct select html with collection passed in' do
       actual_html = standard_builder.select(:role, :collection => @user.role_types, :fields => [:name, :id])
-      assert_has_tag('select', :id => 'user_role', :name => 'user[role]') { actual_html }
-      assert_has_tag('select option', :count => 3) { actual_html }
-      assert_has_tag('select option', :value => '1', :content => 'Admin', :selected => 'selected')     { actual_html }
-      assert_has_tag('select option', :value => '2', :content => 'Moderate')  { actual_html }
-      assert_has_tag('select option', :value => '3', :content => 'Limited')   { actual_html }
+      assert_html_has_tag(actual_html, 'select', :id => 'user_role', :name => 'user[role]')
+      assert_html_has_tag(actual_html, 'select option', :count => 3)
+      assert_html_has_tag(actual_html, 'select option', :value => '1', :content => 'Admin', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'select option', :value => '2', :content => 'Moderate')
+      assert_html_has_tag(actual_html, 'select option', :value => '3', :content => 'Limited')
     end
 
     it 'should display correct select in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
 
     it 'should display correct select in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
 
     it 'should display correct select in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
-      assert_have_selector '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'user-about'
+      assert_response_has_tag '#demo2 textarea', :name => 'markup_user[about]', :id => 'markup_user_about', :class => 'textarea'
     end
   end
 
   describe 'for #submit method' do
     it 'should display correct submit button html with no options' do
       actual_html = standard_builder.submit
-      assert_has_tag('input[type=submit]', :value => "Submit") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=submit]', :value => "Submit")
     end
 
 
     it 'should display correct submit button html with no caption' do
       actual_html = standard_builder.submit(:class => 'btn')
-      assert_has_tag('input.btn[type=submit]', :value => "Submit") { actual_html }
+      assert_html_has_tag(actual_html, 'input.btn[type=submit]', :value => "Submit")
     end
 
     it 'should display correct submit button html with nil caption' do
       actual_html = standard_builder.submit(nil, :class => 'btn')
-      assert_has_tag('input.btn[type=submit]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.btn[type=submit]')
       assert actual_html !~ %r{ value \* = }x
     end
 
     it 'should display correct submit button html' do
       actual_html = standard_builder.submit("Commit", :class => 'large')
-      assert_has_tag('input.large[type=submit]', :value => "Commit") { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=submit]', :value => "Commit")
     end
 
     it 'should display correct submit button in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
-      assert_have_selector '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
+      assert_response_has_tag '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
     end
 
     it 'should display correct submit button in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
-      assert_have_selector '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
+      assert_response_has_tag '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
     end
 
     it 'should display correct submit button in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
-      assert_have_selector '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input', :type => 'submit', :id => 'demo-button', :class => 'success'
+      assert_response_has_tag '#demo2 input', :type => 'submit', :class => 'button', :value => "Create"
     end
   end
 
@@ -826,30 +829,30 @@ describe "FormBuilder" do
 
     it 'should display correct image submit button html with no options' do
       actual_html = standard_builder.image_submit('buttons/ok.png')
-      assert_has_tag('input[type=image]', :src => "/images/buttons/ok.png?#{@stamp}") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=image]', :src => "/images/buttons/ok.png?#{@stamp}")
     end
 
     it 'should display correct image submit button html' do
       actual_html = standard_builder.image_submit('/system/ok.png', :class => 'large')
-      assert_has_tag('input.large[type=image]', :src => "/system/ok.png") { actual_html }
+      assert_html_has_tag(actual_html, 'input.large[type=image]', :src => "/system/ok.png")
     end
 
     it 'should display correct image submit button in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
-      assert_have_selector '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
+      assert_response_has_tag '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
 
     it 'should display correct image submit button in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
-      assert_have_selector '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
+      assert_response_has_tag '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
 
     it 'should display correct image submit button in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
-      assert_have_selector '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input', :type => 'image', :id => 'image-button', :src => "/images/buttons/post.png?#{@stamp}"
+      assert_response_has_tag '#demo2 input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
   end
 
@@ -870,10 +873,10 @@ describe "FormBuilder" do
         child_form.text_field(:number) +
         child_form.check_box('_destroy')
       end
-      assert_has_tag('label', :for => 'user_telephone_attributes_number') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_telephone_attributes_number', :name => 'user[telephone_attributes][number]', :value => "4568769876") { actual_html }
-      assert_has_tag('input', :type => 'hidden', :name => 'user[telephone_attributes][_destroy]', :value => '0') { actual_html }
-      assert_has_tag('input', :type => 'checkbox', :id => 'user_telephone_attributes__destroy', :name => 'user[telephone_attributes][_destroy]', :value => '1') { actual_html }
+      assert_html_has_tag(actual_html, 'label', :for => 'user_telephone_attributes_number')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_telephone_attributes_number', :name => 'user[telephone_attributes][number]', :value => "4568769876")
+      assert_html_has_tag(actual_html, 'input', :type => 'hidden', :name => 'user[telephone_attributes][_destroy]', :value => '0')
+      assert_html_has_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_telephone_attributes__destroy', :name => 'user[telephone_attributes][_destroy]', :value => '1')
     end
 
     it 'should display nested children fields one-to-many within form' do
@@ -883,15 +886,15 @@ describe "FormBuilder" do
         html << child_form.text_field(:name)
       end
       # Address 1 (Saved)
-      assert_has_tag('input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '20') { actual_html }
-      assert_has_tag('label', :for => 'user_addresses_attributes_0_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]') { actual_html }
-      assert_has_tag('input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '20')
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_0_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]')
+      assert_html_has_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]')
       # Address 2 (New)
-      assert_has_no_tag('input', :type => 'hidden', :id => 'user_addresses_attributes_1_id') { actual_html }
-      assert_has_tag('label', :for => 'user_addresses_attributes_1_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_1_name', :name => 'user[addresses_attributes][1][name]') { actual_html }
-      assert_has_no_tag('input', :type => 'checkbox', :id => 'user_addresses_attributes_1__destroy') { actual_html }
+      assert_html_has_no_tag(actual_html, 'input', :type => 'hidden', :id => 'user_addresses_attributes_1_id')
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_1_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_1_name', :name => 'user[addresses_attributes][1][name]')
+      assert_html_has_no_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_addresses_attributes_1__destroy')
     end
 
     it 'should display fields for explicit instance object' do
@@ -901,10 +904,10 @@ describe "FormBuilder" do
         html << child_form.text_field(:name)
         html << child_form.check_box('_destroy')
       end
-      assert_has_tag('input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '40') { actual_html }
-      assert_has_tag('label', :for => 'user_addresses_attributes_0_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]', :value => "Page") { actual_html }
-      assert_has_tag('input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]', :value => '1') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '40')
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_0_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]', :value => "Page")
+      assert_html_has_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]', :value => '1')
     end
 
     it 'should display fields for collection object' do
@@ -915,15 +918,15 @@ describe "FormBuilder" do
         child_form.check_box('_destroy')
       end
       # Address 1
-      assert_has_tag('input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '20') { actual_html }
-      assert_has_tag('label', :for => 'user_addresses_attributes_0_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]', :value => "Foo") { actual_html }
-      assert_has_tag('input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :type => 'hidden', :id => 'user_addresses_attributes_0_id', :name => "user[addresses_attributes][0][id]", :value => '20')
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_0_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_0_name', :name => 'user[addresses_attributes][0][name]', :value => "Foo")
+      assert_html_has_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_addresses_attributes_0__destroy', :name => 'user[addresses_attributes][0][_destroy]')
       # Address 3
-      assert_has_tag('input', :type => 'hidden', :id => 'user_addresses_attributes_2_id', :value => '50') { actual_html }
-      assert_has_tag('label', :for => 'user_addresses_attributes_2_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_2_name', :name => 'user[addresses_attributes][2][name]', :value => "Walter") { actual_html }
-      assert_has_tag('input', :type => 'checkbox', :id => 'user_addresses_attributes_2__destroy') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :type => 'hidden', :id => 'user_addresses_attributes_2_id', :value => '50')
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_2_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_2_name', :name => 'user[addresses_attributes][2][name]', :value => "Walter")
+      assert_html_has_tag(actual_html, 'input', :type => 'checkbox', :id => 'user_addresses_attributes_2__destroy')
     end
 
     it 'should display fields for arbitrarily deep nested forms' do
@@ -934,8 +937,8 @@ describe "FormBuilder" do
           second_child_form.check_box('_destroy')
         end
       end
-      assert_has_tag('label', :for => 'user_addresses_attributes_1_businesses_attributes_0_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_0_name', :name => 'user[addresses_attributes][1][businesses_attributes][0][name]') { actual_html }
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_1_businesses_attributes_0_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_0_name', :name => 'user[addresses_attributes][1][businesses_attributes][0][name]')
     end
 
     it 'should display fields for nested forms with custom indices' do
@@ -951,59 +954,59 @@ describe "FormBuilder" do
         html
       end
 
-      assert_has_tag('label', :for => 'user_addresses_attributes_1_businesses_attributes_a_name', :content => 'Name') { actual_html }
-      assert_has_tag('input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_a_name', :name => 'user[addresses_attributes][1][businesses_attributes][a][name]') { actual_html }
+      assert_html_has_tag(actual_html, 'label', :for => 'user_addresses_attributes_1_businesses_attributes_a_name', :content => 'Name')
+      assert_html_has_tag(actual_html, 'input', :type => 'text', :id => 'user_addresses_attributes_1_businesses_attributes_a_name', :name => 'user[addresses_attributes][1][businesses_attributes][a][name]')
     end
 
     it 'should display nested children fields in erb' do
-      visit '/erb/fields_for'
+      get "/erb/fields_for"
       # Telephone
-      assert_have_selector('label', :for => 'markup_user_telephone_attributes_number')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
+      assert_response_has_tag('label', :for => 'markup_user_telephone_attributes_number')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
       # Address 1 (Saved)
-      assert_have_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
-      assert_have_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
+      assert_response_has_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
+      assert_response_has_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
       # Address 2 (New)
-      assert_have_no_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
-      assert_have_no_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
+      assert_response_has_no_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
+      assert_response_has_no_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
     end
 
     it 'should display nested children fields in haml' do
-      visit '/haml/fields_for'
+      get "/haml/fields_for"
       # Telephone
-      assert_have_selector('label', :for => 'markup_user_telephone_attributes_number')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
+      assert_response_has_tag('label', :for => 'markup_user_telephone_attributes_number')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
       # Address 1 (Saved)
-      assert_have_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
-      assert_have_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
+      assert_response_has_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
+      assert_response_has_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
       # Address 2 (New)
-      assert_have_no_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
-      assert_have_no_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
+      assert_response_has_no_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
+      assert_response_has_no_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
     end
 
     it 'should display nested children fields in slim' do
-      visit '/slim/fields_for'
+      get "/slim/fields_for"
       # Telephone
-      assert_have_selector('label', :for => 'markup_user_telephone_attributes_number')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
+      assert_response_has_tag('label', :for => 'markup_user_telephone_attributes_number')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_telephone_attributes_number', :name => 'markup_user[telephone_attributes][number]', :value => "62634576545")
       # Address 1 (Saved)
-      assert_have_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
-      assert_have_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
+      assert_response_has_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_0_id', :name => "markup_user[addresses_attributes][0][id]", :value => '25')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_0_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_0_name', :name => 'markup_user[addresses_attributes][0][name]')
+      assert_response_has_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_0__destroy', :name => 'markup_user[addresses_attributes][0][_destroy]')
       # Address 2 (New)
-      assert_have_no_selector('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
-      assert_have_selector('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
-      assert_have_selector('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
-      assert_have_no_selector('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
+      assert_response_has_no_tag('input', :type => 'hidden', :id => 'markup_user_addresses_attributes_1_id')
+      assert_response_has_tag('label', :for => 'markup_user_addresses_attributes_1_name', :content => 'Name')
+      assert_response_has_tag('input', :type => 'text', :id => 'markup_user_addresses_attributes_1_name', :name => 'markup_user[addresses_attributes][1][name]')
+      assert_response_has_no_tag('input', :type => 'checkbox', :id => 'markup_user_addresses_attributes_1__destroy')
     end
   end
 
@@ -1014,182 +1017,182 @@ describe "FormBuilder" do
   describe 'for #text_field_block method' do
     it 'should display correct text field block html' do
       actual_html = standard_builder.text_field_block(:first_name, :class => 'large', :caption => "FName")
-      assert_has_tag('p label', :for => 'user_first_name', :content => "FName") { actual_html }
-      assert_has_tag('p input.large[type=text]', :value => "Joe", :id => 'user_first_name', :name => 'user[first_name]') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_first_name', :content => "FName")
+      assert_html_has_tag(actual_html, 'p input.large[type=text]', :value => "Joe", :id => 'user_first_name', :name => 'user[first_name]')
     end
 
     it 'should display correct text field block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
-      assert_have_selector '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
+      assert_response_has_tag '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
     end
 
     it 'should display correct text field block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
-      assert_have_selector '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
+      assert_response_has_tag '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
     end
 
     it 'should display correct text field block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
-      assert_have_selector '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_username', :content => "Nickname: ", :class => 'label'
+      assert_response_has_tag '#demo2 p input', :type => 'text', :name => 'markup_user[username]', :id => 'markup_user_username'
     end
   end
 
   describe 'for #text_area_block method' do
     it 'should display correct text area block html' do
       actual_html = standard_builder.text_area_block(:about, :class => 'large', :caption => "About Me")
-      assert_has_tag('p label', :for => 'user_about', :content => "About Me") { actual_html }
-      assert_has_tag('p textarea', :id => 'user_about', :name => 'user[about]') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_about', :content => "About Me")
+      assert_html_has_tag(actual_html, 'p textarea', :id => 'user_about', :name => 'user[about]')
     end
 
     it 'should display correct text area block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_about', :content => "About: "
-      assert_have_selector '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_about', :content => "About: "
+      assert_response_has_tag '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
     end
 
     it 'should display correct text area block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_about', :content => "About: "
-      assert_have_selector '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_about', :content => "About: "
+      assert_response_has_tag '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
     end
 
     it 'should display correct text area block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_about', :content => "About: "
-      assert_have_selector '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_about', :content => "About: "
+      assert_response_has_tag '#demo2 p textarea', :name => 'markup_user[about]', :id => 'markup_user_about'
     end
   end
 
   describe 'for #password_field_block method' do
     it 'should display correct password field block html' do
       actual_html = standard_builder.password_field_block(:keycode, :class => 'large', :caption => "Code: ")
-      assert_has_tag('p label', :for => 'user_keycode', :content => "Code: ") { actual_html }
-      assert_has_tag('p input.large[type=password]', :id => 'user_keycode', :name => 'user[keycode]') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_keycode', :content => "Code: ")
+      assert_html_has_tag(actual_html, 'p input.large[type=password]', :id => 'user_keycode', :name => 'user[keycode]')
     end
 
     it 'should display correct password field block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
-      assert_have_selector '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
+      assert_response_has_tag '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
     end
 
     it 'should display correct password field block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
-      assert_have_selector '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
+      assert_response_has_tag '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
     end
 
     it 'should display correct password field block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
-      assert_have_selector '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_code', :content => "Code: "
+      assert_response_has_tag '#demo2 p input', :type => 'password', :name => 'markup_user[code]', :id => 'markup_user_code'
     end
   end
 
   describe 'for #file_field_block method' do
     it 'should display correct file field block html' do
       actual_html = standard_builder.file_field_block(:photo, :class => 'large', :caption => "Photo: ")
-      assert_has_tag('p label', :for => 'user_photo', :content => "Photo: ") { actual_html }
-      assert_has_tag('p input.large[type=file]', :id => 'user_photo', :name => 'user[photo]') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_photo', :content => "Photo: ")
+      assert_html_has_tag(actual_html, 'p input.large[type=file]', :id => 'user_photo', :name => 'user[photo]')
     end
 
     it 'should display correct file field block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
-      assert_have_selector '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
+      assert_response_has_tag '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
 
     it 'should display correct file field block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
-      assert_have_selector '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
+      assert_response_has_tag '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
 
     it 'should display correct file field block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
-      assert_have_selector '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_photo', :content => "Photo: "
+      assert_response_has_tag '#demo2 p input.upload', :type => 'file', :name => 'markup_user[photo]', :id => 'markup_user_photo'
     end
   end
 
   describe 'for #check_box_block method' do
     it 'should display correct check box block html' do
       actual_html = standard_builder.check_box_block(:remember_me, :class => 'large', :caption => "Remember session?")
-      assert_has_tag('p label', :for => 'user_remember_me', :content => "Remember session?") { actual_html }
-      assert_has_tag('p input.large[type=checkbox]', :id => 'user_remember_me', :name => 'user[remember_me]') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_remember_me', :content => "Remember session?")
+      assert_html_has_tag(actual_html, 'p input.large[type=checkbox]', :id => 'user_remember_me', :name => 'user[remember_me]')
     end
 
     it 'should display correct check box block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
-      assert_have_selector '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
+      assert_response_has_tag '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
     end
 
     it 'should display correct check box block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
-      assert_have_selector '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
+      assert_response_has_tag '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
     end
 
     it 'should display correct check box block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
-      assert_have_selector '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_remember_me', :content => "Remember me: "
+      assert_response_has_tag '#demo2 p input.checker', :type => 'checkbox', :name => 'markup_user[remember_me]'
     end
   end
 
   describe 'for #select_block method' do
     it 'should display correct select_block block html' do
       actual_html = standard_builder.select_block(:country, :options => ['USA', 'Canada'], :class => 'large', :caption => "Your country")
-      assert_has_tag('p label', :for => 'user_country', :content => "Your country") { actual_html }
-      assert_has_tag('p select', :id => 'user_country', :name => 'user[country]') { actual_html }
-      assert_has_tag('p select option', :content => 'USA')   { actual_html }
-      assert_has_tag('p select option', :content => 'Canada') { actual_html }
+      assert_html_has_tag(actual_html, 'p label', :for => 'user_country', :content => "Your country")
+      assert_html_has_tag(actual_html, 'p select', :id => 'user_country', :name => 'user[country]')
+      assert_html_has_tag(actual_html, 'p select option', :content => 'USA')
+      assert_html_has_tag(actual_html, 'p select option', :content => 'Canada')
     end
 
     it 'should display correct select_block block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_state', :content => "State: "
-      assert_have_selector '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
-      assert_have_selector '#demo2 p select option',  :content => 'California'
-      assert_have_selector '#demo2 p select option',  :content => 'Texas'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_state', :content => "State: "
+      assert_response_has_tag '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
+      assert_response_has_tag '#demo2 p select option',  :content => 'California'
+      assert_response_has_tag '#demo2 p select option',  :content => 'Texas'
     end
 
     it 'should display correct select_block block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_state', :content => "State: "
-      assert_have_selector '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_state', :content => "State: "
+      assert_response_has_tag '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
     end
 
     it 'should display correct select_block block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p label', :for => 'markup_user_state', :content => "State: "
-      assert_have_selector '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p label', :for => 'markup_user_state', :content => "State: "
+      assert_response_has_tag '#demo2 p select', :name => 'markup_user[state]', :id => 'markup_user_state'
     end
   end
 
   describe 'for #submit_block method' do
     it 'should display correct submit block html' do
       actual_html = standard_builder.submit_block("Update", :class => 'large')
-      assert_has_tag('p input.large[type=submit]', :value => 'Update') { actual_html }
+      assert_html_has_tag(actual_html, 'p input.large[type=submit]', :value => 'Update')
     end
 
     it 'should display correct submit block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p input', :type => 'submit', :class => 'button'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p input', :type => 'submit', :class => 'button'
     end
 
     it 'should display correct submit block in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo2 p input', :type => 'submit', :class => 'button'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo2 p input', :type => 'submit', :class => 'button'
     end
 
     it 'should display correct submit block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p input', :type => 'submit', :class => 'button'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p input', :type => 'submit', :class => 'button'
     end
   end
 
@@ -1200,24 +1203,24 @@ describe "FormBuilder" do
 
     it 'should display correct image submit block html' do
       actual_html = standard_builder.image_submit_block("buttons/ok.png", :class => 'large')
-      assert_has_tag('p input.large[type=image]', :src => "/images/buttons/ok.png?#{@stamp}") { actual_html }
+      assert_html_has_tag(actual_html, 'p input.large[type=image]', :src => "/images/buttons/ok.png?#{@stamp}")
     end
 
     it 'should display correct image submit block in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo2 p input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
+      get "/haml/form_for"
+      assert_response_has_tag '#demo2 p input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
 
     it 'should display correct image submit block in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo2 p input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
+      get "/slim/form_for"
+      assert_response_has_tag '#demo2 p input', :type => 'image', :class => 'image', :src => "/images/buttons/ok.png?#{@stamp}"
     end
   end
 
   describe 'for #datetime_field method' do
     it 'should display correct datetime field html' do
       actual_html = standard_builder.datetime_field(:datetime)
-      assert_has_tag('input[type=datetime]', :id => 'user_datetime', :name => 'user[datetime]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime]', :id => 'user_datetime', :name => 'user[datetime]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1231,29 +1234,29 @@ describe "FormBuilder" do
         :min => "1993-02-24T12:30:45.000+0000",
         :value => "2000-04-01T12:00:00.000+0000"
       }
-      assert_has_tag('input[type=datetime]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime]', expected)
     end
 
     it 'should display correct datetime field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
 
     it 'should display correct datetime field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
 
     it 'should display correct datetime field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=datetime]', :id => 'markup_user_datetime', :max => "2000-04-01T12:00:00.000+0000"
     end
   end
 
   describe 'for #datetime_local_field method' do
     it 'should display correct datetime-local field html' do
       actual_html = standard_builder.datetime_local_field(:datetime_local)
-      assert_has_tag('input[type=datetime-local]', :id => 'user_datetime_local', :name => 'user[datetime_local]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime-local]', :id => 'user_datetime_local', :name => 'user[datetime_local]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1267,29 +1270,29 @@ describe "FormBuilder" do
         :min => "1993-02-24T12:30:45",
         :value => "2000-04-01T12:00:00"
       }
-      assert_has_tag('input[type=datetime-local]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime-local]', expected)
     end
 
     it 'should display correct datetime-local field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
     end
 
     it 'should display correct datetime-local field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
     end
 
     it 'should display correct datetime-local field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=datetime-local]', :id => 'markup_user_datetime_local'
     end
   end
 
   describe 'for #date_field method' do
     it 'should display correct date field html' do
       actual_html = standard_builder.date_field(:date)
-      assert_has_tag('input[type=date]', :id => 'user_date', :name => 'user[date]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=date]', :id => 'user_date', :name => 'user[date]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1303,29 +1306,29 @@ describe "FormBuilder" do
         :min => "1993-02-24",
         :value => "2000-04-01"
       }
-      assert_has_tag('input[type=date]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=date]', expected)
     end
 
     it 'should display correct date field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=date]', :id => 'markup_user_date'
     end
 
     it 'should display correct date field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=date]', :id => 'markup_user_date'
     end
 
     it 'should display correct date field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=date]', :id => 'markup_user_date'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=date]', :id => 'markup_user_date'
     end
   end
 
   describe 'for #month_field method' do
     it 'should display correct month field html' do
       actual_html = standard_builder.month_field(:month)
-      assert_has_tag('input[type=month]', :id => 'user_month', :name => 'user[month]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=month]', :id => 'user_month', :name => 'user[month]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1339,29 +1342,29 @@ describe "FormBuilder" do
         :min => "1993-02",
         :value => "2000-04"
       }
-      assert_has_tag('input[type=month]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=month]', expected)
     end
 
     it 'should display correct month field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=month]', :id => 'markup_user_month'
     end
 
     it 'should display correct month field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=month]', :id => 'markup_user_month'
     end
 
     it 'should display correct month field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=month]', :id => 'markup_user_month'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=month]', :id => 'markup_user_month'
     end
   end
 
   describe 'for #week_field method' do
     it 'should display correct week field html' do
       actual_html = standard_builder.week_field(:week)
-      assert_has_tag('input[type=week]', :id => 'user_week', :name => 'user[week]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=week]', :id => 'user_week', :name => 'user[week]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1375,29 +1378,29 @@ describe "FormBuilder" do
         :min => "1993-W08",
         :value => "2000-W13"
       }
-      assert_has_tag('input[type=week]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=week]', expected)
     end
 
     it 'should display correct week field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=week]', :id => 'markup_user_week'
     end
 
     it 'should display correct week field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=week]', :id => 'markup_user_week'
     end
 
     it 'should display correct week field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=week]', :id => 'markup_user_week'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=week]', :id => 'markup_user_week'
     end
   end
 
   describe 'for #time_field method' do
     it 'should display correct time field html' do
       actual_html = standard_builder.time_field(:time)
-      assert_has_tag('input[type=time]', :id => 'user_time', :name => 'user[time]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=time]', :id => 'user_time', :name => 'user[time]')
     end
 
     it 'should format DateTime to correct value if min and max and value options exist' do
@@ -1411,44 +1414,44 @@ describe "FormBuilder" do
         :min => "01:19:12.000",
         :value => "13:30:00.000"
       }
-      assert_has_tag('input[type=time]', expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=time]', expected)
     end
 
     it 'should display correct time field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=time]', :id => 'markup_user_time'
     end
 
     it 'should display correct time field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=time]', :id => 'markup_user_time'
     end
 
     it 'should display correct time field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=time]', :id => 'markup_user_time'
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=time]', :id => 'markup_user_time'
     end
   end
 
   describe 'for #color_field method' do
     it 'should display correct color field html' do
       actual_html = standard_builder.color_field(:color)
-      assert_has_tag('input[type=color]', :id => 'user_color', :name => 'user[color]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=color]', :id => 'user_color', :name => 'user[color]')
     end
 
     it 'should display correct color field in haml' do
-      visit '/haml/form_for'
-      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+      get "/haml/form_for"
+      assert_response_has_tag '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
     end
 
     it 'should display correct color field in erb' do
-      visit '/erb/form_for'
-      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+      get "/erb/form_for"
+      assert_response_has_tag '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
     end
 
     it 'should display correct color field in slim' do
-      visit '/slim/form_for'
-      assert_have_selector '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
+      get "/slim/form_for"
+      assert_response_has_tag '#demo input[type=color]', :id => 'markup_user_color', :value => "#ff0000"
     end
   end
 end

--- a/padrino-helpers/test/test_form_helpers.rb
+++ b/padrino-helpers/test/test_form_helpers.rb
@@ -15,148 +15,148 @@ describe "FormHelpers" do
   describe 'for #form_tag method' do
     it 'should display correct forms in ruby' do
       actual_html = form_tag('/register', :"accept-charset" => "UTF-8", :class => 'test', :method => "post") { "Demo" }
-      assert_has_tag(:form, :"accept-charset" => "UTF-8", :class => "test") { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => '_method', :count => 0) { actual_html }
+      assert_html_has_tag(actual_html, :form, :"accept-charset" => "UTF-8", :class => "test")
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => '_method', :count => 0)
     end
 
     it 'should display correct text inputs within form_tag' do
       actual_html = form_tag('/register', :"accept-charset" => "UTF-8", :class => 'test') { text_field_tag(:username) }
-      assert_has_tag('form input', :type => 'text', :name => "username") { actual_html }
-      assert_has_no_tag('form input', :type => 'hidden', :name => "_method") { actual_html }
+      assert_html_has_tag(actual_html, 'form input', :type => 'text', :name => "username")
+      assert_html_has_no_tag(actual_html, 'form input', :type => 'hidden', :name => "_method")
     end
 
     it 'should display correct form with remote' do
       actual_html = form_tag('/update', :"accept-charset" => "UTF-8", :class => 'put-form', :remote => true) { "Demo" }
-      assert_has_tag(:form, :class => "put-form", :"accept-charset" => "UTF-8", :"data-remote" => 'true') { actual_html }
-      assert_has_no_tag(:form, "data-method" => 'post') { actual_html }
+      assert_html_has_tag(actual_html, :form, :class => "put-form", :"accept-charset" => "UTF-8", :"data-remote" => 'true')
+      assert_html_has_no_tag(actual_html, :form, "data-method" => 'post')
     end
 
     it 'should display correct form with remote and method is put' do
       actual_html = form_tag('/update', :"accept-charset" => "UTF-8", :method => 'put', :remote => true) { "Demo" }
-      assert_has_tag(:form, "data-remote" => 'true', :"accept-charset" => "UTF-8") { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'put') { actual_html }
+      assert_html_has_tag(actual_html, :form, "data-remote" => 'true', :"accept-charset" => "UTF-8")
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'put')
     end
 
     it 'should display correct form with method :put' do
       actual_html = form_tag('/update', :"accept-charset" => "UTF-8", :class => 'put-form', :method => "put") { "Demo" }
-      assert_has_tag(:form, :class => "put-form", :"accept-charset" => "UTF-8", :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'put') { actual_html }
+      assert_html_has_tag(actual_html, :form, :class => "put-form", :"accept-charset" => "UTF-8", :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'put')
     end
 
     it 'should display correct form with method :delete and charset' do
       actual_html = form_tag('/remove', :"accept-charset" => "UTF-8", :class => 'delete-form', :method => "delete") { "Demo" }
-      assert_has_tag(:form, :class => "delete-form", :"accept-charset" => "UTF-8", :method => 'post') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'delete') { actual_html }
+      assert_html_has_tag(actual_html, :form, :class => "delete-form", :"accept-charset" => "UTF-8", :method => 'post')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'delete')
     end
 
     it 'should display correct form with charset' do
       actual_html = form_tag('/charset', :"accept-charset" => "UTF-8", :class => 'charset-form') { "Demo" }
-      assert_has_tag(:form, :class => "charset-form", :"accept-charset" => "UTF-8", :method => 'post') { actual_html }
+      assert_html_has_tag(actual_html, :form, :class => "charset-form", :"accept-charset" => "UTF-8", :method => 'post')
     end
 
     it 'should display correct form with multipart encoding' do
       actual_html = form_tag('/remove', :"accept-charset" => "UTF-8", :multipart => true) { "Demo" }
-      assert_has_tag(:form, :enctype => "multipart/form-data") { actual_html }
+      assert_html_has_tag(actual_html, :form, :enctype => "multipart/form-data")
     end
 
     it 'should have an authenticity_token for method :post, :put or :delete' do
       %w(post put delete).each do |method|
         actual_html = form_tag('/modify', :method => method) { "Demo" }
-        assert_has_tag(:input, :name => 'authenticity_token') { actual_html }
+        assert_html_has_tag(actual_html, :input, :name => 'authenticity_token')
       end
     end
 
     it 'should not have an authenticity_token if method: :get' do
       actual_html = form_tag('/get', :method => :get) { "Demo" }
-      assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
+      assert_html_has_no_tag(actual_html, :input, :name => 'authenticity_token')
     end
 
     it 'should have an authenticity_token by default' do
       actual_html = form_tag('/superadmindelete') { "Demo" }
-      assert_has_tag(:input, :name => 'authenticity_token') { actual_html }
+      assert_html_has_tag(actual_html, :input, :name => 'authenticity_token')
     end
 
     it 'should create csrf meta tags with token and param - #csrf_meta_tags' do
       actual_html = csrf_meta_tags
-      assert_has_tag(:meta, :name => 'csrf-param') { actual_html }
-      assert_has_tag(:meta, :name => 'csrf-token') { actual_html }
+      assert_html_has_tag(actual_html, :meta, :name => 'csrf-param')
+      assert_html_has_tag(actual_html, :meta, :name => 'csrf-token')
     end
 
     it 'should have an authenticity_token by default' do
       actual_html = form_tag('/superadmindelete') { "Demo" }
-      assert_has_tag(:input, :name => 'authenticity_token') { actual_html }
+      assert_html_has_tag(actual_html, :input, :name => 'authenticity_token')
     end
 
     it 'should not have an authenticity_token if passing protect_from_csrf: false' do
       actual_html = form_tag('/superadmindelete', :protect_from_csrf => false) { "Demo" }
-      assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
+      assert_html_has_no_tag(actual_html, :input, :name => 'authenticity_token')
     end
 
     it 'should not have an authenticity_token if protect_from_csrf is false on app settings' do
       self.expects(:settings).returns(UnprotectedApp.new)
       actual_html = form_tag('/superadmindelete') { "Demo" }
-      assert_has_no_tag(:input, :name => 'authenticity_token') { actual_html }
+      assert_html_has_no_tag(actual_html, :input, :name => 'authenticity_token')
     end
 
     it 'should not include protect_from_csrf as an attribute of form element' do
       actual_html = form_tag('/superadmindelete', :protect_from_csrf => true){ "Demo" }
-      assert_has_no_tag(:form, protect_from_csrf: "true"){ actual_html }
+      assert_html_has_no_tag(actual_html, :form, protect_from_csrf: "true")
     end
 
     it 'should display correct forms in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form', :action => '/simple'
-      assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
-      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form', :action => '/simple'
+      assert_response_has_tag 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
+      assert_response_has_tag 'form.simple-form input', :name => 'authenticity_token'
+      assert_response_has_no_tag 'form.no-protection input', :name => 'authenticity_token'
     end
 
     it 'should display correct forms in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form', :action => '/simple'
-      assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
-      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form', :action => '/simple'
+      assert_response_has_tag 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
+      assert_response_has_tag 'form.simple-form input', :name => 'authenticity_token'
+      assert_response_has_no_tag 'form.no-protection input', :name => 'authenticity_token'
     end
 
     it 'should display correct forms in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form', :action => '/simple'
-      assert_have_selector 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
-      assert_have_selector 'form.simple-form input', :name => 'authenticity_token'
-      assert_have_no_selector 'form.no-protection input', :name => 'authenticity_token'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form', :action => '/simple'
+      assert_response_has_tag 'form.advanced-form', :action => '/advanced', :id => 'advanced', :method => 'get'
+      assert_response_has_tag 'form.simple-form input', :name => 'authenticity_token'
+      assert_response_has_no_tag 'form.no-protection input', :name => 'authenticity_token'
     end
   end
 
   describe 'for #field_set_tag method' do
     it 'should display correct field_sets in ruby' do
       actual_html = field_set_tag("Basic", :class => 'basic') { "Demo" }
-      assert_has_tag(:fieldset, :class => 'basic') { actual_html }
-      assert_has_tag('fieldset legend', :content => "Basic") { actual_html }
+      assert_html_has_tag(actual_html, :fieldset, :class => 'basic')
+      assert_html_has_tag(actual_html, 'fieldset legend', :content => "Basic")
     end
 
     it 'should display correct field_sets in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form fieldset', :count => 1
-      assert_have_no_selector 'form.simple-form fieldset legend'
-      assert_have_selector 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
-      assert_have_selector 'form.advanced-form fieldset legend', :content => "Advanced"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form fieldset', :count => 1
+      assert_response_has_no_tag 'form.simple-form fieldset legend'
+      assert_response_has_tag 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
+      assert_response_has_tag 'form.advanced-form fieldset legend', :content => "Advanced"
     end
 
     it 'should display correct field_sets in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form fieldset', :count => 1
-      assert_have_no_selector 'form.simple-form fieldset legend'
-      assert_have_selector 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
-      assert_have_selector 'form.advanced-form fieldset legend', :content => "Advanced"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form fieldset', :count => 1
+      assert_response_has_no_tag 'form.simple-form fieldset legend'
+      assert_response_has_tag 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
+      assert_response_has_tag 'form.advanced-form fieldset legend', :content => "Advanced"
     end
 
     it 'should display correct field_sets in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form fieldset', :count => 1
-      assert_have_no_selector 'form.simple-form fieldset legend'
-      assert_have_selector 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
-      assert_have_selector 'form.advanced-form fieldset legend', :content => "Advanced"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form fieldset', :count => 1
+      assert_response_has_no_tag 'form.simple-form fieldset legend'
+      assert_response_has_tag 'form.advanced-form fieldset', :count => 1, :class => 'advanced-field-set'
+      assert_response_has_tag 'form.advanced-form fieldset legend', :content => "Advanced"
     end
   end
 
@@ -164,53 +164,53 @@ describe "FormHelpers" do
     it 'should display correct error messages list in ruby' do
       user = mock_model("User", :errors => { :a => "1", :b => "2" })
       actual_html = error_messages_for(user)
-      assert_has_tag('div.field-errors') { actual_html }
-      assert_has_tag('div.field-errors h2', :content => "2 errors prohibited this User from being saved") { actual_html }
-      assert_has_tag('div.field-errors p', :content => "There were problems with the following fields:") { actual_html }
-      assert_has_tag('div.field-errors ul') { actual_html }
-      assert_has_tag('div.field-errors ul li', :count => 2) { actual_html }
+      assert_html_has_tag(actual_html, 'div.field-errors')
+      assert_html_has_tag(actual_html, 'div.field-errors h2', :content => "2 errors prohibited this User from being saved")
+      assert_html_has_tag(actual_html, 'div.field-errors p', :content => "There were problems with the following fields:")
+      assert_html_has_tag(actual_html, 'div.field-errors ul')
+      assert_html_has_tag(actual_html, 'div.field-errors ul li', :count => 2)
     end
 
     it 'should display correct error messages list in erb' do
-      visit '/erb/form_tag'
-      assert_have_no_selector 'form.simple-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
-      assert_have_selector 'form.advanced-form .field-errors p', :content => "There were problems with the following fields:"
-      assert_have_selector 'form.advanced-form .field-errors ul'
-      assert_have_selector 'form.advanced-form .field-errors ul li', :count => 4
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Second must be present"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
+      get "/erb/form_tag"
+      assert_response_has_no_tag 'form.simple-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
+      assert_response_has_tag 'form.advanced-form .field-errors p', :content => "There were problems with the following fields:"
+      assert_response_has_tag 'form.advanced-form .field-errors ul'
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :count => 4
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
     end
 
     it 'should display correct error messages list in haml' do
-      visit '/haml/form_tag'
-      assert_have_no_selector 'form.simple-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
-      assert_have_selector 'form.advanced-form .field-errors p',  :content => "There were problems with the following fields:"
-      assert_have_selector 'form.advanced-form .field-errors ul'
-      assert_have_selector 'form.advanced-form .field-errors ul li', :count => 4
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Second must be present"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
+      get "/haml/form_tag"
+      assert_response_has_no_tag 'form.simple-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
+      assert_response_has_tag 'form.advanced-form .field-errors p',  :content => "There were problems with the following fields:"
+      assert_response_has_tag 'form.advanced-form .field-errors ul'
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :count => 4
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
     end
 
     it 'should display correct error messages list in slim' do
-      visit '/slim/form_tag'
-      assert_have_no_selector 'form.simple-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors'
-      assert_have_selector 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
-      assert_have_selector 'form.advanced-form .field-errors p',  :content => "There were problems with the following fields:"
-      assert_have_selector 'form.advanced-form .field-errors ul'
-      assert_have_selector 'form.advanced-form .field-errors ul li', :count => 4
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Second must be present"
-      assert_have_selector 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
+      get "/slim/form_tag"
+      assert_response_has_no_tag 'form.simple-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors'
+      assert_response_has_tag 'form.advanced-form .field-errors h2', :content => "There are problems with saving user!"
+      assert_response_has_tag 'form.advanced-form .field-errors p',  :content => "There were problems with the following fields:"
+      assert_response_has_tag 'form.advanced-form .field-errors ul'
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :count => 4
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Email must be an email"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Fake must be valid"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Second must be present"
+      assert_response_has_tag 'form.advanced-form .field-errors ul li', :content => "Third must be a number"
     end
   end
 
@@ -218,13 +218,13 @@ describe "FormHelpers" do
     it 'should display correct error message on specified model name in ruby' do
       @user = mock_model("User", :errors => { :a => "1", :b => "2" })
       actual_html = error_message_on(:user, :a, :prepend => "foo", :append => "bar")
-      assert_has_tag('span.error', :content => "foo 1 bar") { actual_html }
+      assert_html_has_tag(actual_html, 'span.error', :content => "foo 1 bar")
     end
 
     it 'should display correct error message on specified object in ruby' do
       @bob = mock_model("User", :errors => { :a => "1", :b => "2" })
       actual_html = error_message_on(@bob, :a, :prepend => "foo", :append => "bar")
-      assert_has_tag('span.error', :content => "foo 1 bar") { actual_html }
+      assert_html_has_tag(actual_html, 'span.error', :content => "foo 1 bar")
     end
 
     it 'should display no message when error is not present' do
@@ -243,437 +243,437 @@ describe "FormHelpers" do
   describe 'for #label_tag method' do
     it 'should display label tag in ruby' do
       actual_html = label_tag(:username, :class => 'long-label', :caption => "Nickname")
-      assert_has_tag(:label, :for => 'username', :class => 'long-label', :content => "Nickname") { actual_html }
+      assert_html_has_tag(actual_html, :label, :for => 'username', :class => 'long-label', :content => "Nickname")
     end
 
     it 'should display label tag in ruby with required' do
       actual_html = label_tag(:username, :caption => "Nickname", :required => true)
-      assert_has_tag(:label, :for => 'username', :content => 'Nickname') { actual_html }
-      assert_has_tag('label[for=username] span.required', :content => "*") { actual_html }
+      assert_html_has_tag(actual_html, :label, :for => 'username', :content => 'Nickname')
+      assert_html_has_tag(actual_html, 'label[for=username] span.required', :content => "*")
     end
 
     it 'should display label tag in ruby with a block' do
       actual_html = label_tag(:admin, :class => 'long-label') { input_tag :checkbox }
-      assert_has_tag(:label, :for => 'admin', :class => 'long-label', :content => "Admin") { actual_html }
-      assert_has_tag('label input[type=checkbox]') { actual_html }
+      assert_html_has_tag(actual_html, :label, :for => 'admin', :class => 'long-label', :content => "Admin")
+      assert_html_has_tag(actual_html, 'label input[type=checkbox]')
     end
 
     it 'should display label tag in erb for simple form' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form label', :count => 9
-      assert_have_selector 'form.simple-form label', :content => "Username", :for => 'username'
-      assert_have_selector 'form.simple-form label', :content => "Password", :for => 'password'
-      assert_have_selector 'form.simple-form label', :content => "Gender", :for => 'gender'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form label', :count => 9
+      assert_response_has_tag 'form.simple-form label', :content => "Username", :for => 'username'
+      assert_response_has_tag 'form.simple-form label', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.simple-form label', :content => "Gender", :for => 'gender'
     end
 
     it 'should display label tag in erb for advanced form' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.advanced-form label', :count => 11
-      assert_have_selector 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
-      assert_have_selector 'form.advanced-form label.first', :content => "Password", :for => 'password'
-      assert_have_selector 'form.advanced-form label.about', :content => "About Me", :for => 'about'
-      assert_have_selector 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
-      assert_have_selector 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.advanced-form label', :count => 11
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.advanced-form label.about', :content => "About Me", :for => 'about'
+      assert_response_has_tag 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
+      assert_response_has_tag 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
     end
 
     it 'should display label tag in haml for simple form' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form label', :count => 9
-      assert_have_selector 'form.simple-form label', :content => "Username", :for => 'username'
-      assert_have_selector 'form.simple-form label', :content => "Password", :for => 'password'
-      assert_have_selector 'form.simple-form label', :content => "Gender", :for => 'gender'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form label', :count => 9
+      assert_response_has_tag 'form.simple-form label', :content => "Username", :for => 'username'
+      assert_response_has_tag 'form.simple-form label', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.simple-form label', :content => "Gender", :for => 'gender'
     end
 
     it 'should display label tag in haml for advanced form' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.advanced-form label', :count => 11
-      assert_have_selector 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
-      assert_have_selector 'form.advanced-form label.first', :content => "Password", :for => 'password'
-      assert_have_selector 'form.advanced-form label.about', :content => "About Me", :for => 'about'
-      assert_have_selector 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
-      assert_have_selector 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.advanced-form label', :count => 11
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.advanced-form label.about', :content => "About Me", :for => 'about'
+      assert_response_has_tag 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
+      assert_response_has_tag 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
     end
 
     it 'should display label tag in slim for simple form' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form label', :count => 9
-      assert_have_selector 'form.simple-form label', :content => "Username", :for => 'username'
-      assert_have_selector 'form.simple-form label', :content => "Password", :for => 'password'
-      assert_have_selector 'form.simple-form label', :content => "Gender", :for => 'gender'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form label', :count => 9
+      assert_response_has_tag 'form.simple-form label', :content => "Username", :for => 'username'
+      assert_response_has_tag 'form.simple-form label', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.simple-form label', :content => "Gender", :for => 'gender'
     end
 
     it 'should display label tag in slim for advanced form' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.advanced-form label', :count => 11
-      assert_have_selector 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
-      assert_have_selector 'form.advanced-form label.first', :content => "Password", :for => 'password'
-      assert_have_selector 'form.advanced-form label.about', :content => "About Me", :for => 'about'
-      assert_have_selector 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
-      assert_have_selector 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.advanced-form label', :count => 11
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Nickname", :for => 'username'
+      assert_response_has_tag 'form.advanced-form label.first', :content => "Password", :for => 'password'
+      assert_response_has_tag 'form.advanced-form label.about', :content => "About Me", :for => 'about'
+      assert_response_has_tag 'form.advanced-form label.photo', :content => "Photo"   , :for => 'photo'
+      assert_response_has_tag 'form.advanced-form label.gender', :content => "Gender"   , :for => 'gender'
     end
   end
 
   describe 'for #hidden_field_tag method' do
     it 'should display hidden field in ruby' do
       actual_html = hidden_field_tag(:session_key, :id => 'session_id', :value => '56768')
-      assert_has_tag(:input, :type => 'hidden', :id => "session_id", :name => 'session_key', :value => '56768') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'hidden', :id => "session_id", :name => 'session_key', :value => '56768')
     end
 
     it 'should display hidden field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
-      assert_have_selector 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      assert_response_has_tag 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
     end
 
     it 'should display hidden field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
-      assert_have_selector 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      assert_response_has_tag 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
     end
 
     it 'should display hidden field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
-      assert_have_selector 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
+      assert_response_has_tag 'form.advanced-form input[type=hidden]', :count => 1, :name => 'session_id', :value => "__secret__"
     end
   end
 
   describe 'for #text_field_tag method' do
     it 'should display text field in ruby' do
       actual_html = text_field_tag(:username, :class => 'long')
-      assert_has_tag(:input, :type => 'text', :class => "long", :name => 'username') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'text', :class => "long", :name => 'username')
     end
 
     it 'should display text field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=text]', :count => 1, :name => 'username'
-      assert_have_selector 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=text]', :count => 1, :name => 'username'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
     end
 
     it 'should display text field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=text]', :count => 1, :name => 'username'
-      assert_have_selector 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=text]', :count => 1, :name => 'username'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
     end
 
     it 'should display text field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=text]', :count => 1, :name => 'username'
-      assert_have_selector 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=text]', :count => 1, :name => 'username'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=text]', :count => 1, :name => 'username', :id => 'the_username'
     end
   end
 
   describe 'for #number_field_tag method' do
     it 'should display number field in ruby' do
       actual_html = number_field_tag(:age, :class => 'numeric')
-      assert_has_tag(:input, :type => 'number', :class => 'numeric', :name => 'age') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'number', :class => 'numeric', :name => 'age')
     end
 
     it 'should display number field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=number]', :count => 1, :name => 'age'
-      assert_have_selector 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=number]', :count => 1, :name => 'age'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
     end
 
     it 'should display number field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=number]', :count => 1, :name => 'age'
-      assert_have_selector 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=number]', :count => 1, :name => 'age'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
     end
 
     it 'should display number field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=number]', :count => 1, :name => 'age'
-      assert_have_selector 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=number]', :count => 1, :name => 'age'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=number]', :count => 1, :name => 'age', :class => 'numeric'
     end
   end
 
   describe 'for #telephone_field_tag method' do
     it 'should display number field in ruby' do
       actual_html = telephone_field_tag(:telephone, :class => 'numeric')
-      assert_has_tag(:input, :type => 'tel', :class => 'numeric', :name => 'telephone') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'tel', :class => 'numeric', :name => 'telephone')
     end
 
     it 'should display telephone field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
-      assert_have_selector 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
     end
 
     it 'should display telephone field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
-      assert_have_selector 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
     end
 
     it 'should display telephone field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
-      assert_have_selector 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=tel]', :count => 1, :name => 'telephone'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=tel]', :count => 1, :name => 'telephone', :class => 'numeric'
     end
   end
 
   describe 'for #search_field_tag method' do
     it 'should display search field in ruby' do
       actual_html = search_field_tag(:search, :class => 'string')
-      assert_has_tag(:input, :type => 'search', :class => 'string', :name => 'search') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'search', :class => 'string', :name => 'search')
     end
 
     it 'should display search field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=search]', :count => 1, :name => 'search'
-      assert_have_selector 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=search]', :count => 1, :name => 'search'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
     end
 
     it 'should display search field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=search]', :count => 1, :name => 'search'
-      assert_have_selector 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=search]', :count => 1, :name => 'search'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
     end
 
     it 'should display search field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=search]', :count => 1, :name => 'search'
-      assert_have_selector 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=search]', :count => 1, :name => 'search'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=search]', :count => 1, :name => 'search', :class => 'string'
     end
   end
 
   describe 'for #email_field_tag method' do
     it 'should display email field in ruby' do
       actual_html = email_field_tag(:email, :class => 'string')
-      assert_has_tag(:input, :type => 'email', :class => 'string', :name => 'email') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'email', :class => 'string', :name => 'email')
     end
 
     it 'should display email field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=email]', :count => 1, :name => 'email'
-      assert_have_selector 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=email]', :count => 1, :name => 'email'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
     end
 
     it 'should display email field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=email]', :count => 1, :name => 'email'
-      assert_have_selector 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=email]', :count => 1, :name => 'email'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
     end
 
     it 'should display email field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=email]', :count => 1, :name => 'email'
-      assert_have_selector 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=email]', :count => 1, :name => 'email'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=email]', :count => 1, :name => 'email', :class => 'string'
     end
   end
 
   describe 'for #url_field_tag method' do
     it 'should display url field in ruby' do
       actual_html = url_field_tag(:webpage, :class => 'string')
-      assert_has_tag(:input, :type => 'url', :class => 'string', :name => 'webpage') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'url', :class => 'string', :name => 'webpage')
     end
 
     it 'should display url field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
-      assert_have_selector 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
     end
 
     it 'should display url field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
-      assert_have_selector 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
     end
 
     it 'should display url field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
-      assert_have_selector 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=url]', :count => 1, :name => 'webpage'
+      assert_response_has_tag 'form.advanced-form fieldset input[type=url]', :count => 1, :name => 'webpage', :class => 'string'
     end
   end
 
   describe 'for #text_area_tag method' do
     it 'should display text area in ruby' do
       actual_html = text_area_tag(:about, :class => 'long')
-      assert_has_tag(:textarea, :class => "long", :name => 'about') { actual_html }
+      assert_html_has_tag(actual_html, :textarea, :class => "long", :name => 'about')
     end
 
     it 'should display text area in ruby with specified content' do
       actual_html = text_area_tag(:about, :value => "a test", :rows => 5, :cols => 6)
-      assert_has_tag(:textarea, :content => "a test", :name => 'about', :rows => "5", :cols => "6") { actual_html }
+      assert_html_has_tag(actual_html, :textarea, :content => "a test", :name => 'about', :rows => "5", :cols => "6")
     end
 
     it 'should insert newline to before of content' do
       actual_html = text_area_tag(:about, :value => "\na test&".html_safe)
-      assert_has_tag(:textarea, :content => "\na test&".html_safe, :name => 'about') { actual_html }
+      assert_html_has_tag(actual_html, :textarea, :content => "\na test&".html_safe, :name => 'about')
       assert_match(%r{<textarea[^>]*>\n\na test&</textarea>}, actual_html)
     end
 
     it 'should display text area in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
     end
 
     it 'should display text area in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
     end
 
     it 'should display text area in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.advanced-form textarea', :count => 1, :name => 'about', :class => 'large'
     end
   end
 
   describe 'for #password_field_tag method' do
     it 'should display password field in ruby' do
       actual_html = password_field_tag(:password, :class => 'long')
-      assert_has_tag(:input, :type => 'password', :class => "long", :name => 'password') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'password', :class => "long", :name => 'password')
     end
 
     it 'should display password field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=password]', :count => 1, :name => 'password'
-      assert_have_selector 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=password]', :count => 1, :name => 'password'
+      assert_response_has_tag 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
     end
 
     it 'should display password field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=password]', :count => 1, :name => 'password'
-      assert_have_selector 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=password]', :count => 1, :name => 'password'
+      assert_response_has_tag 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
     end
 
     it 'should display password field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=password]', :count => 1, :name => 'password'
-      assert_have_selector 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=password]', :count => 1, :name => 'password'
+      assert_response_has_tag 'form.advanced-form input[type=password]', :count => 1, :name => 'password'
     end
   end
 
   describe 'for #file_field_tag method' do
     it 'should display file field in ruby' do
       actual_html = file_field_tag(:photo, :class => 'photo')
-      assert_has_tag(:input, :type => 'file', :class => "photo", :name => 'photo') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'file', :class => "photo", :name => 'photo')
     end
 
     it 'should have an array name with multiple option' do
       actual_html = file_field_tag(:photos, :multiple => true)
-      assert_has_tag(:input, :name => 'photos[]') { actual_html }
+      assert_html_has_tag(actual_html, :input, :name => 'photos[]')
     end
 
     it 'should display file field in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
     end
 
     it 'should display file field in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
     end
 
     it 'should display file field in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=file]', :count => 1, :name => 'photo', :class => 'upload'
     end
   end
 
   describe "for #check_box_tag method" do
     it 'should display check_box tag in ruby' do
       actual_html = check_box_tag("clear_session")
-      assert_has_tag(:input, :type => 'checkbox', :value => '1', :name => 'clear_session') { actual_html }
-      assert_has_no_tag(:input, :type => 'hidden') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'checkbox', :value => '1', :name => 'clear_session')
+      assert_html_has_no_tag(actual_html, :input, :type => 'hidden')
     end
 
     it 'should display check_box tag in ruby with extended attributes' do
       actual_html = check_box_tag("clear_session", :disabled => true, :checked => true)
-      assert_has_tag(:input, :type => 'checkbox', :disabled => 'disabled', :checked => 'checked') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'checkbox', :disabled => 'disabled', :checked => 'checked')
     end
 
     it 'should display check_box tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=checkbox]', :count => 1
-      assert_have_selector 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=checkbox]', :count => 1
+      assert_response_has_tag 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
     end
 
     it 'should display check_box tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=checkbox]', :count => 1
-      assert_have_selector 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=checkbox]', :count => 1
+      assert_response_has_tag 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
     end
 
     it 'should display check_box tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=checkbox]', :count => 1
-      assert_have_selector 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=checkbox]', :count => 1
+      assert_response_has_tag 'form.advanced-form input[type=checkbox]', :value => "1", :checked => 'checked'
     end
   end
 
   describe "for #radio_button_tag method" do
     it 'should display radio_button tag in ruby' do
       actual_html = radio_button_tag("gender", :value => 'male')
-      assert_has_tag(:input, :type => 'radio', :value => 'male', :name => 'gender') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'radio', :value => 'male', :name => 'gender')
     end
 
     it 'should display radio_button tag in ruby with extended attributes' do
       actual_html = radio_button_tag("gender", :disabled => true, :checked => true)
-      assert_has_tag(:input, :type => 'radio', :disabled => 'disabled', :checked => 'checked') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'radio', :disabled => 'disabled', :checked => 'checked')
     end
 
     it 'should display radio_button tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "female"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "female"
     end
 
     it 'should display radio_button tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "female"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "female"
     end
 
     it 'should display radio_button tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
-      assert_have_selector 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
-      assert_have_selector 'form.advanced-form input[type=radio]', :value => "female"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'male'
+      assert_response_has_tag 'form.simple-form input[type=radio]', :count => 1, :value => 'female'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "male", :checked => 'checked'
+      assert_response_has_tag 'form.advanced-form input[type=radio]', :value => "female"
     end
   end
 
   describe "for #select_tag method" do
     it 'should display select tag in ruby' do
       actual_html = select_tag(:favorite_color, :options => ['green', 'blue', 'black'], :include_blank => true)
-      assert_has_tag(:select, :name => 'favorite_color') { actual_html }
-      assert_has_tag('select option:first-child', :content => '') { actual_html }
-      assert_has_tag('select option', :content => 'green', :value => 'green') { actual_html }
-      assert_has_tag('select option', :content => 'blue',  :value => 'blue')  { actual_html }
-      assert_has_tag('select option', :content => 'black', :value => 'black') { actual_html }
+      assert_html_has_tag(actual_html, :select, :name => 'favorite_color')
+      assert_html_has_tag(actual_html, 'select option:first-child', :content => '')
+      assert_html_has_tag(actual_html, 'select option', :content => 'green', :value => 'green')
+      assert_html_has_tag(actual_html, 'select option', :content => 'blue',  :value => 'blue')
+      assert_html_has_tag(actual_html, 'select option', :content => 'black', :value => 'black')
     end
 
     it 'should display select tag in ruby with extended attributes' do
       actual_html = select_tag(:favorite_color, :disabled => true, :options => ['only', 'option'])
-      assert_has_tag(:select, :disabled => 'disabled') { actual_html }
+      assert_html_has_tag(actual_html, :select, :disabled => 'disabled')
     end
 
     it 'should take a range as a collection for options' do
       actual_html = select_tag(:favorite_color, :options => (1..3))
-      assert_has_tag(:select) { actual_html }
-      assert_has_tag('select option', :content => '1', :value => '1') { actual_html }
-      assert_has_tag('select option', :content => '2', :value => '2') { actual_html }
-      assert_has_tag('select option', :content => '3', :value => '3') { actual_html }
+      assert_html_has_tag(actual_html, :select)
+      assert_html_has_tag(actual_html, 'select option', :content => '1', :value => '1')
+      assert_html_has_tag(actual_html, 'select option', :content => '2', :value => '2')
+      assert_html_has_tag(actual_html, 'select option', :content => '3', :value => '3')
     end
 
     it 'should include blank for grouped options' do
       opts = { "Red"  => ["Rose","Fire"], "Blue" => ["Sky","Sea"] }
       actual_html = select_tag( 'color', :grouped_options => opts, :include_blank => true )
-      assert_has_tag('select option:first-child', :value => "", :content => "") { actual_html }
+      assert_html_has_tag(actual_html, 'select option:first-child', :value => "", :content => "")
     end
 
     it 'should include blank as caption' do
       opts = { "Red"  => ["Rose","Fire"], "Blue" => ["Sky","Sea"] }
       actual_html = select_tag( 'color', :grouped_options => opts, :include_blank => 'Choose your destiny' )
-      assert_has_tag('select option:first-child', :value => "", :content => "Choose your destiny") { actual_html }
-      assert_has_no_tag('select[include_blank]') { actual_html }
+      assert_html_has_tag(actual_html, 'select option:first-child', :value => "", :content => "Choose your destiny")
+      assert_html_has_no_tag(actual_html, 'select[include_blank]')
     end
 
     it 'should display select tag with grouped options for a nested array' do
@@ -682,13 +682,13 @@ describe "FormHelpers" do
         ["Enemies", ["Palpatine",['Darth Vader',3]]]
       ]
       actual_html = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag(:select,   :name => "name") { actual_html }
-      assert_has_tag(:optgroup, :label => "Friends") { actual_html }
-      assert_has_tag(:option,   :value => "Yoda", :content => "Yoda") { actual_html }
-      assert_has_tag(:option,   :value => "2",  :content => "Obiwan") { actual_html }
-      assert_has_tag(:optgroup, :label => "Enemies") { actual_html }
-      assert_has_tag(:option,   :value => "Palpatine", :content => "Palpatine") { actual_html }
-      assert_has_tag(:option,   :value => "3", :content => "Darth Vader") { actual_html }
+      assert_html_has_tag(actual_html, :select,   :name => "name")
+      assert_html_has_tag(actual_html, :optgroup, :label => "Friends")
+      assert_html_has_tag(actual_html, :option,   :value => "Yoda", :content => "Yoda")
+      assert_html_has_tag(actual_html, :option,   :value => "2",  :content => "Obiwan")
+      assert_html_has_tag(actual_html, :optgroup, :label => "Enemies")
+      assert_html_has_tag(actual_html, :option,   :value => "Palpatine", :content => "Palpatine")
+      assert_html_has_tag(actual_html, :option,   :value => "3", :content => "Darth Vader")
     end
 
     it 'should display select tag with grouped options for a nested array and accept disabled groups' do
@@ -697,10 +697,10 @@ describe "FormHelpers" do
         ["Enemies", ["Palpatine",['Darth Vader',3]], {:disabled => true}]
       ]
       actual_html = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag(:select,   :name => "name") { actual_html }
-      assert_has_tag(:option,   :disabled => 'disabled', :count => 0) { actual_html }
-      assert_has_tag(:optgroup, :disabled => 'disabled', :count => 1) { actual_html }
-      assert_has_tag(:optgroup, :label => "Enemies", :disabled => 'disabled') { actual_html }
+      assert_html_has_tag(actual_html, :select,   :name => "name")
+      assert_html_has_tag(actual_html, :option,   :disabled => 'disabled', :count => 0)
+      assert_html_has_tag(actual_html, :optgroup, :disabled => 'disabled', :count => 1)
+      assert_html_has_tag(actual_html, :optgroup, :label => "Enemies", :disabled => 'disabled')
     end
 
     it 'should display select tag with grouped options for a nested array and accept disabled groups and/or with disabled options' do
@@ -709,12 +709,12 @@ describe "FormHelpers" do
         ["Enemies", [["Palpatine", "Palpatine", {:disabled => true}],['Darth Vader',3]], {:disabled => true}]
       ]
       actual_html = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag(:select,   :name => "name") { actual_html }
-      assert_has_tag(:option,   :disabled => 'disabled', :count => 2) { actual_html }
-      assert_has_tag(:optgroup, :disabled => 'disabled', :count => 1) { actual_html }
-      assert_has_tag(:option,   :content => "Obiwan", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:optgroup, :label => "Enemies", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:option,   :value => "Palpatine", :content => "Palpatine", :disabled => 'disabled') { actual_html }
+      assert_html_has_tag(actual_html, :select,   :name => "name")
+      assert_html_has_tag(actual_html, :option,   :disabled => 'disabled', :count => 2)
+      assert_html_has_tag(actual_html, :optgroup, :disabled => 'disabled', :count => 1)
+      assert_html_has_tag(actual_html, :option,   :content => "Obiwan", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :optgroup, :label => "Enemies", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :option,   :value => "Palpatine", :content => "Palpatine", :disabled => 'disabled')
     end
 
     it 'should display select tag with grouped options for a hash' do
@@ -723,13 +723,13 @@ describe "FormHelpers" do
         "Enemies" => ["Palpatine",['Darth Vader',3]]
       }
       actual_html = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag(:select,   :name  => "name")    { actual_html }
-      assert_has_tag(:optgroup, :label => "Friends") { actual_html }
-      assert_has_tag(:option,   :value => "Yoda", :content => "Yoda")   { actual_html }
-      assert_has_tag(:option,   :value => "2",    :content => "Obiwan") { actual_html }
-      assert_has_tag(:optgroup, :label => "Enemies") { actual_html }
-      assert_has_tag(:option,   :value => "Palpatine", :content => "Palpatine") { actual_html }
-      assert_has_tag(:option,   :value => "3", :content => "Darth Vader") { actual_html }
+      assert_html_has_tag(actual_html, :select,   :name  => "name")
+      assert_html_has_tag(actual_html, :optgroup, :label => "Friends")
+      assert_html_has_tag(actual_html, :option,   :value => "Yoda", :content => "Yoda")
+      assert_html_has_tag(actual_html, :option,   :value => "2",    :content => "Obiwan")
+      assert_html_has_tag(actual_html, :optgroup, :label => "Enemies")
+      assert_html_has_tag(actual_html, :option,   :value => "Palpatine", :content => "Palpatine")
+      assert_html_has_tag(actual_html, :option,   :value => "3", :content => "Darth Vader")
     end
 
     it 'should display select tag with grouped options for a hash and accept disabled groups and/or with disabled options' do
@@ -738,12 +738,12 @@ describe "FormHelpers" do
         "Enemies" => [["Palpatine","Palpatine",{:disabled => true}],["Darth Vader",3], {:disabled => true}]
       }
       actual_html = select_tag( 'name', :grouped_options => opts )
-      assert_has_tag(:select,   :name => "name") { actual_html }
-      assert_has_tag(:option,   :disabled => 'disabled', :count => 2) { actual_html }
-      assert_has_tag(:optgroup, :disabled => 'disabled', :count => 1) { actual_html }
-      assert_has_tag(:option,   :content => "Obiwan", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:optgroup, :label => "Enemies", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:option,   :value => "Palpatine", :content => "Palpatine", :disabled => 'disabled') { actual_html }
+      assert_html_has_tag(actual_html, :select,   :name => "name")
+      assert_html_has_tag(actual_html, :option,   :disabled => 'disabled', :count => 2)
+      assert_html_has_tag(actual_html, :optgroup, :disabled => 'disabled', :count => 1)
+      assert_html_has_tag(actual_html, :option,   :content => "Obiwan", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :optgroup, :label => "Enemies", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :option,   :value => "Palpatine", :content => "Palpatine", :disabled => 'disabled')
     end
 
     it 'should display select tag with grouped options for a rails-style attribute hash' do
@@ -752,185 +752,185 @@ describe "FormHelpers" do
         "Enemies" => [["Palpatine","Palpatine",{:scary=>'yes',:old=>'yes'}],["Darth Vader",3,{:disabled=>true}]]
       }
       actual_html = select_tag( 'name', :grouped_options => opts, :disabled_options => [2], :selected => ['Yoda'] )
-      assert_has_tag(:optgroup, :label => "Friends", :lame => 'yes') { actual_html }
-      assert_has_tag(:option,   :value => "Palpatine", :content => "Palpatine", :scary => 'yes', :old => 'yes') { actual_html }
-      assert_has_tag(:option,   :content => "Darth Vader", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:option,   :content => "Obiwan", :disabled => 'disabled') { actual_html }
-      assert_has_tag(:option,   :content => "Yoda", :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, :optgroup, :label => "Friends", :lame => 'yes')
+      assert_html_has_tag(actual_html, :option,   :value => "Palpatine", :content => "Palpatine", :scary => 'yes', :old => 'yes')
+      assert_html_has_tag(actual_html, :option,   :content => "Darth Vader", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :option,   :content => "Obiwan", :disabled => 'disabled')
+      assert_html_has_tag(actual_html, :option,   :content => "Yoda", :selected => 'selected')
     end
 
     it 'should display select tag in ruby with multiple attribute' do
       actual_html = select_tag(:favorite_color, :multiple => true, :options => ['only', 'option'])
-      assert_has_tag(:select, :multiple => 'multiple', :name => 'favorite_color[]') { actual_html }
+      assert_html_has_tag(actual_html, :select, :multiple => 'multiple', :name => 'favorite_color[]')
     end
 
     it 'should display options with values and single selected' do
       options = [['Green', 'green1'], ['Blue', 'blue1'], ['Black', "black1"]]
       actual_html = select_tag(:favorite_color, :options => options, :selected => 'green1')
-      assert_has_tag(:select, :name => 'favorite_color') { actual_html }
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'Green', :value => 'green1', :selected => 'selected') { actual_html }
-      assert_has_tag('select option', :content => 'Blue', :value => 'blue1') { actual_html }
-      assert_has_tag('select option', :content => 'Black', :value => 'black1') { actual_html }
+      assert_html_has_tag(actual_html, :select, :name => 'favorite_color')
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'Green', :value => 'green1', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Blue', :value => 'blue1')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Black', :value => 'black1')
     end
 
     it 'should display selected options first based on values not content' do
       options = [['First', 'one'], ['one', 'two'], ['three', 'three']]
       actual_html = select_tag(:number, :options => options, :selected => 'one')
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'First', :value => 'one', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'First', :value => 'one', :selected => 'selected')
     end
 
     it 'should display selected options falling back to checking content' do
       options = [['one', nil, :value => nil], ['two', nil, :value => nil], ['three', 'three']]
       actual_html = select_tag(:number, :options => options, :selected => 'one')
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'one', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'one', :selected => 'selected')
     end
 
     it 'should display options with values and accept disabled options' do
       options = [['Green', 'green1', {:disabled => true}], ['Blue', 'blue1'], ['Black', "black1"]]
       actual_html = select_tag(:favorite_color, :options => options)
-      assert_has_tag(:select, :name => 'favorite_color') { actual_html }
-      assert_has_tag('select option', :disabled => 'disabled', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'Green', :value => 'green1', :disabled => 'disabled') { actual_html }
-      assert_has_tag('select option', :content => 'Blue', :value => 'blue1') { actual_html }
-      assert_has_tag('select option', :content => 'Black', :value => 'black1') { actual_html }
+      assert_html_has_tag(actual_html, :select, :name => 'favorite_color')
+      assert_html_has_tag(actual_html, 'select option', :disabled => 'disabled', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'Green', :value => 'green1', :disabled => 'disabled')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Blue', :value => 'blue1')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Black', :value => 'black1')
     end
 
     it 'should display option with values and multiple selected' do
       options = [['Green', 'green1'], ['Blue', 'blue1'], ['Black', "black1"]]
       actual_html = select_tag(:favorite_color, :options => options, :selected => ['green1', 'black1'])
-      assert_has_tag(:select, :name => 'favorite_color') { actual_html }
-      assert_has_tag('select option', :selected => 'selected', :count => 2) { actual_html }
-      assert_has_tag('select option', :content => 'Green', :value => 'green1', :selected => 'selected') { actual_html }
-      assert_has_tag('select option', :content => 'Blue', :value => 'blue1') { actual_html }
-      assert_has_tag('select option', :content => 'Black', :value => 'black1', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, :select, :name => 'favorite_color')
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 2)
+      assert_html_has_tag(actual_html, 'select option', :content => 'Green', :value => 'green1', :selected => 'selected')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Blue', :value => 'blue1')
+      assert_html_has_tag(actual_html, 'select option', :content => 'Black', :value => 'black1', :selected => 'selected')
     end
 
     it 'should not misselect options with default value' do
       options = ['Green', 'Blue']
       actual_html = select_tag(:favorite_color, :options => options, :selected => ['Green', ''])
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'Green', :value => 'Green', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'Green', :value => 'Green', :selected => 'selected')
     end
 
     it 'should display options selected only for exact match' do
       options = [['One', '1'], ['1', '10'], ['Two', "-1"]]
       actual_html = select_tag(:range, :options => options, :selected => '-1')
-      assert_has_tag(:select, :name => 'range') { actual_html }
-      assert_has_tag('select option', :selected => 'selected', :count => 1) { actual_html }
-      assert_has_tag('select option', :content => 'Two', :value => '-1', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, :select, :name => 'range')
+      assert_html_has_tag(actual_html, 'select option', :selected => 'selected', :count => 1)
+      assert_html_has_tag(actual_html, 'select option', :content => 'Two', :value => '-1', :selected => 'selected')
     end
 
     it 'should display select tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form select', :count => 1, :name => 'color'
-      assert_have_selector('select option', :content => 'green',  :value => 'green')
-      assert_have_selector('select option', :content => 'orange', :value => 'orange')
-      assert_have_selector('select option', :content => 'purple', :value => 'purple')
-      assert_have_selector('form.advanced-form select', :name => 'fav_color')
-      assert_have_selector('select option', :content => 'green',  :value => '1')
-      assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
-      assert_have_selector('select option', :content => 'purple', :value => '3')
-      assert_have_selector('select optgroup', :label => 'foo')
-      assert_have_selector('select optgroup', :label => 'bar')
-      assert_have_selector('select optgroup option', :content => 'foo', :value => 'foo')
-      assert_have_selector('select optgroup option', :content => 'bar', :value => 'bar')
-      assert_have_selector('select optgroup', :label => 'Friends')
-      assert_have_selector('select optgroup', :label => 'Enemies')
-      assert_have_selector('select optgroup option', :content => 'Yoda', :value => 'Yoda')
-      assert_have_selector('select optgroup option', :content => 'Obiwan', :value => '1')
-      assert_have_selector('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
-      assert_have_selector('select optgroup option', :content => 'Darth Vader', :value => '3')
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form select', :count => 1, :name => 'color'
+      assert_response_has_tag('select option', :content => 'green',  :value => 'green')
+      assert_response_has_tag('select option', :content => 'orange', :value => 'orange')
+      assert_response_has_tag('select option', :content => 'purple', :value => 'purple')
+      assert_response_has_tag('form.advanced-form select', :name => 'fav_color')
+      assert_response_has_tag('select option', :content => 'green',  :value => '1')
+      assert_response_has_tag('select option', :content => 'orange', :value => '2', :selected => 'selected')
+      assert_response_has_tag('select option', :content => 'purple', :value => '3')
+      assert_response_has_tag('select optgroup', :label => 'foo')
+      assert_response_has_tag('select optgroup', :label => 'bar')
+      assert_response_has_tag('select optgroup option', :content => 'foo', :value => 'foo')
+      assert_response_has_tag('select optgroup option', :content => 'bar', :value => 'bar')
+      assert_response_has_tag('select optgroup', :label => 'Friends')
+      assert_response_has_tag('select optgroup', :label => 'Enemies')
+      assert_response_has_tag('select optgroup option', :content => 'Yoda', :value => 'Yoda')
+      assert_response_has_tag('select optgroup option', :content => 'Obiwan', :value => '1')
+      assert_response_has_tag('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
+      assert_response_has_tag('select optgroup option', :content => 'Darth Vader', :value => '3')
     end
 
     it 'should display select tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form select', :count => 1, :name => 'color'
-      assert_have_selector('select option', :content => 'green',  :value => 'green')
-      assert_have_selector('select option', :content => 'orange', :value => 'orange')
-      assert_have_selector('select option', :content => 'purple', :value => 'purple')
-      assert_have_selector('form.advanced-form select', :name => 'fav_color')
-      assert_have_selector('select option', :content => 'green',  :value => '1')
-      assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
-      assert_have_selector('select option', :content => 'purple', :value => '3')
-      assert_have_selector('select optgroup', :label => 'foo')
-      assert_have_selector('select optgroup', :label => 'bar')
-      assert_have_selector('select optgroup option', :content => 'foo', :value => 'foo')
-      assert_have_selector('select optgroup option', :content => 'bar', :value => 'bar')
-      assert_have_selector('select optgroup', :label => 'Friends')
-      assert_have_selector('select optgroup', :label => 'Enemies')
-      assert_have_selector('select optgroup option', :content => 'Yoda', :value => 'Yoda')
-      assert_have_selector('select optgroup option', :content => 'Obiwan', :value => '1')
-      assert_have_selector('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
-      assert_have_selector('select optgroup option', :content => 'Darth Vader', :value => '3')
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form select', :count => 1, :name => 'color'
+      assert_response_has_tag('select option', :content => 'green',  :value => 'green')
+      assert_response_has_tag('select option', :content => 'orange', :value => 'orange')
+      assert_response_has_tag('select option', :content => 'purple', :value => 'purple')
+      assert_response_has_tag('form.advanced-form select', :name => 'fav_color')
+      assert_response_has_tag('select option', :content => 'green',  :value => '1')
+      assert_response_has_tag('select option', :content => 'orange', :value => '2', :selected => 'selected')
+      assert_response_has_tag('select option', :content => 'purple', :value => '3')
+      assert_response_has_tag('select optgroup', :label => 'foo')
+      assert_response_has_tag('select optgroup', :label => 'bar')
+      assert_response_has_tag('select optgroup option', :content => 'foo', :value => 'foo')
+      assert_response_has_tag('select optgroup option', :content => 'bar', :value => 'bar')
+      assert_response_has_tag('select optgroup', :label => 'Friends')
+      assert_response_has_tag('select optgroup', :label => 'Enemies')
+      assert_response_has_tag('select optgroup option', :content => 'Yoda', :value => 'Yoda')
+      assert_response_has_tag('select optgroup option', :content => 'Obiwan', :value => '1')
+      assert_response_has_tag('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
+      assert_response_has_tag('select optgroup option', :content => 'Darth Vader', :value => '3')
     end
 
     it 'should display select tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form select', :count => 1, :name => 'color'
-      assert_have_selector('select option', :content => 'green',  :value => 'green')
-      assert_have_selector('select option', :content => 'orange', :value => 'orange')
-      assert_have_selector('select option', :content => 'purple', :value => 'purple')
-      assert_have_selector('form.advanced-form select', :name => 'fav_color')
-      assert_have_selector('select option', :content => 'green',  :value => '1')
-      assert_have_selector('select option', :content => 'orange', :value => '2', :selected => 'selected')
-      assert_have_selector('select option', :content => 'purple', :value => '3')
-      assert_have_selector('select optgroup', :label => 'foo')
-      assert_have_selector('select optgroup', :label => 'bar')
-      assert_have_selector('select optgroup option', :content => 'foo', :value => 'foo')
-      assert_have_selector('select optgroup option', :content => 'bar', :value => 'bar')
-      assert_have_selector('select optgroup', :label => 'Friends')
-      assert_have_selector('select optgroup', :label => 'Enemies')
-      assert_have_selector('select optgroup option', :content => 'Yoda', :value => 'Yoda')
-      assert_have_selector('select optgroup option', :content => 'Obiwan', :value => '1')
-      assert_have_selector('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
-      assert_have_selector('select optgroup option', :content => 'Darth Vader', :value => '3')
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form select', :count => 1, :name => 'color'
+      assert_response_has_tag('select option', :content => 'green',  :value => 'green')
+      assert_response_has_tag('select option', :content => 'orange', :value => 'orange')
+      assert_response_has_tag('select option', :content => 'purple', :value => 'purple')
+      assert_response_has_tag('form.advanced-form select', :name => 'fav_color')
+      assert_response_has_tag('select option', :content => 'green',  :value => '1')
+      assert_response_has_tag('select option', :content => 'orange', :value => '2', :selected => 'selected')
+      assert_response_has_tag('select option', :content => 'purple', :value => '3')
+      assert_response_has_tag('select optgroup', :label => 'foo')
+      assert_response_has_tag('select optgroup', :label => 'bar')
+      assert_response_has_tag('select optgroup option', :content => 'foo', :value => 'foo')
+      assert_response_has_tag('select optgroup option', :content => 'bar', :value => 'bar')
+      assert_response_has_tag('select optgroup', :label => 'Friends')
+      assert_response_has_tag('select optgroup', :label => 'Enemies')
+      assert_response_has_tag('select optgroup option', :content => 'Yoda', :value => 'Yoda')
+      assert_response_has_tag('select optgroup option', :content => 'Obiwan', :value => '1')
+      assert_response_has_tag('select optgroup option', :content => 'Palpatine', :value => 'Palpatine')
+      assert_response_has_tag('select optgroup option', :content => 'Darth Vader', :value => '3')
     end
   end
 
   describe 'for #submit_tag method' do
     it 'should display submit tag in ruby' do
       actual_html = submit_tag("Update", :class => 'success')
-      assert_has_tag(:input, :type => 'submit', :class => "success", :value => 'Update') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'submit', :class => "success", :value => 'Update')
     end
 
     it 'should display submit tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
-      assert_have_selector 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
+      assert_response_has_tag 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
     end
 
     it 'should display submit tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
-      assert_have_selector 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
+      assert_response_has_tag 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
     end
 
     it 'should display submit tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
-      assert_have_selector 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.simple-form input[type=submit]', :count => 1, :value => "Submit"
+      assert_response_has_tag 'form.advanced-form input[type=submit]', :count => 1, :value => "Login"
     end
 
     describe 'for omitted args' do
       it 'should display submit tag with default caption' do
         actual_html = submit_tag()
-        assert_has_tag(:input, :type => 'submit', :value => 'Submit') { actual_html }
+        assert_html_has_tag(actual_html, :input, :type => 'submit', :value => 'Submit')
       end
     end
 
     describe 'for omitted caption arg' do
       it 'should display submit tag with default caption' do
         actual_html = submit_tag(:class => 'success')
-        assert_has_tag(:input, :type => 'submit', :class => 'success', :value => 'Submit') { actual_html }
+        assert_html_has_tag(actual_html, :input, :type => 'submit', :class => 'success', :value => 'Submit')
       end
 
       it 'should display submit tag without caption value when nil' do
         actual_html = submit_tag(nil, :class => 'success')
-        assert_has_tag(:input, :type => 'submit', :class => 'success') { actual_html }
-        assert_has_no_tag(:input, :type => 'submit', :class => 'success', :value => 'Submit') { actual_html }
+        assert_html_has_tag(actual_html, :input, :type => 'submit', :class => 'success')
+        assert_html_has_no_tag(actual_html, :input, :type => 'submit', :class => 'success', :value => 'Submit')
       end
     end
   end
@@ -938,22 +938,22 @@ describe "FormHelpers" do
   describe 'for #button_tag method' do
     it 'should display submit tag in ruby' do
       actual_html = button_tag("Cancel", :class => 'clear')
-      assert_has_tag(:input, :type => 'button', :class => "clear", :value => 'Cancel') { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'button', :class => "clear", :value => 'Cancel')
     end
 
     it 'should display submit tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
     end
 
     it 'should display submit tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
     end
 
     it 'should display submit tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=button]', :count => 1, :value => "Cancel"
     end
   end
 
@@ -964,108 +964,108 @@ describe "FormHelpers" do
 
     it 'should display image submit tag in ruby with relative path' do
       actual_html = image_submit_tag('buttons/ok.png', :class => 'success')
-      assert_has_tag(:input, :type => 'image', :class => "success", :src => "/images/buttons/ok.png?#{@stamp}") { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'image', :class => "success", :src => "/images/buttons/ok.png?#{@stamp}")
     end
 
     it 'should display image submit tag in ruby with absolute path' do
       actual_html = image_submit_tag('/system/ok.png', :class => 'success')
-      assert_has_tag(:input, :type => 'image', :class => "success", :src => "/system/ok.png") { actual_html }
+      assert_html_has_tag(actual_html, :input, :type => 'image', :class => "success", :src => "/system/ok.png")
     end
 
     it 'should display image submit tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
+      get "/erb/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
     end
 
     it 'should display image submit tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
+      get "/haml/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
     end
 
     it 'should display image submit tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
+      get "/slim/form_tag"
+      assert_response_has_tag 'form.advanced-form input[type=image]', :count => 1, :src => "/images/buttons/submit.png?#{@stamp}"
     end
   end
 
   describe 'for #button_to method' do
     it 'should have a form and set the method properly' do
       actual_html = button_to('Delete', '/users/1', :method => :delete)
-      assert_has_tag('form', :action => '/users/1') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "_method", :value => 'delete') { actual_html }
-      assert_has_tag('form input', :type => 'hidden', :name => "authenticity_token") { actual_html }
+      assert_html_has_tag(actual_html, 'form', :action => '/users/1')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "_method", :value => 'delete')
+      assert_html_has_tag(actual_html, 'form input', :type => 'hidden', :name => "authenticity_token")
     end
 
     it 'should add a submit button by default if no content is specified' do
       actual_html = button_to('My Delete Button', '/users/1', :method => :delete)
-      assert_has_tag('form input', :type => 'submit', :value => 'My Delete Button') { actual_html }
+      assert_html_has_tag(actual_html, 'form input', :type => 'submit', :value => 'My Delete Button')
     end
 
     it 'should set specific content inside the form if a block was sent' do
       actual_html = button_to('My Delete Button', '/users/1', :method => :delete) do
         content_tag :button, "My button's content", :type => :submit, :title => "My button"
       end
-      assert_has_tag('form button', :type => 'submit', :content => "My button's content", :title => "My button") { actual_html }
+      assert_html_has_tag(actual_html, 'form button', :type => 'submit', :content => "My button's content", :title => "My button")
     end
 
     it 'should pass options on submit button when submit_options are given' do
       actual_html = button_to("Fancy button", '/users/1', :submit_options => { :class => :fancy })
-      assert_has_tag('form input', :type => 'submit', :value => 'Fancy button', :class => 'fancy') { actual_html }
-      assert_has_no_tag('form', :"submit_options-class" => 'fancy'){ actual_html }
+      assert_html_has_tag(actual_html, 'form input', :type => 'submit', :value => 'Fancy button', :class => 'fancy')
+      assert_html_has_no_tag(actual_html, 'form', :"submit_options-class" => 'fancy')
     end
 
     it 'should display correct button_to in erb' do
-      visit '/erb/button_to'
-      assert_have_selector('form', :action => '/foo')
-      assert_have_selector('form button label', :for => 'username', :content => 'Username: ')
-      assert_have_selector('form', :action => '/bar')
-      assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      get "/erb/button_to"
+      assert_response_has_tag('form', :action => '/foo')
+      assert_response_has_tag('form button label', :for => 'username', :content => 'Username: ')
+      assert_response_has_tag('form', :action => '/bar')
+      assert_response_has_tag('#test-point ~ form > input[type=submit]', :value => 'Bar button')
     end
 
     it 'should display correct button_to in haml' do
-      visit '/haml/button_to'
-      assert_have_selector('form', :action => '/foo')
-      assert_have_selector('form button label', :for => 'username', :content => 'Username: ')
-      assert_have_selector('form', :action => '/bar')
-      assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      get "/haml/button_to"
+      assert_response_has_tag('form', :action => '/foo')
+      assert_response_has_tag('form button label', :for => 'username', :content => 'Username: ')
+      assert_response_has_tag('form', :action => '/bar')
+      assert_response_has_tag('#test-point ~ form > input[type=submit]', :value => 'Bar button')
     end
 
     it 'should display correct button_to in slim' do
-      visit '/slim/button_to'
-      assert_have_selector('form', :action => '/foo')
-      assert_have_selector('form button label', :for => 'username', :content => 'Username: ')
-      assert_have_selector('form', :action => '/bar')
-      assert_have_selector('#test-point ~ form > input[type=submit]', :value => 'Bar button')
+      get "/slim/button_to"
+      assert_response_has_tag('form', :action => '/foo')
+      assert_response_has_tag('form button label', :for => 'username', :content => 'Username: ')
+      assert_response_has_tag('form', :action => '/bar')
+      assert_response_has_tag('#test-point ~ form > input[type=submit]', :value => 'Bar button')
     end
   end
 
   describe 'for #range_field_tag' do
     it 'should create an input tag with min and max options' do
       actual_html = range_field_tag('ranger', :min => 20, :max => 50)
-      assert_has_tag('input', :type => 'range', :name => 'ranger', :min => '20', :max => '50') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :type => 'range', :name => 'ranger', :min => '20', :max => '50')
     end
 
     it 'should create an input tag with range' do
       actual_html = range_field_tag('ranger', :range => 1..20)
-      assert_has_tag('input', :min => '1', :max => '20') { actual_html }
+      assert_html_has_tag(actual_html, 'input', :min => '1', :max => '20')
     end
 
     it 'should display correct range_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
     end
 
     it 'should display correct range_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
     end
 
     it 'should display correct range_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
-      assert_have_selector 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_min_max', :min => '1', :max => '50', :count => 1
+      assert_response_has_tag 'input', :type => 'range', :name => 'ranger_with_range', :min => '1', :max => '5', :count => 1
     end
   end
 
@@ -1084,32 +1084,32 @@ describe "FormHelpers" do
       min = DateTime.new(1993, 2, 24, 12, 30, 45)
       value = DateTime.new(2000, 4, 1, 12, 0, 0)
       actual_html = datetime_field_tag('datetime', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with datetime' do
       actual_html = datetime_field_tag('datetime')
-      assert_has_tag('input[type=datetime]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime]')
     end
 
     it 'should create an input tag when the format string passed as datetime option value' do
       actual_html = datetime_field_tag('datetime', :value => '1993-02-24T12:30:45+00:00')
-      assert_has_tag('input[type=datetime]', :value => "1993-02-24T12:30:45.000+0000") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=datetime]', :value => "1993-02-24T12:30:45.000+0000")
     end
 
     it 'should display correct datetime_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct datetime_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct datetime_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1128,32 +1128,32 @@ describe "FormHelpers" do
       min = DateTime.new(1993, 2, 24, 12, 30, 45)
       value = DateTime.new(2000, 4, 1, 12, 0, 0)
       actual_html = datetime_local_field_tag('datetime_local', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with datetime-local' do
       actual_html = datetime_local_field_tag('datetime_local')
-      assert_has_tag('input[type="datetime-local"]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="datetime-local"]')
     end
 
     it 'should create an input tag when the format string passed as datetime-local option value' do
       actual_html = datetime_local_field_tag('datetime_local', :value => '1993-02-24T12:30:45')
-      assert_has_tag('input[type="datetime-local"]', :value => "1993-02-24T12:30:45") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="datetime-local"]', :value => "1993-02-24T12:30:45")
     end
 
     it 'should display correct datetime_local_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct datetime_local_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct datetime_local_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1172,32 +1172,32 @@ describe "FormHelpers" do
       min = DateTime.new(1993, 2, 24)
       value = DateTime.new(2000, 4, 1)
       actual_html = date_field_tag('date', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with date' do
       actual_html = date_field_tag('date')
-      assert_has_tag('input[type="date"]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="date"]')
     end
 
     it 'should create an input tag when the format string passed as date option value' do
       actual_html = date_field_tag('date', :value => '1993-02-24')
-      assert_has_tag('input[type="date"]', :value => "1993-02-24") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="date"]', :value => "1993-02-24")
     end
 
     it 'should display correct date_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct date_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct date_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1216,32 +1216,32 @@ describe "FormHelpers" do
       min = DateTime.new(1993, 2, 24)
       value = DateTime.new(2000, 4, 1)
       actual_html = month_field_tag('month', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with month' do
       actual_html = month_field_tag('month')
-      assert_has_tag('input[type="month"]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="month"]')
     end
 
     it 'should create an input tag when the format string passed as month option value' do
       actual_html = month_field_tag('month', :value => '1993-02-24')
-      assert_has_tag('input[type="month"]', :value => "1993-02") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="month"]', :value => "1993-02")
     end
 
     it 'should display correct month_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct month_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct month_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1260,32 +1260,32 @@ describe "FormHelpers" do
       min = DateTime.new(1993, 2, 24)
       value = DateTime.new(2000, 4, 1)
       actual_html = week_field_tag('week', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with week' do
       actual_html = week_field_tag('week')
-      assert_has_tag('input[type="week"]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="week"]')
     end
 
     it 'should create an input tag when the format string passed as week option value' do
       actual_html = week_field_tag('week', :value => '1993-02-24')
-      assert_has_tag('input[type="week"]', :value => "1993-W08") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="week"]', :value => "1993-W08")
     end
 
     it 'should display correct week_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct week_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct week_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1304,32 +1304,32 @@ describe "FormHelpers" do
       min = Time.new(1993, 2, 24, 1, 19, 12)
       value = Time.new(2008, 6, 21, 13, 30, 0)
       actual_html = time_field_tag('time', :max => max, :min => min, :value => value)
-      assert_has_tag('input', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input', @expected)
     end
 
     it 'should create an input tag with time' do
       actual_html = time_field_tag('time')
-      assert_has_tag('input[type="time"]') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="time"]')
     end
 
     it 'should create an input tag when the format string passed as time option value' do
       actual_html = time_field_tag('time', :value => '1993-02-24 01:19:12')
-      assert_has_tag('input[type="time"]', :value => "01:19:12.000") { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="time"]', :value => "01:19:12.000")
     end
 
     it 'should display correct time_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct time_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct time_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 
@@ -1343,27 +1343,27 @@ describe "FormHelpers" do
 
     it 'should create an input tag with value option' do
       actual_html = color_field_tag('color', :value => "#ff0000")
-      assert_has_tag('input[type="color"]', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="color"]', @expected)
     end
 
     it 'should create an input tag with short color code' do
       actual_html = color_field_tag('color', :value => "#f00")
-      assert_has_tag('input[type="color"]', @expected) { actual_html }
+      assert_html_has_tag(actual_html, 'input[type="color"]', @expected)
     end
 
     it 'should display correct color_field_tag in erb' do
-      visit '/erb/form_tag'
-      assert_have_selector 'input', @expected
+      get "/erb/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct color_field_tag in haml' do
-      visit '/haml/form_tag'
-      assert_have_selector 'input', @expected
+      get "/haml/form_tag"
+      assert_response_has_tag 'input', @expected
     end
 
     it 'should display correct color_field_tag in slim' do
-      visit '/slim/form_tag'
-      assert_have_selector 'input', @expected
+      get "/slim/form_tag"
+      assert_response_has_tag 'input', @expected
     end
   end
 end

--- a/padrino-helpers/test/test_output_helpers.rb
+++ b/padrino-helpers/test/test_output_helpers.rb
@@ -8,150 +8,150 @@ describe "OutputHelpers" do
 
   describe 'for #content_for method' do
     it 'should work for erb templates' do
-      visit '/erb/content_for'
-      assert_have_selector '.demo h1', :content => "This is content yielded from a content_for", :count => 1
-      assert_have_selector '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
-      assert_have_no_selector '.demo3 p', :content => "One", :class => "duplication"
-      assert_have_selector '.demo3 p', :content => "Two", :class => "duplication"
+      get "/erb/content_for"
+      assert_response_has_tag '.demo h1', :content => "This is content yielded from a content_for", :count => 1
+      assert_response_has_tag '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
+      assert_response_has_no_tag '.demo3 p', :content => "One", :class => "duplication"
+      assert_response_has_tag '.demo3 p', :content => "Two", :class => "duplication"
     end
 
     it 'should work for haml templates' do
-      visit '/haml/content_for'
-      assert_have_selector '.demo h1', :content => "This is content yielded from a content_for", :count => 1
-      assert_have_selector '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
-      assert_have_no_selector '.demo3 p', :content => "One", :class => "duplication"
-      assert_have_selector '.demo3 p', :content => "Two", :class => "duplication"
+      get "/haml/content_for"
+      assert_response_has_tag '.demo h1', :content => "This is content yielded from a content_for", :count => 1
+      assert_response_has_tag '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
+      assert_response_has_no_tag '.demo3 p', :content => "One", :class => "duplication"
+      assert_response_has_tag '.demo3 p', :content => "Two", :class => "duplication"
     end
 
     it 'should work for slim templates' do
-      visit '/slim/content_for'
-      assert_have_selector '.demo h1', :content => "This is content yielded from a content_for", :count => 1
-      assert_have_selector '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
-      assert_have_no_selector '.demo3 p', :content => "One", :class => "duplication"
-      assert_have_selector '.demo3 p', :content => "Two", :class => "duplication"
+      get "/slim/content_for"
+      assert_response_has_tag '.demo h1', :content => "This is content yielded from a content_for", :count => 1
+      assert_response_has_tag '.demo2 h1', :content => "This is content yielded with name Johnny Smith", :count => 1
+      assert_response_has_no_tag '.demo3 p', :content => "One", :class => "duplication"
+      assert_response_has_tag '.demo3 p', :content => "Two", :class => "duplication"
     end
   end # content_for
 
   describe "for #content_for? method" do
     it 'should work for erb templates' do
-      visit '/erb/content_for'
-      assert_have_selector '.demo_has_content', :content => "true"
-      assert_have_selector '.fake_has_content', :content => "false"
+      get "/erb/content_for"
+      assert_response_has_tag '.demo_has_content', :content => "true"
+      assert_response_has_tag '.fake_has_content', :content => "false"
     end
 
     it 'should work for haml templates' do
-      visit '/haml/content_for'
-      assert_have_selector '.demo_has_content', :content => "true"
-      assert_have_selector '.fake_has_content', :content => "false"
+      get "/haml/content_for"
+      assert_response_has_tag '.demo_has_content', :content => "true"
+      assert_response_has_tag '.fake_has_content', :content => "false"
     end
 
     it 'should work for slim templates' do
-      visit '/slim/content_for'
-      assert_have_selector '.demo_has_content', :content => "true"
-      assert_have_selector '.fake_has_content', :content => "false"
+      get "/slim/content_for"
+      assert_response_has_tag '.demo_has_content', :content => "true"
+      assert_response_has_tag '.fake_has_content', :content => "false"
     end
   end # content_for?
 
   describe 'for #capture_html method' do
     it 'should work for erb templates' do
-      visit '/erb/capture_concat'
-      assert_have_selector 'p span', :content => "Captured Line 1", :count => 1
-      assert_have_selector 'p span', :content => "Captured Line 2", :count => 1
+      get "/erb/capture_concat"
+      assert_response_has_tag 'p span', :content => "Captured Line 1", :count => 1
+      assert_response_has_tag 'p span', :content => "Captured Line 2", :count => 1
     end
 
     it 'should work for haml templates' do
-      visit '/haml/capture_concat'
-      assert_have_selector 'p span', :content => "Captured Line 1", :count => 1
-      assert_have_selector 'p span', :content => "Captured Line 2", :count => 1
+      get "/haml/capture_concat"
+      assert_response_has_tag 'p span', :content => "Captured Line 1", :count => 1
+      assert_response_has_tag 'p span', :content => "Captured Line 2", :count => 1
     end
 
     it 'should work for slim templates' do
-      visit '/slim/capture_concat'
-      assert_have_selector 'p span', :content => "Captured Line 1", :count => 1
-      assert_have_selector 'p span', :content => "Captured Line 2", :count => 1
+      get "/slim/capture_concat"
+      assert_response_has_tag 'p span', :content => "Captured Line 1", :count => 1
+      assert_response_has_tag 'p span', :content => "Captured Line 2", :count => 1
     end
   end
 
   describe 'for #concat_content method' do
     it 'should work for erb templates' do
-      visit '/erb/capture_concat'
-      assert_have_selector 'p', :content => "Concat Line 3", :count => 1
+      get "/erb/capture_concat"
+      assert_response_has_tag 'p', :content => "Concat Line 3", :count => 1
     end
 
     it 'should work for haml templates' do
-      visit '/haml/capture_concat'
-      assert_have_selector 'p', :content => "Concat Line 3", :count => 1
+      get "/haml/capture_concat"
+      assert_response_has_tag 'p', :content => "Concat Line 3", :count => 1
     end
 
     it 'should work for slim templates' do
-      visit '/slim/capture_concat'
-      assert_have_selector 'p', :content => "Concat Line 3", :count => 1
+      get "/slim/capture_concat"
+      assert_response_has_tag 'p', :content => "Concat Line 3", :count => 1
     end
   end
 
   describe 'for #block_is_template?' do
     it 'should work for erb templates' do
-      visit '/erb/capture_concat'
-      assert_have_selector 'p', :content => "The erb block passed in is a template", :class => 'is_template', :count => 1
-      assert_have_no_selector 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
+      get "/erb/capture_concat"
+      assert_response_has_tag 'p', :content => "The erb block passed in is a template", :class => 'is_template', :count => 1
+      assert_response_has_no_tag 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
     end
 
     it 'should work for haml templates' do
-      visit '/haml/capture_concat'
-      assert_have_selector 'p', :content => "The haml block passed in is a template", :class => 'is_template', :count => 1
-      assert_have_no_selector 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
+      get "/haml/capture_concat"
+      assert_response_has_tag 'p', :content => "The haml block passed in is a template", :class => 'is_template', :count => 1
+      assert_response_has_no_tag 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
     end
 
     it 'should work for slim templates' do
-      visit '/slim/capture_concat'
-      assert_have_selector 'p', :content => "The slim block passed in is a template", :class => 'is_template', :count => 1
-      assert_have_no_selector 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
+      get "/slim/capture_concat"
+      assert_response_has_tag 'p', :content => "The slim block passed in is a template", :class => 'is_template', :count => 1
+      assert_response_has_no_tag 'p', :content => "The ruby block passed in is a template", :class => 'is_template', :count => 1
     end
   end
 
   describe 'for #current_engine method' do
     it 'should detect correctly current engine for erb' do
-      visit '/erb/current_engine'
-      assert_have_selector 'p.start', :content => "erb"
-      assert_have_selector 'p.haml',  :content => "haml"
-      assert_have_selector 'p.erb',   :content => "erb"
-      assert_have_selector 'p.slim',  :content => "slim"
-      assert_have_selector 'p.end',   :content => "erb"
+      get "/erb/current_engine"
+      assert_response_has_tag 'p.start', :content => "erb"
+      assert_response_has_tag 'p.haml',  :content => "haml"
+      assert_response_has_tag 'p.erb',   :content => "erb"
+      assert_response_has_tag 'p.slim',  :content => "slim"
+      assert_response_has_tag 'p.end',   :content => "erb"
     end
 
     it 'should detect correctly current engine for haml' do
-      visit '/haml/current_engine'
-      assert_have_selector 'p.start', :content => "haml"
-      assert_have_selector 'p.haml',  :content => "haml"
-      assert_have_selector 'p.erb',   :content => "erb"
-      assert_have_selector 'p.slim',  :content => "slim"
-      assert_have_selector 'p.end',   :content => "haml"
+      get "/haml/current_engine"
+      assert_response_has_tag 'p.start', :content => "haml"
+      assert_response_has_tag 'p.haml',  :content => "haml"
+      assert_response_has_tag 'p.erb',   :content => "erb"
+      assert_response_has_tag 'p.slim',  :content => "slim"
+      assert_response_has_tag 'p.end',   :content => "haml"
     end
 
     it 'should detect correctly current engine for slim' do
-      visit '/slim/current_engine'
-      assert_have_selector 'p.start', :content => "slim"
-      assert_have_selector 'p.haml',  :content => "haml"
-      assert_have_selector 'p.erb',   :content => "erb"
-      assert_have_selector 'p.slim',  :content => "slim"
-      assert_have_selector 'p.end',   :content => "slim"
+      get "/slim/current_engine"
+      assert_response_has_tag 'p.start', :content => "slim"
+      assert_response_has_tag 'p.haml',  :content => "haml"
+      assert_response_has_tag 'p.erb',   :content => "erb"
+      assert_response_has_tag 'p.slim',  :content => "slim"
+      assert_response_has_tag 'p.end',   :content => "slim"
     end
   end
 
   describe 'for #partial method in simple sinatra application' do
     it 'should properly output in erb' do
-      visit '/erb/simple_partial'
-      assert_have_selector 'p.erb',  :content => "erb"
+      get "/erb/simple_partial"
+      assert_response_has_tag 'p.erb',  :content => "erb"
     end
 
     it 'should properly output in haml' do
-      visit '/haml/simple_partial'
-      assert_have_selector 'p.haml',  :content => "haml"
+      get "/haml/simple_partial"
+      assert_response_has_tag 'p.haml',  :content => "haml"
     end
 
     it 'should properly output in slim' do
-      visit '/slim/simple_partial'
-      assert_have_selector 'p.slim',  :content => "slim"
+      get "/slim/simple_partial"
+      assert_response_has_tag 'p.slim',  :content => "slim"
     end
   end
 end

--- a/padrino-helpers/test/test_render_helpers.rb
+++ b/padrino-helpers/test/test_render_helpers.rb
@@ -7,209 +7,209 @@ describe "RenderHelpers" do
   end
 
   describe 'for #partial method and object' do
-    before { visit '/partial/object' }
+    before { get "/partial/object" }
     it 'should render partial html with object' do
-      assert_have_selector "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is John"
     end
     it 'should have no counter index for single item' do
-      assert_have_no_selector "p", :content => "My counter is 1", :count => 1
+      assert_response_has_no_tag "p", :content => "My counter is 1", :count => 1
     end
     it 'should include extra locals information' do
-      assert_have_selector 'p', :content => "Extra is bar"
+      assert_response_has_tag 'p', :content => "Extra is bar"
     end
   end
 
   describe 'for #partial method and collection' do
-    before { visit '/partial/collection' }
+    before { get "/partial/collection" }
     it 'should render partial html with collection' do
-      assert_have_selector "h1", :content => "User name is John"
-      assert_have_selector "h1", :content => "User name is Billy"
+      assert_response_has_tag "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is Billy"
     end
     it 'should include counter which contains item index' do
-      assert_have_selector "p", :content => "My counter is 1"
-      assert_have_selector "p", :content => "My counter is 2"
+      assert_response_has_tag "p", :content => "My counter is 1"
+      assert_response_has_tag "p", :content => "My counter is 2"
     end
     it 'should include extra locals information' do
-      assert_have_selector 'p', :content => "Extra is bar"
+      assert_response_has_tag 'p', :content => "Extra is bar"
     end
   end
 
   describe 'for #partial with ext and collection' do
-    before { visit '/partial/collection.ext' }
+    before { get "/partial/collection.ext" }
     it 'should not fail horribly with `invalid locals key` RuntimeError' do
-      assert_have_selector "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is John"
     end
   end
 
   describe 'for #partial method and locals' do
-    before { visit '/partial/locals' }
+    before { get "/partial/locals" }
     it 'should render partial html with locals' do
-      assert_have_selector "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is John"
     end
     it 'should have no counter index for single item' do
-      assert_have_no_selector "p", :content => "My counter is 1", :count => 1
+      assert_response_has_no_tag "p", :content => "My counter is 1", :count => 1
     end
     it 'should include extra locals information' do
-      assert_have_selector 'p', :content => "Extra is bar"
+      assert_response_has_tag 'p', :content => "Extra is bar"
     end
   end
 
   describe 'for #partial method taking a path starting with forward slash' do
-    before { visit '/partial/foward_slash' }
+    before { get "/partial/foward_slash" }
     it 'should render partial without throwing an error' do
-      assert_have_selector "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is John"
     end
   end
 
   describe 'for #partial method with unsafe engine' do
     it 'should render partial without escaping it' do
-      visit '/partial/unsafe'
-      assert_have_selector "h1", :content => "User name is John"
+      get "/partial/unsafe"
+      assert_response_has_tag "h1", :content => "User name is John"
     end
     it 'should render partial object without escaping it' do
-      visit '/partial/unsafe_one'
-      assert_have_selector "h1", :content => "User name is Mary"
+      get "/partial/unsafe_one"
+      assert_response_has_tag "h1", :content => "User name is Mary"
     end
     it 'should render partial collection without escaping it' do
-      visit '/partial/unsafe_many'
-      assert_have_selector "h1", :content => "User name is John"
-      assert_have_selector "h1", :content => "User name is Mary"
+      get "/partial/unsafe_many"
+      assert_response_has_tag "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is Mary"
     end
     it 'should render unsafe partial without escaping it' do
-      visit '/partial/unsafe?block=%3Cevil%3E'
-      assert_have_selector "h1", :content => "User name is John"
-      assert_have_selector "evil"
+      get "/partial/unsafe?block=%3Cevil%3E"
+      assert_response_has_tag "h1", :content => "User name is John"
+      assert_response_has_tag "evil"
     end
     it 'should render unsafe partial object without escaping it' do
-      visit '/partial/unsafe_one?block=%3Cevil%3E'
-      assert_have_selector "h1", :content => "User name is Mary"
-      assert_have_selector "evil"
+      get "/partial/unsafe_one?block=%3Cevil%3E"
+      assert_response_has_tag "h1", :content => "User name is Mary"
+      assert_response_has_tag "evil"
     end
     it 'should render unsafe partial collection without escaping it' do
-      visit '/partial/unsafe_many?block=%3Cevil%3E'
-      assert_have_selector "h1", :content => "User name is John"
-      assert_have_selector "h1", :content => "User name is Mary"
-      assert_have_selector "evil"
+      get "/partial/unsafe_many?block=%3Cevil%3E"
+      assert_response_has_tag "h1", :content => "User name is John"
+      assert_response_has_tag "h1", :content => "User name is Mary"
+      assert_response_has_tag "evil"
     end
   end
 
   describe 'render with block' do
     it 'should render slim with block' do
-      visit '/render_block_slim'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.slim-block'
-      assert_have_selector 'div', :content => 'go block!'
+      get "/render_block_slim"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.slim-block'
+      assert_response_has_tag 'div', :content => 'go block!'
     end
     it 'should render erb with block' do
-      visit '/render_block_erb'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.erb-block'
-      assert_have_selector 'div', :content => 'go block!'
+      get "/render_block_erb"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.erb-block'
+      assert_response_has_tag 'div', :content => 'go block!'
     end
     it 'should render haml with block' do
-      visit '/render_block_haml'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.haml-block'
-      assert_have_selector 'div', :content => 'go block!'
+      get "/render_block_haml"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.haml-block'
+      assert_response_has_tag 'div', :content => 'go block!'
     end
   end
 
   describe 'partial with block' do
     it 'should show partial slim with block' do
-      visit '/partial_block_slim'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.slim-block'
-      assert_have_selector 'div', :content => 'go block!'
-      assert_have_selector 'div.deep', :content => 'Done'
+      get "/partial_block_slim"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.slim-block'
+      assert_response_has_tag 'div', :content => 'go block!'
+      assert_response_has_tag 'div.deep', :content => 'Done'
     end
     it 'should show partial erb with block' do
-      visit '/partial_block_erb'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.erb-block'
-      assert_have_selector 'div', :content => 'go block!'
-      assert_have_selector 'div.deep', :content => 'Done'
+      get "/partial_block_erb"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.erb-block'
+      assert_response_has_tag 'div', :content => 'go block!'
+      assert_response_has_tag 'div.deep', :content => 'Done'
     end
     it 'should show partial haml with block' do
-      visit '/partial_block_haml'
-      assert_have_selector 'h1', :content => 'prefix'
-      assert_have_selector 'h3', :content => 'postfix'
-      assert_have_selector '.haml-block'
-      assert_have_selector 'div', :content => 'go block!'
-      assert_have_selector 'div.deep', :content => 'Done'
+      get "/partial_block_haml"
+      assert_response_has_tag 'h1', :content => 'prefix'
+      assert_response_has_tag 'h3', :content => 'postfix'
+      assert_response_has_tag '.haml-block'
+      assert_response_has_tag 'div', :content => 'go block!'
+      assert_response_has_tag 'div.deep', :content => 'Done'
     end
   end
 
   describe 'for #current_engine method' do
     it 'should detect correctly current engine for a padrino application' do
-      visit '/current_engine'
-      assert_have_selector 'p.start', :content => "haml"
-      assert_have_selector 'p.haml span',  :content => "haml"
-      assert_have_selector 'p.erb span',   :content => "erb"
-      assert_have_selector 'p.slim span',  :content => "slim"
-      assert_have_selector 'p.end',   :content => "haml"
+      get "/current_engine"
+      assert_response_has_tag 'p.start', :content => "haml"
+      assert_response_has_tag 'p.haml span',  :content => "haml"
+      assert_response_has_tag 'p.erb span',   :content => "erb"
+      assert_response_has_tag 'p.slim span',  :content => "slim"
+      assert_response_has_tag 'p.end',   :content => "haml"
     end
 
     it 'should detect correctly current engine for explicit engine on partials' do
-      visit '/explicit_engine'
-      assert_have_selector 'p.start', :content => "haml"
-      assert_have_selector 'p.haml span',  :content => "haml"
-      assert_have_selector 'p.erb span',   :content => "erb"
-      assert_have_selector 'p.slim span',  :content => "slim"
-      assert_have_selector 'p.end',   :content => "haml"
+      get "/explicit_engine"
+      assert_response_has_tag 'p.start', :content => "haml"
+      assert_response_has_tag 'p.haml span',  :content => "haml"
+      assert_response_has_tag 'p.erb span',   :content => "erb"
+      assert_response_has_tag 'p.slim span',  :content => "slim"
+      assert_response_has_tag 'p.end',   :content => "haml"
     end
 
     it 'should capture slim template once and only once' do
       $number_of_captures = 0
-      visit '/double_capture_slim'
+      get "/double_capture_slim"
       assert_equal 1,$number_of_captures
     end
 
     it 'should capture haml template once and only once' do
       $number_of_captures = 0
-      visit '/double_capture_haml'
+      get "/double_capture_haml"
       assert_equal 1,$number_of_captures
     end
 
     it 'should capture erb template once and only once' do
       $number_of_captures = 0
-      visit '/double_capture_erb'
+      get "/double_capture_erb"
       assert_equal 1,$number_of_captures
     end
 
     it 'should fail on wrong erb usage' do
       assert_raises(SyntaxError) do
-        visit '/wrong_capture_erb'
+        get "/wrong_capture_erb"
       end
     end
 
     it 'should ignore wrong haml usage' do
-      visit '/wrong_capture_haml'
-      assert_have_no_selector 'p', :content => 'this is wrong'
+      get "/wrong_capture_haml"
+      assert_response_has_no_tag 'p', :content => 'this is wrong'
     end
 
     it 'should ignore wrong slim usage' do
-      visit '/wrong_capture_slim'
-      assert_have_no_selector 'p', :content => 'this is wrong'
+      get "/wrong_capture_slim"
+      assert_response_has_no_tag 'p', :content => 'this is wrong'
     end
 
     it 'should support weird ruby blocks in erb' do
-      visit '/ruby_block_capture_erb'
-      assert_have_selector 'b', :content => 'c'
+      get "/ruby_block_capture_erb"
+      assert_response_has_tag 'b', :content => 'c'
     end
 
     it 'should support weird ruby blocks in haml' do
-      visit '/ruby_block_capture_haml'
-      assert_have_selector 'b', :content => 'c'
+      get "/ruby_block_capture_haml"
+      assert_response_has_tag 'b', :content => 'c'
     end
     
     it 'should support weird ruby blocks in slim' do
-      visit '/ruby_block_capture_slim'
-      assert_have_selector 'b', :content => 'c'
+      get "/ruby_block_capture_slim"
+      assert_response_has_tag 'b', :content => 'c'
     end
   end
 

--- a/padrino-helpers/test/test_rendering.rb
+++ b/padrino-helpers/test/test_rendering.rb
@@ -755,8 +755,8 @@ describe "Rendering" do
     %W{erb haml slim}.each do |engine|
       it "should work with #{engine}" do
         @app = RenderDemo
-        visit "/double_dive_#{engine}"
-        assert_have_selector '.outer .wrapper form .inner .core'
+        get "/double_dive_#{engine}"
+        assert_response_has_tag '.outer .wrapper form .inner .core'
       end
     end
   end

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -8,29 +8,29 @@ describe "TagHelpers" do
 
   describe 'for #tag method' do
     it 'should support tags with no content no attributes' do
-      assert_has_tag(:br) { tag(:br) }
+      assert_html_has_tag(tag(:br), :br)
     end
 
     it 'should support tags with no content with attributes' do
       actual_html = tag(:br, :style => 'clear:both', :class => 'yellow')
-      assert_has_tag(:br, :class => 'yellow', :style=>'clear:both') { actual_html }
+      assert_html_has_tag(actual_html, :br, :class => 'yellow', :style=>'clear:both')
     end
 
     it 'should support selected attribute by using "selected" if true' do
       actual_html = tag(:option, :selected => true)
       # fix nokogiri 1.6.8 on jRuby
       actual_html = content_tag(:select, actual_html)
-      assert_has_tag('option', :selected => 'selected') { actual_html }
+      assert_html_has_tag(actual_html, 'option', :selected => 'selected')
     end
 
     it 'should support data attributes' do
       actual_html = tag(:a, :data => { :remote => true, :method => 'post'})
-      assert_has_tag(:a, 'data-remote' => 'true', 'data-method' => 'post') { actual_html }
+      assert_html_has_tag(actual_html, :a, 'data-remote' => 'true', 'data-method' => 'post')
     end
 
     it 'should support nested attributes' do
       actual_html = tag(:div, :data => {:dojo => {:type => 'dijit.form.TextBox', :props => 'readOnly: true'}})
-      assert_has_tag(:div, 'data-dojo-type' => 'dijit.form.TextBox', 'data-dojo-props' => 'readOnly: true') { actual_html }
+      assert_html_has_tag(actual_html, :div, 'data-dojo-type' => 'dijit.form.TextBox', 'data-dojo-props' => 'readOnly: true')
     end
 
     it 'should support open tags' do
@@ -47,87 +47,87 @@ describe "TagHelpers" do
   describe 'for #content_tag method' do
     it 'should support tags with content as parameter' do
       actual_html = content_tag(:p, "Demo", :class => 'large', :id => 'thing')
-      assert_has_tag('p.large#thing', :content => "Demo") { actual_html }
+      assert_html_has_tag(actual_html, 'p.large#thing', :content => "Demo")
     end
 
     it 'should support tags with content as block' do
       actual_html = content_tag(:p, :class => 'large', :id => 'star') { "Demo" }
-      assert_has_tag('p.large#star', :content => "Demo") { actual_html }
+      assert_html_has_tag(actual_html, 'p.large#star', :content => "Demo")
     end
 
     it 'should escape non-html-safe content' do
       actual_html = content_tag(:p, :class => 'large', :id => 'star') { "<>" }
-      assert_has_tag('p.large#star') { actual_html }
+      assert_html_has_tag(actual_html, 'p.large#star')
       assert_match('&lt;&gt;', actual_html)
     end
 
     it 'should not escape html-safe content' do
       actual_html = content_tag(:p, :class => 'large', :id => 'star') { "<>" }
-      assert_has_tag('p.large#star', :content => "<>") { actual_html }
+      assert_html_has_tag(actual_html, 'p.large#star', :content => "<>")
     end
 
     it 'should convert to a string if the content is not a string' do
       actual_html = content_tag(:p, 97)
-      assert_has_tag('p', :content => "97") { actual_html }
+      assert_html_has_tag(actual_html, 'p', :content => "97")
     end
 
     it 'should support tags with erb' do
-      visit '/erb/content_tag'
-      assert_have_selector :p, :content => "Test 1", :class => 'test', :id => 'test1'
-      assert_have_selector :p, :content => "Test 2"
-      assert_have_selector :p, :content => "Test 3"
-      assert_have_selector :p, :content => "Test 4"
-      assert_have_selector :p, :content => "one"
-      assert_have_selector :p, :content => "two"
-      assert_have_no_selector :p, :content => "failed"
+      get "/erb/content_tag"
+      assert_response_has_tag :p, :content => "Test 1", :class => 'test', :id => 'test1'
+      assert_response_has_tag :p, :content => "Test 2"
+      assert_response_has_tag :p, :content => "Test 3"
+      assert_response_has_tag :p, :content => "Test 4"
+      assert_response_has_tag :p, :content => "one"
+      assert_response_has_tag :p, :content => "two"
+      assert_response_has_no_tag :p, :content => "failed"
     end
 
     it 'should support tags with haml' do
-      visit '/haml/content_tag'
-      assert_have_selector :p, :content => "Test 1", :class => 'test', :id => 'test1'
-      assert_have_selector :p, :content => "Test 2"
-      assert_have_selector :p, :content => "Test 3", :class => 'test', :id => 'test3'
-      assert_have_selector :p, :content => "Test 4"
-      assert_have_selector :p, :content => "one"
-      assert_have_selector :p, :content => "two"
-      assert_have_no_selector :p, :content => "failed"
+      get "/haml/content_tag"
+      assert_response_has_tag :p, :content => "Test 1", :class => 'test', :id => 'test1'
+      assert_response_has_tag :p, :content => "Test 2"
+      assert_response_has_tag :p, :content => "Test 3", :class => 'test', :id => 'test3'
+      assert_response_has_tag :p, :content => "Test 4"
+      assert_response_has_tag :p, :content => "one"
+      assert_response_has_tag :p, :content => "two"
+      assert_response_has_no_tag :p, :content => "failed"
     end
 
     it 'should support tags with slim' do
-      visit '/slim/content_tag'
-      assert_have_selector :p, :content => "Test 1", :class => 'test', :id => 'test1'
-      assert_have_selector :p, :content => "Test 2"
-      assert_have_selector :p, :content => "Test 3", :class => 'test', :id => 'test3'
-      assert_have_selector :p, :content => "Test 4"
-      assert_have_selector :p, :content => "one"
-      assert_have_selector :p, :content => "two"
-      assert_have_no_selector :p, :content => "failed"
+      get "/slim/content_tag"
+      assert_response_has_tag :p, :content => "Test 1", :class => 'test', :id => 'test1'
+      assert_response_has_tag :p, :content => "Test 2"
+      assert_response_has_tag :p, :content => "Test 3", :class => 'test', :id => 'test3'
+      assert_response_has_tag :p, :content => "Test 4"
+      assert_response_has_tag :p, :content => "one"
+      assert_response_has_tag :p, :content => "two"
+      assert_response_has_no_tag :p, :content => "failed"
     end
   end
 
   describe 'for #input_tag method' do
     it 'should support field with type' do
-      assert_has_tag('input[type=text]') { input_tag(:text) }
+      assert_html_has_tag(input_tag(:text), 'input[type=text]')
     end
 
     it 'should support field with type and options' do
       actual_html = input_tag(:text, :class => "first", :id => 'texter')
-      assert_has_tag('input.first#texter[type=text]') { actual_html }
+      assert_html_has_tag(actual_html, 'input.first#texter[type=text]')
     end
 
     it 'should support checked attribute by using "checked" if true' do
       actual_html = input_tag(:checkbox, :checked => true)
-      assert_has_tag('input[type=checkbox]', :checked => 'checked') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=checkbox]', :checked => 'checked')
     end
 
     it 'should remove checked attribute if false' do
       actual_html = input_tag(:checkbox, :checked => false)
-      assert_has_no_tag('input[type=checkbox][checked=false]') { actual_html }
+      assert_html_has_no_tag(actual_html, 'input[type=checkbox][checked=false]')
     end
 
     it 'should support disabled attribute by using "disabled" if true' do
       actual_html = input_tag(:checkbox, :disabled => true)
-      assert_has_tag('input[type=checkbox]', :disabled => 'disabled') { actual_html }
+      assert_html_has_tag(actual_html, 'input[type=checkbox]', :disabled => 'disabled')
     end
   end
 end

--- a/padrino/test/ext/minitest-spec.rb
+++ b/padrino/test/ext/minitest-spec.rb
@@ -1,22 +1,4 @@
 class MiniTest::Spec
-  # assert_has_tag(:h1, :content => "yellow") { "<h1>yellow</h1>" }
-  # In this case, block is the html to evaluate
-  def assert_has_tag(name, attributes = {})
-    html = yield if block_given?
-    assert html.html_safe?, 'output in not #html_safe?'
-    matcher = HaveSelector.new(name, attributes)
-    assert matcher.matches?(html), matcher.failure_message
-  end
-
-  # assert_has_no_tag(:h1, :content => "yellow") { "<h1>green</h1>" }
-  # In this case, block is the html to evaluate
-  def assert_has_no_tag(name, attributes = {}, &block)
-    html = yield if block_given?
-    assert html.html_safe?, 'output in not #html_safe?'
-    matcher = HaveSelector.new(name, attributes)
-    assert !matcher.matches?(html), matcher.negative_failure_message
-  end
-
   # Assert_file_exists('/tmp/app')
   def assert_file_exists(file_path)
     assert File.file?(file_path), "File at path '#{file_path}' does not exist!"

--- a/padrino/test/padrino/test-methods.rb
+++ b/padrino/test/padrino/test-methods.rb
@@ -1,0 +1,55 @@
+require 'oga'
+
+module Padrino
+  module TestMethods
+    def assert_html_has_tag(html, tag, attributes={})
+      assert html.html_safe?, 'output in not #html_safe?'
+      assert_has_selector(html, tag, attributes)
+    end
+
+    def assert_html_has_no_tag(html, tag, attributes={})
+      assert html.html_safe?, 'output in not #html_safe?'
+      assert_has_no_selector(html, tag, attributes)
+    end
+
+    def assert_response_has_tag(tag, attributes={})
+      assert_has_selector(last_response.body, tag, attributes)
+    end
+
+    def assert_response_has_no_tag(tag, attributes={})
+      assert_has_no_selector(last_response.body, tag, attributes)
+    end
+
+    def assert_has_selector(html, selector, attributes)
+      count_requirement = attributes.delete(:count)
+      message = "'#{selector}' with attributes #{attributes} in html\n#{html}"
+      matched_count = html_matched_tags(html, selector.to_s, attributes)
+      if count_requirement
+        assert_equal count_requirement, matched_count, "count of tags #{message}"
+      else
+        assert matched_count > 0, "expected a tag #{message}"
+      end
+    end
+
+    def assert_has_no_selector(html, selector, attributes)
+      message = "'#{selector}' with attributes #{attributes} in html\n#{html}"
+      matched_count = html_matched_tags(html, selector.to_s, attributes)
+      assert matched_count == 0, "expected no tags #{message}"
+    end
+
+    private
+
+    def html_matched_tags(html, selector, attributes)
+      @dom ||= Oga.parse_html(html)
+      content_requirement = attributes.delete(:content)
+      attributes.each do |name, value|
+        selector += %{[#{name}="#{value}"]}
+      end
+      tags = @dom.css(selector.to_s.gsub(/\[([^"']*?)=([^'"]*?)\]/, '[\1="\2"]'))
+      if content_requirement
+        tags = tags.select{ |tag| (tag.get('content') || tag.text).index(content_requirement) }
+      end
+      tags.count
+    end
+  end
+end


### PR DESCRIPTION
Though slower on run time, Oga has very fast compile time and is much more compatible with JRuby and Rubinius.

ref: [Problems with Nokogiri](https://github.com/YorickPeterse/oga/wiki/Problems-with-Nokogiri)