### PR TITLE
Allow array as html attribute

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/tag_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/tag_helpers.rb
@@ -272,6 +272,7 @@ module Padrino
       # Escape tag values to their HTML/XML entities.
       #
       def escape_value(string)
+        string =  string.collect(&:to_s).join(' ') if string.is_a?(Array)
         string.to_s.gsub(ESCAPE_REGEXP, ESCAPE_VALUES)
       end
 

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -44,12 +44,12 @@ describe "TagHelpers" do
     end
 
     it 'should allow array as attributes' do
-        actual_html = tag(:p, :class => %i[foo bar])
+        actual_html = tag(:p, :class => [:foo, :bar])
         assert_html_has_tag(actual_html, 'p.foo.bar')
     end
 
     it 'should allow array as nested attributes' do
-        actual_html = tag(:p, :data => { :foo => %i[bar baz] })
+        actual_html = tag(:p, :data => { :foo => [:bar, :baz] })
         assert_html_has_tag(actual_html, 'p', :'data-foo' => 'bar baz')
     end
   end

--- a/padrino-helpers/test/test_tag_helpers.rb
+++ b/padrino-helpers/test/test_tag_helpers.rb
@@ -42,6 +42,16 @@ describe "TagHelpers" do
       actual_html = tag(:br, :class => 'Example <foo> & "bar"')
       assert_equal "<br class=\"Example &lt;foo&gt; &amp; &quot;bar&quot;\" />", actual_html
     end
+
+    it 'should allow array as attributes' do
+        actual_html = tag(:p, :class => %i[foo bar])
+        assert_html_has_tag(actual_html, 'p.foo.bar')
+    end
+
+    it 'should allow array as nested attributes' do
+        actual_html = tag(:p, :data => { :foo => %i[bar baz] })
+        assert_html_has_tag(actual_html, 'p', :'data-foo' => 'bar baz')
+    end
   end
 
   describe 'for #content_tag method' do


### PR DESCRIPTION
Hi,

Currently, attributes only allow single string value, which force developer to manually generate string value from array, for example for dynamic classes generation.
```erb
<% @classes = %i[foo bar] %>
<%= image_tag 'foo.png', class: @classes.join(' ') %>
```

This patch allows to use array of strings or symbols for attributes values, as in Ruby on Rails.
```erb
<% @classes = %i[foo bar] %>
<%= image_tag 'foo.png', class: @classes %>
```