### PR TITLE
Switch to exe/ for application bins.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/project.rb
+++ b/padrino-gen/lib/padrino-gen/generators/project.rb
@@ -63,8 +63,8 @@ module Padrino
           end
           template 'templates/Gemfile.tt', destination_root('Gemfile')
           template 'templates/Rakefile.tt', destination_root('Rakefile')
-          template 'templates/project_bin.tt', destination_root("bin/#{name}")
-          File.chmod(0755, destination_root("bin/#{name}"))
+          template 'templates/project_bin.tt', destination_root("exe/#{name}")
+          File.chmod(0755, destination_root("exe/#{name}"))
           if options.gem?
             template 'templates/gem/gemspec.tt', destination_root(name + '.gemspec')
             template 'templates/gem/README.md.tt', destination_root('README.md')

--- a/padrino-gen/lib/padrino-gen/generators/templates/gem/gemspec.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/gem/gemspec.tt
@@ -8,8 +8,9 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{TODO: Write a gem summary}
   gem.homepage      = ""
 
+  gem.bindir        = "exe"
   gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = gem.files.grep(%r{^exe/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = <%= name.downcase.inspect %>
   gem.require_paths = ["lib", "app"]

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -20,7 +20,7 @@ describe "ProjectGenerator" do
       assert_match_in_file("Padrino.mount('SampleProject::App', :app_file => Padrino.root('app/app.rb')).to('/')", "#{@apptmp}/sample_project/config/apps.rb")
       assert_file_exists("#{@apptmp}/sample_project/config/boot.rb")
       assert_file_exists("#{@apptmp}/sample_project/Rakefile")
-      assert_file_exists("#{@apptmp}/sample_project/bin/sample_project")
+      assert_file_exists("#{@apptmp}/sample_project/exe/sample_project")
       assert_file_exists("#{@apptmp}/sample_project/public/favicon.ico")
       assert_dir_exists("#{@apptmp}/sample_project/public/images")
       assert_dir_exists("#{@apptmp}/sample_project/public/javascripts")


### PR DESCRIPTION
Using bin/ for our own executables is problematic when storing binstubs
in the same folder.

New acceptable practice per Bundler is to use the exe/ path for our own
bin.

Issue #2097