### PR TITLE
Fix params handling (broke with Sinatra 2.0.1)

### DIFF
--- a/padrino-core/lib/padrino-core/application/routing.rb
+++ b/padrino-core/lib/padrino-core/application/routing.rb
@@ -929,10 +929,8 @@ module Padrino
       end
 
       def dispatch!
-        unless @params
-          @params = defined?(Sinatra::IndifferentHash) ? Sinatra::IndifferentHash[@request.params] : indifferent_params(@request.params)
-          force_encoding(@params)
-        end
+        @params = defined?(Sinatra::IndifferentHash) ? Sinatra::IndifferentHash[@request.params] : indifferent_params(@request.params)
+        force_encoding(@params)
         invoke do
           static! if settings.static? && (request.get? || request.head?)
           route!


### PR DESCRIPTION
Fixes #2174 by removing guard clause that was preventing `@params` from being set if already defined. As of sinatra 2.0.1 `@params` in `Sinatra::Base` is always initialized to an empty `Sinatra::IndifferentHash` (see [lib/sinatra/base.rb:918](https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L918)) so this guard clause prevented the params from being updated with the contents of `@request.params`. Fix tested under sinatra 2.0.0 and 2.0.1, all tests passing.