### PR TITLE
fix uninitialized constant in padrino stop command

### DIFF
--- a/padrino-core/lib/padrino-core/cli/adapter.rb
+++ b/padrino-core/lib/padrino-core/cli/adapter.rb
@@ -1,3 +1,5 @@
+require 'padrino-support'
+
 module Padrino
   module Cli
     module Adapter


### PR DESCRIPTION
calling padrino stop --pid=path/to/pid fails with the error:
NameError: uninitialized constant #<Class:Padrino::Cli::Adapter>::Utils

The adaptor uses the Utils class, but it is not loaded at when using the
padrino binary stop command.

Add require 'padrino-support' to load the Utils class in the apadtor.rb
file.