### PR TITLE
Fixed: padrino crashed in starting

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -143,10 +143,10 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       desc "Resets your database using your migrations for the current environment."
       task :reset => ["ar:drop", "ar:create", "ar:migrate"]
 
-      desc "Runs the "up" for a given MIGRATION_VERSION."
+      desc "Runs the 'up' for a given MIGRATION_VERSION."
       task(:up => :skeleton){ migrate_as(:up) }
 
-      desc "Runs the "down" for a given MIGRATION_VERSION."
+      desc "Runs the 'down' for a given MIGRATION_VERSION."
       task(:down => :skeleton){ migrate_as(:down) }
     end
 


### PR DESCRIPTION
https://github.com/padrino/padrino-framework/pull/2129 contains syntax error!

So padrino crashed in starting

Gemfile

```ruby
gem "padrino", "0.14.0.2"
```

starting...

```
$ bundle exec padrino s
=> Padrino/0.14.0.2 has taken the stage development at http://127.0.0.1:3000
[1356] Puma starting in cluster mode...
[1356] * Version 3.8.2 (ruby 2.4.1-p111), codename: Sassy Salamander
[1356] * Min threads: 5, max threads: 5
[1356] * Environment: development
[1356] * Process workers: 2
[1356] * Preloading application
[1356] * Listening on tcp://127.0.0.1:3000
[1356] Use Ctrl-C to stop
rake aborted!
SyntaxError: /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/padrino-gen-0.14.0.2/lib/padrino-gen/padrino-tasks/activerecord.rb:146: syntax error, unexpected tIDENTIFIER, expecting keyword_end
      desc "Runs the "up" for a given MIGRATION_VERSIO
                        ^
/Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/padrino-gen-0.14.0.2/lib/padrino-gen/padrino-tasks/activerecord.rb:149: syntax error, unexpected tIDENTIFIER, expecting keyword_end
      desc "Runs the "down" for a given MIGRATION_VERSIO
                          ^
/Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/padrino-gen-0.14.0.2/lib/padrino-gen/padrino-tasks/activerecord.rb:318: syntax error, unexpected keyword_end, expecting end-of-input
  end
     ^
/Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/padrino-core-0.14.0.2/lib/padrino-core/cli/rake.rb:15:in `init'
/Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/Rakefile:8:in `<top (required)>'
/Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```

