### PR TITLE
Fix plugin list

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/plugin.rb
+++ b/padrino-gen/lib/padrino-gen/generators/plugin.rb
@@ -55,7 +55,7 @@ module Padrino
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           http.start do
             http.request_get(uri.path) do |res|
-              plugins = res.body.scan(%r{/plugins/(\w+-\w+)_plugin.rb}).uniq
+              plugins = res.body.scan(%r{/plugins/([-\w]+)_plugin.rb}).flatten.uniq
             end
           end
           say "Available plugins:", :green


### PR DESCRIPTION
... to not show plugins containing a `-` only. Also flatten down the matches Array generated by `String.scan`