### PR TITLE
[Docs] fix padrinorb.com links and padrino-gen projects' options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,18 +65,18 @@ usage of Sinatra itself.
 
 You can also check out the {Why Learn Padrino?}[http://padrinorb.com/guides/introduction/why-learn-padrino/] introduction to learn more about how Sinatra and Padrino work together.
 
-For information on how to use a specific gem in isolation within an existing Sinatra project, checkout the guide for {Using Padrino within Sinatra}[http://www.padrinorb.com/guides/standalone-usage-in-sinatra].
+For information on how to use a specific gem in isolation within an existing Sinatra project, checkout the guide for {Using Padrino within Sinatra}[http://padrinorb.com/guides/advanced-usage/standalone-usage-in-sinatra/].
 
 == Getting Started
 
 Once a developer understands Sinatra, Padrino is quite easy to get comfortable with since Padrino is simply a superset of existing Sinatra functionality!
 
-First, be sure to read over the {Getting Started}[http://www.padrinorb.com/guides/getting-started/overview/] guide
+First, be sure to read over the {Getting Started}[http://padrinorb.com/guides/getting-started/overview/] guide
 to learn more about how Sinatra and Padrino work together.
 
 Best way to learn more about building Padrino applications is to read following resources:
 
-* {Padrino Guides}[http://www.padrinorb.com/guides] - Guides outlining the major functionality within Padrino.
+* {Padrino Guides}[http://padrinorb.com/guides] - Guides outlining the major functionality within Padrino.
 * {Blog Tutorial}[http://padrinorb.com/guides/getting-started/blog-tutorial/] - Step-by-step guide to building a blog application with Padrino.
 * {Padrino API}[http://www.rubydoc.info/github/padrino/padrino-framework] - YARD documentation for the Padrino framework.
 * {Quick Overview}[http://padrinorb.com/guides/getting-started/basic-projects/] - Outlines basic generation commands.

--- a/padrino-admin/README.rdoc
+++ b/padrino-admin/README.rdoc
@@ -13,7 +13,7 @@ Access Control:: Supports authentication and role permissions for your applicati
 === Admin Dashboard Usage
 
 For a complete look at usage of the Admin dashboard functionality, be sure to check out the
-{Padrino Admin}[http://www.padrinorb.com/guides/padrino-admin] guide.
+{Padrino Admin}[http://padrinorb.com/guides/features/padrino-admin/] guide.
 
 Create a new project:
 
@@ -63,7 +63,7 @@ In this example +if+ we visit URLs that start with /+customer+/+orders+ or /+car
 to our :+login_page+ "/login". Once we are correctly logged in we can visit these pages.
 
 For a more complete look at using the Admin panel functionality and access features, be sure to check out the
-{Padrino Admin}[http://www.padrinorb.com/guides/padrino-admin] guide.
+{Padrino Admin}[http://padrinorb.com/guides/features/padrino-admin/] guide.
 
 == Copyright
 

--- a/padrino-core/README.rdoc
+++ b/padrino-core/README.rdoc
@@ -34,7 +34,7 @@ Reloading:: Automatically reloads server code during development.
 Localization:: Full support of I18n language localization and can auto-set user's locale.
 
 Keep in mind, the user will be able to pull in these components
-{seperately into existing Sinatra applications}[http://www.padrinorb.com/guides/standalone-usage-in-sinatra]
+{seperately into existing Sinatra applications}[http://padrinorb.com/guides/advanced-usage/standalone-usage-in-sinatra/]
 or use them altogether for a comprehensive upgrade to Sinatra (a full-stack Padrino application).
 
 == Installation
@@ -47,7 +47,7 @@ This will install the necessary padrino gems to get you started.
 Now you are ready to use this gem to enhance your sinatra projects or to create new Padrino applications.
 
 For a more detailed look at Padrino installation,
-check out the {Installation Guide}[http://www.padrinorb.com/guides/installation].
+check out the {Installation Guide}[http://padrinorb.com/guides/getting-started/installation/].
 
 == Usage
 
@@ -57,20 +57,20 @@ on the enhancements to the core Sinatra functionality. To use Padrino, one shoul
 usage of Sinatra itself.
 
 Please check out the
-{Understanding Sinatra}[http://www.padrinorb.com/guides/underlying-sinatra-overview] guide
+{Understanding Sinatra}[http://padrinorb.com/guides/introduction/why-learn-padrino/#learning-to-love-sinatra] guide
 to learn more about these fundamentals.
 
 For information on how to use a specific gem in isolation within an existing Sinatra project, checkout the guide for
-{Using Padrino in Sinatra}[http://www.padrinorb.com/guides/standalone-usage-in-sinatra].
+{Using Padrino in Sinatra}[http://padrinorb.com/guides/advanced-usage/standalone-usage-in-sinatra/].
 
 == Getting Started
 
 Once a developer understands Sinatra, Padrino is quite easy to get comfortable with since Padrino is simply a superset
 of existing Sinatra Functionality! Best way to get started with building Padrino applications is to read following resources:
 
-* {Blog Tutorial}[http://www.padrinorb.com/guides/blog-tutorial] - Step-by-step guide to building a blog application with Padrino.
-* {Quick Overview}[http://www.padrinorb.com/guides/basic-projects] - Outlines basic generation commands.
-* {Padrino Examples}[http://www.padrinorb.com/guides/examples] - List of known Padrino applications which can serve as examples.
+* {Blog Tutorial}[http://padrinorb.com/guides/getting-started/blog-tutorial/] - Step-by-step guide to building a blog application with Padrino.
+* {Quick Overview}[http://padrinorb.com/guides/getting-started/basic-projects/] - Outlines basic generation commands.
+* {Padrino Examples}[http://padrinorb.com/guides/introduction/examples/] - List of known Padrino applications which can serve as examples.
 
 == Enhanced Base Application (padrino-core)
 
@@ -104,10 +104,10 @@ Let us first take a look at the simplest possible Padrino application:
     end
   end
 
-=== Enhanced Route Definitions and Controllers
-
 For a complete overview of the Padrino routing and controller system,
-check out the {Routing and Controller guide}[http://www.padrinorb.com/guides/controllers].
+check out the {Routing and Controller guide}[http://padrinorb.com/guides/controllers/overview/].
+
+=== Enhanced Route Definitions and Controllers
 
 Suppose we wanted to add additional routes to our Padrino application, and we want to organize the routes
 within a more structured layout. Simply add a <tt>controllers</tt> or <tt>app/controllers</tt> folder and create a file as such:
@@ -175,7 +175,7 @@ When you visit :+show+ and your I18n.locale == :ru Padrino try to look for "admi
 they try "admin/show.ru.*" then "admin/show.js.*" if none match return "admin/show.erb" (or other engine i.e. haml)
 
 For a complete overview of the routing and controller system, check out the
-{Routing and Controller guide}[http://www.padrinorb.com/guides/controllers].
+{Routing and Controller guide}[http://padrinorb.com/guides/controllers/overview/].
 
 === Rendering
 
@@ -191,7 +191,7 @@ The existing render function works as well if an engine type should be specified
 render :haml, 'account/index'
 
 For a complete overview of the Padrino rendering system, check out the
-{Routing and Controller guide}[http://www.padrinorb.com/guides/controllers].
+{Routing and Controller guide}[http://padrinorb.com/guides/controllers/rendering/].
 
 === Layout
 
@@ -206,7 +206,7 @@ With Padrino you can (like rails do) use for your custom layout, disable it
     layout :custom
 
 For a complete overview of the layout functionality,
-check out the {Routing and Controller guide}[http://www.padrinorb.com/guides/controllers].
+check out the {Routing and Controller guide}[http://padrinorb.com/guides/controllers/layouts/].
 
 === Mounting Applications
 
@@ -221,7 +221,7 @@ Padrino stores application mounting information by default within <tt>config/app
 to keep all information regarding what applications are mounted to which uri's.
 
 For a complete look at mounting applications within a Padrino project,
-check out the guide on {Mounting Applications}[http://www.padrinorb.com/guides/mounting-applications].
+check out the guide on {Mounting Applications}[http://padrinorb.com/guides/features/mounting-applications/].
 
 === Auto Load Paths
 
@@ -231,7 +231,7 @@ as a convention for establishing database connection. Also, any files within the
 automatically by Padrino.
 
 For a complete overview of auto-loaded paths within Padrino,
-check out the {Padrino Development Guide}[http://www.padrinorb.com/guides/development-and-terminal-commands].
+check out the {Padrino Development Guide}[http://padrinorb.com/guides/features/development-commands/#auto-load-paths].
 
 === Application Logging
 
@@ -248,7 +248,7 @@ within your app and any controller or views:
   end
 
 For a complete overview of Padrino logger functionality, check out the
-{Padrino Development Guide}[http://www.padrinorb.com/guides/development-and-terminal-commands].
+{Padrino Development Guide}[http://padrinorb.com/guides/features/development-commands/].
 
 === Development Reloader
 
@@ -260,7 +260,7 @@ This makes rapid development much easier and provides a better alternative to 's
 which requires the application server to be restarted which makes requests take much longer to complete.
 
 For a complete overview of code reloading in development,
-check out the {Padrino Development Guide}[http://www.padrinorb.com/guides/development-and-terminal-commands].
+check out the {Padrino Development Guide}[http://padrinorb.com/guides/features/development-commands/#development-reloader].
 
 === Terminal Commands
 
@@ -287,7 +287,7 @@ You can also create custom rake tasks as well. Using these commands can simplify
 making development that much smoother.
 
 For a complete overview of Padrino terminal commands, check out the
-{Padrino Commands Guide}[http://www.padrinorb.com/guides/development-and-terminal-commands].
+{Padrino Commands Guide}[http://padrinorb.com/guides/features/development-commands/#terminal-commands].
 
 == Copyright
 

--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -214,7 +214,7 @@ module Padrino
       #   before :agent => /IE/ do; ...; end
       #   # => match +HTTP_USER_AGENT+ containing +IE+
       #
-      # @see http://www.padrinorb.com/guides/controllers#route-filters
+      # @see http://padrinorb.com/guides/controllers/route-filters/
       #
       def construct_filter(*args, &block)
         options = args.last.is_a?(Hash) ? args.pop : {}

--- a/padrino-gen/README.rdoc
+++ b/padrino-gen/README.rdoc
@@ -7,7 +7,7 @@ Padrino comes preloaded with flexible code generators powered in part by the exc
 both in creating new applications and building on existing ones. The generators have been built to be as library agnostic
 as possible, supporting a myriad of test frameworks, js libraries, mocking libraries, etc.
 
-See the guide for {Padrino Generators}[http://www.padrinorb.com/guides/generators] for a
+See the guide for {Padrino Generators}[http://padrinorb.com/guides/generators/overview] for a
 more in-depth look at the system.
 
 === Project Generator
@@ -38,8 +38,8 @@ You can also instruct the generator to skip a certain component to avoid using o
 
 The available components and their default options are listed below:
 
-test::       none  (default), bacon, shoulda, cucumber, rspec, minitest
-renderer::   slim  (default), erb, erubis, liquid, haml
+test::       none  (default), bacon, shoulda, cucumber, rspec, minitest, testunit
+renderer::   none  (default), slim, erb, erubis, liquid, haml
 stylesheet:: none  (default), less, compass, sass, scss
 mock::       none  (default), mocha, rr
 script::     none  (default), jquery, prototype, mootools, extcore, dojo
@@ -50,7 +50,7 @@ In addition, you can generate projects based on existing templates:
   $ padrino-gen project demo_project --template sampleblog
 
 To learn more about the project generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/projects/].
 
 === Plugin System
 
@@ -61,7 +61,7 @@ Padrino provides support for plugins to be executed within your application. For
 would install the hoptoad middleware into your application automatically.
 
 To learn more about the plugin system, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/plugins/].
 
 === Sub App Generator
 
@@ -85,7 +85,7 @@ By default these apps are mounted under:
 but you can edit config/apps.rb and change it.
 
 To learn more about the subapp generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/sub-applications/].
 
 === Model Generator
 
@@ -106,7 +106,7 @@ You can also specify desired fields to be contained within your User model:
   $ padrino-gen model User name:string age:integer email:string
 
 To learn more about the model generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/models/].
 
 === Migration Generator
 
@@ -123,7 +123,7 @@ Using the migration generator is as simple as:
   $ padrino-gen migration RemoveFieldsFromUsers
 
 To learn more about the migration generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/migrations/].
 
 === Controller Generator
 
@@ -143,7 +143,7 @@ You can also specify desired actions to be added to your controller:
   $ padrino-gen controller Admin get:index get:new post:create
 
 To learn more about the controller generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/controllers/].
 
 === Mailer Generator
 
@@ -156,7 +156,7 @@ Using the mailer generator is as simple as:
   $ padrino-gen mailer UserNotifier
 
 To learn more about the mailer generator, check out the guide to
-{Padrino Generators}[http://www.padrinorb.com/guides/generators].
+{Padrino Generators}[http://padrinorb.com/guides/generators/mailers/].
 
 == Copyright
 

--- a/padrino-helpers/README.rdoc
+++ b/padrino-helpers/README.rdoc
@@ -53,7 +53,7 @@ to the template through the use of <tt>concat_content</tt>. Note have been built
 templates using the same syntax.
 
 For more information on using output helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/output-helpers/].
 
 === Tag Helpers
 
@@ -74,7 +74,7 @@ The input_tag is used to build tags that are related to accepting input from the
 Note that all of these accept html options and result in returning a string containing html tags.
 
 For more information on using tag helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/tag-helpers/].
 
 === Asset Helpers
 
@@ -95,7 +95,7 @@ simple view template:
     %p= image_tag 'padrino.png', :width => '35', :class => 'logo'
 
 For more information on using asset helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/asset-helpers/].
 
 === Form Helpers
 
@@ -120,7 +120,7 @@ example of constructing a non-object form would be:
       = submit_tag "Remove"
 
 For more information on using form helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/form-helpers/].
 
 === FormBuilders
 
@@ -153,7 +153,7 @@ A form_for using these basic fields might look like:
     %p
       = f.submit "Create", :class => 'button'
 
-Forms can also accept nested attributes using `fields_for` within the form builder in recent releases. Check out the guide for {Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers] to learn more about nested forms.
+Forms can also accept nested attributes using `fields_for` within the form builder in recent releases. Check out the guide for {Padrino Helpers}[http://padrinorb.com/guides/application-helpers/form-builders/] to learn more about nested forms.
 
 There is also an additional StandardFormBuilder which builds on the abstract fields that can be used within a form_for.
 
@@ -179,7 +179,7 @@ and would generate this html (with each input contained in a paragraph and conta
 You can also easily build your own FormBuilder which allows for customized fields and behavior.
 
 For more information on using the Padrino form builders, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/standard-form-builder/].
 
 === Format Helpers
 
@@ -207,7 +207,7 @@ Format helpers also includes a number of useful text manipulation functions such
 These helpers can be invoked from any route or view within your application.
 
 For more information on using the format helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/format-helpers/].
 
 === Render Helpers
 
@@ -232,7 +232,7 @@ Finally, we have the all-important partials support for rendering mini-templates
   partial 'photo/_item', :collection => @photos
 
 For more information on using the render and partial helpers, check out the guide for
-{Padrino Helpers}[http://www.padrinorb.com/guides/application-helpers].
+{Padrino Helpers}[http://padrinorb.com/guides/application-helpers/render-helpers/].
 
 == Copyright
 

--- a/padrino-mailer/README.rdoc
+++ b/padrino-mailer/README.rdoc
@@ -98,7 +98,7 @@ Once the mailer definition has been completed and the template has been defined,
 And that will then deliver the email according the configured options. This is all you need to send basic emails.
 
 The mailer also supports the attachment of files and various other options. Be sure to check out the
-{Padrino Mailer}[http://www.padrinorb.com/guides/padrino-mailer] guide for more details on usage.
+{Padrino Mailer}[http://padrinorb.com/guides/features/padrino-mailer/] guide for more details on usage.
 
 == Copyright
 


### PR DESCRIPTION
1: Modify the old links to the new links.
2: Add "testunit" to padrino-gen projects' test option.
3: Modify default of padrino-gen projects' renderer option. (slim -> none)