### PR TITLE
Override default values if parameter is present

### DIFF
--- a/padrino-core/lib/padrino-core/path_router/matcher.rb
+++ b/padrino-core/lib/padrino-core/path_router/matcher.rb
@@ -14,7 +14,7 @@ module Padrino
         @capture = options[:capture]
         @default_values = options[:default_values]
       end
-  
+
       ##
       # Matches a pattern with the route matcher.
       #
@@ -32,12 +32,12 @@ module Padrino
       def to_regexp
         mustermann? ? handler.to_regexp : handler
       end
-  
+
       ##
       # Expands the path by using parameters.
       #
       def expand(params)
-        params = params.merge(@default_values) if @default_values.is_a?(Hash)
+        params = @default_values.merge(params) if @default_values.is_a?(Hash)
         params, query = params.each_with_object([{}, {}]) do |(key, val), parts|
           parts[handler.names.include?(key.to_s) ? 0 : 1][key] = val
         end
@@ -45,7 +45,7 @@ module Padrino
         expanded_path += ?? + Padrino::Utils.build_uri_query(query) unless query.empty?
         expanded_path
       end
-  
+
       ##
       # Returns true if handler is an instance of Mustermann.
       #
@@ -72,7 +72,7 @@ module Padrino
         end
         params
       end
-  
+
       ##
       # Returns the handler which is an instance of Mustermann or Regexp.
       #
@@ -87,14 +87,14 @@ module Padrino
             @path
           end
       end
-  
+
       ##
       # Converts the handler into string.
       #
       def to_s
         handler.to_s
       end
-  
+
       ##
       # Returns names of the handler.
       # @see Regexp#names

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -1247,6 +1247,17 @@ describe "Routing" do
     assert_equal "lang is en", body
   end
 
+  it 'should override default values when parameters are passed' do
+    mock_app do
+      controller lang: :it do
+        get(:index, map: '/:lang') { "lang is #{params[:lang]}" }
+      end
+    end
+    assert_equal '/pt', @app.url(:index, lang: 'pt')
+    get '/pt'
+    assert_equal 'lang is pt', body
+  end
+
   it 'should transitions to the next matching route on pass' do
     mock_app do
       get '/:foo' do


### PR DESCRIPTION
As reported in bug #2113 if we are using default values in the
controllers, and those values are present in the URL, they are not being
correctly replaced when building the URL.

The reason is we are using the default values as overrides and not
otherwise, the given values to override the default ones. This patch
fixes this behaviour and introduces a new test to validate it.

Closes #2113 