### PR TITLE
Fix mailer check for Windows

### DIFF
--- a/padrino-mailer/lib/padrino-mailer/helpers.rb
+++ b/padrino-mailer/lib/padrino-mailer/helpers.rb
@@ -148,7 +148,10 @@ module Padrino
         #
         def delivery_settings
           @_delivery_setting ||= begin
-            raise "You must setup :delivery_method, see api for more details" if RUBY_PLATFORM =~ /win32/ && !respond_to?(:delivery_method)
+            if Gem.win_platform? && !respond_to?(:delivery_method)
+              raise "To use mailers on Windows you must set a :delivery_method, see http://padrinorb.com/guides/features/padrino-mailer/#configuration"
+            end
+
             return [:sendmail, { :location => `which sendmail`.chomp }] unless respond_to?(:delivery_method)
             return [delivery_method.keys[0], delivery_method.values[0]] if delivery_method.is_a?(Hash)
             return [delivery_method, {}] if delivery_method.is_a?(Symbol)


### PR DESCRIPTION
RubyInstaller ruby returns `i386-mingw32` for me. Using `Gem.win_platform?` is more robust anyhow. But I take it I may be the only one using Padrino Mailer (or just Padrino) on Windows 😳.

May be a good idea -and potentially provide some fun results- to set the test suite up on [AppVeyor](http://appveyor.com). I just did some Ruby/AppVeyor stuff recently so it's still semi-fresh on my mind. Let me know if you're interested. 
