### PR TITLE
Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/padrino-helpers/lib/padrino/rendering/erb_template.rb
+++ b/padrino-helpers/lib/padrino/rendering/erb_template.rb
@@ -30,10 +30,20 @@ module Padrino
         super
       end
 
-      def prepare
-        @outvar = options[:outvar] || self.class.default_output_variable
-        options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
-        @engine = SafeERB.new(data, options[:safe], options[:trim], @outvar)
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        def prepare
+          @outvar = options[:outvar] || self.class.default_output_variable
+          options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
+
+          @engine = SafeERB.new(data, trim_mode: options[:trim], eoutvar: @outvar)
+        end
+      else
+        def prepare
+          @outvar = options[:outvar] || self.class.default_output_variable
+          options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
+
+          @engine = SafeERB.new(data, options[:safe], options[:trim], @outvar)
+        end
       end
 
       def precompiled_preamble(locals)


### PR DESCRIPTION
The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

The following address is related Ruby's commit.
https://github.com/ruby/ruby/commit/cc777d0

This PR uses `ERB.instance_method(:initialize).parameters.assoc(:key)` to switch `ERB.new` interface. Because Padrino supports multiple Ruby versions, it need to use the appropriate interface.

This patch is built into Ruby.
https://github.com/ruby/ruby/commit/3406c5d