### PR TITLE
Install binstubs when running bundle install

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/actions.rb
+++ b/padrino-gen/lib/padrino-gen/generators/actions.rb
@@ -432,7 +432,7 @@ WARNING
       #
       def run_bundler
         say 'Bundling application dependencies using bundler...', :yellow
-        in_root { run 'bundle install' }
+        in_root { run 'bundle install --binstubs' }
       end
 
       ##


### PR DESCRIPTION
I can't see any reason _not_ to do this, if someone passed the `-b` argument when generating a project.

Any thoughts?