### PR TITLE
Fix ruby warnings

### DIFF
--- a/padrino-core/lib/padrino-core/logger.rb
+++ b/padrino-core/lib/padrino-core/logger.rb
@@ -309,7 +309,7 @@ module Padrino
 
     @@mutex = Mutex.new
     def self.logger
-      @_logger || setup!
+      (@_logger ||= nil) || setup!
     end
 
     def self.logger=(logger)

--- a/padrino-core/lib/padrino-core/module.rb
+++ b/padrino-core/lib/padrino-core/module.rb
@@ -1,6 +1,6 @@
 module Padrino
   module Module
-    attr_accessor :root
+    attr_writer :root
 
     ##
     # Register this module as being loaded from a gem. This automatically

--- a/padrino-core/lib/padrino-core/path_router.rb
+++ b/padrino-core/lib/padrino-core/path_router.rb
@@ -58,8 +58,8 @@ module Padrino
         params = args.last.is_a?(Hash) ? args.pop : {}
         candidates = @routes.select { |route| route.name == name }
         fail InvalidRouteException if candidates.empty?
-        route = candidates.sort_by! { |route|
-          (params.keys.map(&:to_s) - route.matcher.names).length }.shift
+        route = candidates.sort_by! { |candidate|
+          (params.keys.map(&:to_s) - candidate.matcher.names).length }.shift
         matcher = route.matcher
         params_for_expand = params.dup
         if !args.empty? && matcher.mustermann?

--- a/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
+++ b/padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb
@@ -108,7 +108,7 @@ module Padrino
         end
 
         def submit(*args)
-          @template.submit_tag *args
+          @template.submit_tag(*args)
         end
 
         def image_submit(source, options={})


### PR DESCRIPTION
These were the warnings:

```
padrino-core/lib/padrino-core/logger.rb:312: warning: instance variable @_logger not initialized
padrino-helpers/lib/padrino-helpers/form_builder/abstract_form_builder.rb:111: warning: `*' interpreted as argument prefix
padrino-core/lib/padrino-core/module.rb:32: warning: method redefined; discarding old root
padrino-core/lib/padrino-core/path_router.rb:61: warning: shadowing outer local variable - route
```

`ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]`