### PR TITLE
Return an empty array when mounted App has no routes method

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -129,6 +129,8 @@ module Padrino
     #   Array of routes.
     #
     def named_routes
+      return [] unless app_obj.respond_to?(:routes)
+
       app_obj.routes.map { |route|
         request_method = route.request_methods.first
         next if !route.name || request_method == 'HEAD'


### PR DESCRIPTION
When mounting Sidekiq, it's possible for `padrino rake routes` to fail depending on the order of the mounting process.

I would almost wonder if this is the case for all Sinatra / Rack apps.

Maybe the eager return isn't best suited here but somewhere else? Open to comments.

Issue #2098