### PR TITLE
Fix exception with regexp routes and trailing slashes

### DIFF
--- a/padrino-core/lib/padrino-core/path_router/matcher.rb
+++ b/padrino-core/lib/padrino-core/path_router/matcher.rb
@@ -21,7 +21,7 @@ module Padrino
       def match(pattern)
         if match_data = handler.match(pattern)
           match_data
-        elsif mustermann? && pattern != "/" && pattern.end_with?("/")
+        elsif pattern != "/" && pattern.end_with?("/")
           handler.match(pattern[0..-2])
         end
       end

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -156,6 +156,16 @@ describe "Routing" do
     assert_equal "My lucky number: 99 99", body
   end
 
+  it 'should ignore trailing slashes' do
+    mock_app do
+      get(%r./trailing.) { "slash" }
+    end
+    get "/trailing"
+    assert_equal "slash", body
+    get "/trailing/"
+    assert_equal "slash", body
+  end
+
   it 'should accept regexp routes with generate with :generate_with' do
     mock_app do
       get(%r{/fob|/baz}, :name => :foo, :generate_with => '/fob') { "regexp" }


### PR DESCRIPTION
Fixes #2175 where defining a route with a regex that does not include a trailing slash results in an exception when accessed with a trailing slash. I'm not convinced this is the _right_ behavior, IMO if the regex is not defined with a trailing slash it should 404 but it is consistent with the existing behavior of the other route definition types which are agnostic to trailing slashes. Fix was simply to ignore the check if the route being matched is an instance of `Mustermann::Sinatra` before determining whether to strip the trailing slash in the match.