### PR TITLE
Use symbolize_keys method from Utils module

### DIFF
--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -104,7 +104,7 @@ module Padrino
     #
     def self.parse_server_options(options)
       parsed_server_options = Array(options).flat_map{ |option| option.split('=', 2) }
-      Hash[*parsed_server_options].symbolize_keys
+      Utils.symbolize_keys(Hash[*parsed_server_options])
     end
 
     # Detects Host and Port for Rack server.


### PR DESCRIPTION
I'm not sure if `symbolize_keys` should exist on Hash, but I am assuming not, due to the removal of ActiveSupport in 84226527b3fd.

I noticed it's expected to exist elsewhere, so I might be missing something - or perhaps the other references are busted and I haven't experienced them yet.