### PR TITLE
Drop ruby < 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 install:
   - bundle update
 rvm:
-  - 2.2.0
+  - 2.2.2
   - 2.3.0
   - 2.3.3
   - 2.4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,15 @@ before_install:
 install:
   - bundle update
 rvm:
+  - 2.2.0
+  - 2.3.0
+  - 2.3.3
+  - 2.4.3
+  - 2.5.0
+  - ruby-head
   - rbx-2
   - jruby
   - jruby-head
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2.2
-  - 2.3.3
-  - 2.4.1
-  - ruby-head
 notifications:
   irc: 'irc.freenode.org#padrino'
   recipients:
@@ -32,22 +31,23 @@ branches:
   only:
     - master
     - 0.12
+    - 0.14
 services: mongodb
 matrix:
   include:
-    - rvm: 2.2.2
+    - rvm: 2.3.3
       env: SINATRA_EDGE=true
-    - rvm: 2.1
+    - rvm: 2.3.3
       env: ERB_ENGINE=stdlib
-    - rvm: 2.1
+    - rvm: 2.3.3
       env: ERB_ENGINE=erubis
-    - rvm: 2.1
+    - rvm: 2.3.3
       env: HAML_ENGINE=hamlit
-    - rvm: 2.1
+    - rvm: 2.3.3
       env: AS_VERSION=3.2
   allow_failures:
-    - rvm: jruby-9.0.5.0
     - rvm: rbx-2
-    - env: SINATRA_EDGE=true
-    - rvm: ruby-head
+    - rvm: jruby
     - rvm: jruby-head
+    - rvm: ruby-head
+    - env: SINATRA_EDGE=true

--- a/Gemfile
+++ b/Gemfile
@@ -19,31 +19,16 @@ group :development do
   elsif ENV['SINATRA_EDGE']
     puts "=> Using sinatra edge"
     gem "sinatra", :git => "git://github.com/sinatra/sinatra.git"
-  elsif RUBY_VERSION < "2.2.0"
-    gem "sinatra", "< 2"
   end
 
-  if RUBY_VERSION < "2.0.0"
-    gem "slim",      ">= 1.3.0", "< 3"
-  else
-    gem "slim",      ">= 1.3.0"
-  end
+  gem "slim",      ">= 1.3.0"
+  gem "liquid",    ">= 2.1.1"
 
-  if RUBY_VERSION < "2.1.0"
-    gem "liquid",    ">= 2.1.1", "< 4"
-  else
-    gem "liquid",    ">= 2.1.1"
-  end
-
-  if ENV['HAML_ENGINE'] == 'hamlit' && RUBY_VERSION >= "2.0.0"
+  if ENV['HAML_ENGINE'] == 'hamlit'
     puts "=> Using Hamlit Haml engine"
     gem "hamlit"
   else
-    if RUBY_VERSION < "2.0.0"
-      gem "haml",      ">= 4.0.5", "< 5"
-    else
-      gem "haml",      ">= 4.0.5"
-    end
+    gem "haml",      ">= 4.0.5"
   end
 
   case ENV['ERB_ENGINE']

--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-support", Padrino.version)
-  s.add_dependency("sinatra", ">= 1.4.6")
-  s.add_dependency("mustermann", ">= 1.0.1")
+  s.add_dependency("sinatra", ">= 2.0.0")
   s.add_dependency("thor", "~> 0.18")
-  s.add_dependency("rack-protection", ">= 1.5.0")
 end

--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("padrino-support", Padrino.version)
   s.add_dependency("sinatra", ">= 1.4.6")
-  s.add_dependency("mustermann19")
+  s.add_dependency("mustermann", ">= 1.0.1")
   s.add_dependency("thor", "~> 0.18")
   s.add_dependency("rack-protection", ">= 1.5.0")
 end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2255,7 +2255,6 @@ describe "Routing" do
   end
 
   it "should support named captures like %r{/hello/(?<person>[^/?#]+)} on Ruby >= 1.9" do
-    next if RUBY_VERSION < '1.9'
     mock_app do
       get Regexp.new('/hello/(?<person>[^/?#]+)') do
         "Hello #{params['person']}"

--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# Padrino supports Ruby version 1.9 and later
+# Padrino supports Ruby version 2.2.0 and later
 # ruby '<%= RUBY_VERSION.to_s %>'
 
 # Distribute your app as a gem

--- a/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
+++ b/padrino-gen/lib/padrino-gen/generators/templates/Gemfile.tt
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# Padrino supports Ruby version 2.2.0 and later
+# Padrino supports Ruby version 2.2.2 and later
 # ruby '<%= RUBY_VERSION.to_s %>'
 
 # Distribute your app as a gem


### PR DESCRIPTION
This PR removes testing against ruby older than 2.2.0 and locks onto Sinatra 2 with it's dependencies.