### PR TITLE
Enable cascading with Rack application

### DIFF
--- a/padrino-core/lib/padrino-core/mounter.rb
+++ b/padrino-core/lib/padrino-core/mounter.rb
@@ -108,6 +108,7 @@ module Padrino
         app_obj.set :static,         public_folder_exists
         app_obj.set :cascade,        app_data.cascade
       else
+        app_obj.cascade       = app_data.cascade
         app_obj.uri_root      = uri_root
         app_obj.public_folder = Padrino.root('public', uri_root) unless public_folder_exists
       end

--- a/padrino-core/lib/padrino-core/mounter/application_extension.rb
+++ b/padrino-core/lib/padrino-core/mounter/application_extension.rb
@@ -1,7 +1,7 @@
 module Padrino
   class Mounter
     module ApplicationExtension
-      attr_accessor :uri_root, :mounter_options
+      attr_accessor :uri_root, :mounter_options, :cascade
       attr_writer :public_folder
 
       def dependencies
@@ -26,6 +26,10 @@ module Padrino
 
       def app_name
         @__app_name ||= mounter_options[:app_name] || self.to_s.underscore.to_sym
+      end
+
+      def cascade
+        @__cascade ||= trace_method(:cascade) { [] }
       end
 
       def setup_application!

--- a/padrino-core/test/fixtures/apps/mountable_apps/rack_apps.rb
+++ b/padrino-core/test/fixtures/apps/mountable_apps/rack_apps.rb
@@ -1,7 +1,11 @@
 
 class RackApp
-  def self.call(_)
-    [200, {}, ["hello rack app"]]
+  def self.call(env)
+    if env['PATH_INFO'] == '/404'
+      [404, {}, ["not found ;("]]
+    else
+      [200, {}, ["hello rack app"]]
+    end
   end
 
   def self.prerequisites

--- a/padrino-core/test/test_mounter.rb
+++ b/padrino-core/test/test_mounter.rb
@@ -272,6 +272,16 @@ describe "Mounter" do
       assert_equal [], RackApp.prerequisites
     end
 
+    it 'should support the Rack Application with cascading style' do
+      path = File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/mountable_apps/rack_apps')
+      require path
+      Padrino.mount('rack_app', :app_class => 'RackApp', :app_file => path, cascade: false).to('/rack_app')
+      Padrino.mount('sinatra_app', :app_class => 'SinatraApp', :app_file => path).to('/')
+      app = Padrino.application
+      res = Rack::MockRequest.new(app).get("/rack_app/404")
+      assert_equal "not found ;(", res.body
+    end
+
     it 'should support the Rack Application inside padrino project' do
       path = File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/demo_project/app')
       api_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/apps/demo_project/api/app')


### PR DESCRIPTION
When mounting grape, I encountered a problem that the cascade option did not become effective.