### PR TITLE
Generate ActiveRecord 5.0 style migrations

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -152,7 +152,19 @@ def create_model_file(name, options={})
   create_file(model_path, model_contents,:skip => true)
 end
 
+if defined?(ActiveRecord::Migration) && ActiveRecord::Migration.respond_to?(:[])
+AR_MIGRATION = (<<-MIGRATION) unless defined?(AR_MIGRATION)
+class !FILECLASS! < ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]
+  def self.up
+    !UP!
+  end
 
+  def self.down
+    !DOWN!
+  end
+end
+MIGRATION
+else
 AR_MIGRATION = (<<-MIGRATION) unless defined?(AR_MIGRATION)
 class !FILECLASS! < ActiveRecord::Migration
   def self.up
@@ -164,6 +176,7 @@ class !FILECLASS! < ActiveRecord::Migration
   end
 end
 MIGRATION
+end
 
 AR_MODEL_UP_MG = (<<-MIGRATION).gsub(/^/,'    ') unless defined?(AR_MODEL_UP_MG)
 create_table :!TABLE! do |t|


### PR DESCRIPTION
Not a super elegant solution, but it works. Depends on `ActiveRecord::Migration` being defined. This doesn't happen during tests, so I was unable to add a test for it.

We need to test that `ActiveRecord::Migration` responds to `.[]` before
using `.current_version`, as `.current_version` is used in previous versions
of `ActiveRecord` but with different semantics.

I'm open to a better approach if someone is aware of one.

Closes #2148.