### PR TITLE
Full path to symbolize_keys method in DataMapper tasks

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/datamapper.rb
@@ -50,7 +50,7 @@ if PadrinoTasks.load?(:datamapper, defined?(DataMapper))
 
     desc "Create the database"
     task :create => :environment do
-      config = Utils.symbolize_keys(DataMapper.repository.adapter.options)
+      config = Padrino::Utils.symbolize_keys(DataMapper.repository.adapter.options)
       adapter = config[:adapter]
       user, password, host = config[:user], config[:password], config[:host]
 
@@ -67,7 +67,7 @@ if PadrinoTasks.load?(:datamapper, defined?(DataMapper))
 
     desc "Drop the database (postgres and mysql only)"
     task :drop => :environment do
-      config = Utils.symbolize_keys(DataMapper.repository.adapter.options)
+      config = Padrino::Utils.symbolize_keys(DataMapper.repository.adapter.options)
       adapter = config[:adapter]
       user, password, host = config[:user], config[:password], config[:host]
 


### PR DESCRIPTION
Fixes instances of "NameError: uninitialized constant Utils"

(as discussed in Google group here: https://groups.google.com/forum/#!topic/padrino/qIjTZjnzdR8)