### PR TITLE
drop ruby 1.9 windows string colorize support

### DIFF
--- a/padrino-support/lib/padrino-support/core_ext/string/colorize.rb
+++ b/padrino-support/lib/padrino-support/core_ext/string/colorize.rb
@@ -1,14 +1,3 @@
-# Ruby color support for Windows
-# If you want colorize on Windows with Ruby 1.9, please use ansicon:
-#   https://github.com/adoxa/ansicon
-# Other ways, add `gem 'win32console'` to your Gemfile.
-if RUBY_PLATFORM =~ /mswin|mingw/ && RUBY_VERSION < '2.0' && ENV['ANSICON'].nil?
-  begin
-    require 'win32console'
-  rescue LoadError
-  end
-end
-
 ##
 # Add colors
 #


### PR DESCRIPTION
We are dropping support for ruby < 2.2.2, so these 10 lines of code could be safely removed