### PR TITLE
Erubi support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
   else
     gem "erubis",    ">= 2.7.0"
   end
-  gem "erubi"
+  gem "erubi",     ">= 1.6.0"
   gem "slim",      ">= 1.3.0"
   gem "builder",    ">= 2.1.2"
   gem "mustermann19"

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development do
   else
     gem "erubis",    ">= 2.7.0"
   end
+  gem "erubi"
   gem "slim",      ">= 1.3.0"
   gem "builder",    ">= 2.1.2"
   gem "mustermann19"

--- a/padrino-gen/lib/padrino-gen/generators/components/renderers/erb.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/renderers/erb.rb
@@ -1,3 +1,3 @@
 def setup_renderer
-  require_dependencies 'erubis', :version => "~> 2.7.0"
+  require_dependencies 'erubi', :version => '~> 1.6'
 end

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -444,7 +444,7 @@ describe "ProjectGenerator" do
     it 'should properly generate for erb' do
       out, err = capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}", '--renderer=erb', '--script=none') }
       assert_match(/applying.*?erb.*?renderer/, out)
-      assert_match_in_file(/gem 'erubis'/, "#{@apptmp}/sample_project/Gemfile")
+      assert_match_in_file(/gem 'erubi'/, "#{@apptmp}/sample_project/Gemfile")
     end
 
     it 'should properly generate for haml' do

--- a/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
+++ b/padrino-helpers/lib/padrino-helpers/output_helpers/erb_handler.rb
@@ -23,6 +23,7 @@ module Padrino
       end
       OutputHelpers.register(:erb, ErbHandler)
       OutputHelpers.register(:erubis, ErbHandler)
+      OutputHelpers.register(:erubi, ErbHandler)
     end
   end
 end

--- a/padrino-helpers/lib/padrino/rendering.rb
+++ b/padrino-helpers/lib/padrino/rendering.rb
@@ -382,3 +382,12 @@ unless defined? Padrino::Rendering::SlimTemplate
     require 'padrino/rendering/slim_template'
   end
 end
+
+unless defined? Padrino::Rendering::ErubiTemplate
+  begin
+    require 'erubi'
+  rescue LoadError
+  else
+    require 'padrino/rendering/erubi_template'
+  end
+end

--- a/padrino-helpers/lib/padrino/rendering/erubi_template.rb
+++ b/padrino-helpers/lib/padrino/rendering/erubi_template.rb
@@ -11,11 +11,7 @@ module Padrino
         end
 
         def add_text(text)
-          @src << " #{bufvar}.safe_concat '" << escape_text(text) << "';" unless text.empty?
-        end
-
-        def escape_text(text)
-          text.gsub(/['\\]/, '\\\\\&')
+          @src << " #{bufvar}.safe_concat '" << text.gsub(/['\\]/, '\\\\\&') << "';" unless text.empty?
         end
       end
     end

--- a/padrino-helpers/lib/padrino/rendering/erubi_template.rb
+++ b/padrino-helpers/lib/padrino/rendering/erubi_template.rb
@@ -7,7 +7,7 @@ module Padrino
         end
 
         def add_expression_result_escaped(code)
-          @src << " #{bufvar}.safe_concat #{@escapefunc}((" << code << "));"
+          @src << " #{bufvar}.safe_concat (" << code << ");"
         end
 
         def add_text(text)
@@ -21,8 +21,6 @@ module Padrino
     end
 
     class ErubiTemplate < Tilt::ErubiTemplate
-      include SafeTemplate
-
       def precompiled_preamble(*)
         "__in_erb_template = true\n" << super
       end

--- a/padrino-helpers/test/test_rendering.rb
+++ b/padrino-helpers/test/test_rendering.rb
@@ -622,6 +622,22 @@ describe "Rendering" do
       assert_equal 'this is a <span>span</span>', body
     end
 
+    it 'should render unescaped erb if requested' do
+      mock_app do
+        layout do
+          "<%= yield %>"
+        end
+
+        get "/" do
+          render  :erb, '<%== "<script></script>" %>'
+        end
+      end
+
+      get "/"
+      assert ok?
+      assert_equal "<script></script>", body
+    end
+
     it 'should render haml to a SafeBuffer' do
       mock_app do
         layout do


### PR DESCRIPTION
Definitely not ready for merging, but looking for some feedback as I am still mostly unfamiliar with the Padrino codebase.

A couple items I feel I need some guidance on:

- [x] ~Best places to insert tests for this?~ Tested via existing code.
- [x] ~Does this require a generator? I noticed there is an Erubis dependency generator in padrino-gen.~ Replaced Erubis with Erubi.
- [x] ~I've had to temporarily comment out a block of code that re-loads `erb` to have my handler actually called (d53641f7204a4). Can we check if there is a Tilt handler registered and skip the require? what's the best way to approach this?~ No longer relevant.
- [x] ~I had to duplicate configuration for the engine configuration in two different keys. Looks like a smell to me - open to alternatives. (dce2cc31a)~ No longer relevant.
- [x] ~Am I using SafeBuffer correctly?~ I believe i am.
- [x] ~Raw output is being escaped when it shouldn't be (`<%==` should not be escaped)~ Added test case and fix.

Finally, Erubi supports an interesting block-capture method in a yet-to-be released gem version. I'm not sure if this is something that should be supported or not.

Issue #2089 