### PR TITLE
Remove sequel deprecation warning

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/sequel.rb
@@ -1,5 +1,4 @@
 SEQUEL = (<<-SEQUEL) unless defined?(SEQUEL)
-Sequel::Model.plugin(:schema)
 Sequel::Model.raise_on_save_failure = false # Do not throw exceptions on failure
 Sequel::Model.db = case Padrino.env
   when :development then Sequel.connect(!DB_DEVELOPMENT!, :loggers => [logger])


### PR DESCRIPTION
When working with a Sequel as an `orm` and I'm running migrations or printing the routes I got the message:

```
SEQUEL DEPRECATION WARNING: The schema plugin is deprecated and will be removed in Sequel 5.  Switch to defining your schema using Database schema methods before creating your model classes.
/home/wm/.rvm/gems/ruby-2.4.1/gems/sequel-4.46.0/lib/sequel/plugins/schema.rb:3:in `<top (required)>'
/home/wm/.rvm/gems/ruby-2.4.1/gems/sequel-4.46.0/lib/sequel/model/base.rb:1195:in `require'
/home/wm/.rvm/gems/ruby-2.4.1/gems/sequel-4.46.0/lib/sequel/model/base.rb:1195:in `plugin_module'
/home/wm/.rvm/gems/ruby-2.4.1/gems/sequel-4.46.0/lib/sequel/model/base.rb:731:in `plugin'
/home/wm/git/blog-update/config/database.rb:1:in `<top (required)>'
/home/wm/.rvm/gems/ruby-2.4.1/gems/padrino-core-0.14.1.1/lib/padrino-core/reloader.rb:91:in `require'
/home/wm/.rvm/gems/ruby-2.4.1/gems/padrino-core-0.14.1.1/lib/padrino-core/reloader.rb:91:in `safe_load'
/home/wm/.rvm/gems/ruby-2.4.1/gems/padrino-core-0.14.1.1/lib/padrino-core/loader.rb:154:in `block in require_dependencies'
/home/wm/.rvm/gems/ruby-2.4.1/gems/padrino-core-0.14.1.1/lib/padrino-core/loader.rb:152:in `each'
/home/wm/.rvm/gems/ruby-2.4.1/gems/padrino-core-0.14.1.1/lib/padrino-core/loader.rb:152:in `require_dependencies'
```


**Solution:** remove `Sequel::Model.plugin(:schema)` from `config/database.rb`.
