### PR TITLE
Avoid to unwanted duplication of ENV['RACK_BASE_URI'].

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -373,7 +373,7 @@ module Padrino
       def rebase_url(url)
         if url.start_with?('/')
           new_url = ''
-          new_url << conform_uri(ENV['RACK_BASE_URI']) if ENV['RACK_BASE_URI']
+          new_url << conform_uri(ENV['RACK_BASE_URI']) if ENV['RACK_BASE_URI'] && ! url.start_with?(ENV['RACK_BASE_URI'])
           new_url << conform_uri(uri_root) if defined?(uri_root)
           new_url << url
         else


### PR DESCRIPTION
Sometimes Padrino::Routing::ClassMethods#rebase_url duplicates ENV['RACK_BASE_URI'].
It happends often when Padrino::Contrib::AutoLocale is used.  This code avoids
unwanted duplication of ENV['RACK_BASE_URI'].