### PR TITLE
update default_inflections

### DIFF
--- a/padrino-support/lib/padrino-support/default_inflections.rb
+++ b/padrino-support/lib/padrino-support/default_inflections.rb
@@ -1,6 +1,7 @@
+# frozen-string-literal: true
 ##
-# This module is based on Sequel 4.27.0
-# sequel-4.27.0/lib/sequel/model/default_inflections.rb
+# This module is based on Sequel 5.4.0
+# sequel-5.4.0/lib/sequel/model/default_inflections.rb
 #
 module Padrino
   # Proc that is instance evaled to create the default inflections for both the


### PR DESCRIPTION
This pr synchronizes code from https://github.com/jeremyevans/sequel/blob/master/lib/sequel/model/default_inflections.rb. Two changes included:

1. add `# frozen-string-literal: true` because we never mutate strings in this file
2. chanage comment from `Sequel 4.27.0` to `Sequel 5.4.0`