### PR TITLE
Handle nil database passwords for create_db and drop_db.

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/sql-helpers.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/sql-helpers.rb
@@ -7,7 +7,7 @@ module Padrino
         case adapter
           when 'postgres'
             environment = {}
-            environment['PGPASSWORD'] = password unless password.empty?
+            environment['PGPASSWORD'] = password unless password.nil? || password.empty?
 
             arguments = []
             arguments << "--encoding=#{charset}" if charset
@@ -18,7 +18,7 @@ module Padrino
             Process.wait Process.spawn(environment, 'createdb', *arguments)
           when 'mysql', 'mysql2'
             environment = {}
-            environment['MYSQL_PWD'] = password unless password.empty?
+            environment['MYSQL_PWD'] = password unless password.nil? || password.empty?
 
             arguments = []
             arguments << "--user=#{user}" if user
@@ -41,7 +41,7 @@ module Padrino
         case adapter
           when 'postgres'
             environment = {}
-            environment['PGPASSWORD'] = password unless password.empty?
+            environment['PGPASSWORD'] = password unless password.nil? || password.empty?
 
             arguments = []
             arguments << "--host=#{host}" if host
@@ -51,7 +51,7 @@ module Padrino
             Process.wait Process.spawn(environment, 'dropdb', *arguments)
           when 'mysql', 'mysql2'
             environment = {}
-            environment['MYSQL_PWD'] = password unless password.empty?
+            environment['MYSQL_PWD'] = password unless password.nil? || password.empty?
 
             arguments = []
             arguments << "--user=#{user}" if user

--- a/padrino-gen/test/test_sql_helpers.rb
+++ b/padrino-gen/test/test_sql_helpers.rb
@@ -1,0 +1,105 @@
+require File.expand_path(File.dirname(__FILE__) + "/helper")
+require File.expand_path(File.dirname(__FILE__) + "/../lib/padrino-gen/padrino-tasks/sql-helpers")
+
+describe "SqlHelpers" do
+  def setup
+    Process.expects(:wait)
+  end
+
+  describe "create_db" do
+    describe "postgres" do
+      it "does not set PGPASSWORD when password is nil" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.create_db("postgres", nil, nil, nil, "database", nil, nil)
+      end
+
+      it "does not set PGPASSWORD when password is blank" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.create_db("postgres", nil, "", nil, "database", nil, nil)
+      end
+
+      it "sets PGPASSWORD when password is present" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {"PGPASSWORD" => "hunter2"}
+        end
+        Padrino::Generators::SqlHelpers.create_db("postgres", nil, "hunter2", nil, "database", nil, nil)
+      end
+    end
+
+    describe "mysql" do
+      it "does not set MYSQL_PWD when password is nil" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.create_db("mysql", nil, nil, nil, "database", nil, nil)
+      end
+
+      it "does not set MYSQL_PWD when password is blank" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.create_db("mysql", nil, "", nil, "database", nil, nil)
+      end
+
+      it "sets MYSQL_PWD when password is present" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {"MYSQL_PWD" => "hunter2"}
+        end
+        Padrino::Generators::SqlHelpers.create_db("mysql", nil, "hunter2", nil, "database", nil, nil)
+      end
+    end
+  end
+
+  describe "drop_db" do
+    describe "postgres" do
+      it "does not set PGPASSWORD when password is nil" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("postgres", nil, nil, nil, "database")
+      end
+
+      it "does not set PGPASSWORD when password is blank" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("postgres", nil, "", nil, "database")
+      end
+
+      it "sets PGPASSWORD when password is present" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {"PGPASSWORD" => "hunter2"}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("postgres", nil, "hunter2", nil, "database")
+      end
+    end
+
+    describe "mysql" do
+      it "does not set MYSQL_PWD when password is nil" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("mysql", nil, nil, nil, "database")
+      end
+
+      it "does not set MYSQL_PWD when password is blank" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("mysql", nil, "", nil, "database")
+      end
+
+      it "sets MYSQL_PWD when password is present" do
+        Process.expects(:spawn).with() do |environment, *args|
+          environment == {"MYSQL_PWD" => "hunter2"}
+        end
+        Padrino::Generators::SqlHelpers.drop_db("mysql", nil, "hunter2", nil, "database")
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Commit ce7ab0a4c2a606dbeef4212db0e74dba67ba81f7 introduced a bug where
if the database configuration didn't specify a password attempts to
create/drop the database would fail. The underlying cause was that prior
to the above the code used `blank?` to which would catch both nil values
and empty values. The new code uses `empty?` which fails if used on a
nil value.

This patch fixes that by checking for nil in addition to an empty string.

This can be reproduced by creating a brand new app, using postgresql or
mysql, and setting the database configuration to this:

`  postgres://localhost/nilpassword_development
`

And then running `rake sq:create` which will result in this:

```
  $ rake sq:create
  => Creating database 'nilpassword_development'
  rake aborted!
  NoMethodError: undefined method `empty?' for nil:NilClass
  .../gems/padrino-gen-0.13.3.3/lib/padrino-gen/padrino-tasks/sql-helpers.rb:10:in `create_db'
  .../gems/padrino-gen-0.13.3.3/lib/padrino-gen/padrino-tasks/sequel.rb:52:in `block (2 levels) in <top (required)>'
  .../gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
  .../bin/ruby_executable_hooks:15:in `eval'
  .../bin/ruby_executable_hooks:15:in `<main>'
  Tasks: TOP => sq:create
  (See full trace by running task with --trace)
```