### PR TITLE
Confirm protect_from_csrf method exists before calling

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -500,7 +500,7 @@ module Padrino
         route_options[:params] = @_params unless @_params.nil? || route_options.include?(:params)
 
         # Add Sinatra condition to check rack-protection failure.
-        if protect_from_csrf && (report_csrf_failure || allow_disabled_csrf)
+        if respond_to?(:protect_from_csrf) && protect_from_csrf && (report_csrf_failure || allow_disabled_csrf)
           unless route_options.has_key?(:csrf_protection)
             route_options[:csrf_protection] = true
           end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2424,4 +2424,13 @@ describe "Routing" do
     get '/prohibit/123?id=456'
     assert_equal '123', body
   end
+
+  it "functions in a standalone app" do
+    mock_app(Sinatra::Application) do
+      register Padrino::Routing
+      get(:index) { 'Standalone' }
+    end
+    get '/'
+    assert_equal 200, status
+  end
 end


### PR DESCRIPTION
Assuming this method exists breaks the usage of the router in
non-Padrino applications, such as the standalone Sinatra example listed
on the website.