### PR TITLE
Update mime-types dependency

### DIFF
--- a/padrino-mailer/padrino-mailer.gemspec
+++ b/padrino-mailer/padrino-mailer.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-core", Padrino.version)
-  s.add_dependency("mime-types", "< 3")
+  s.add_dependency("mime-types", "< 4")
   s.add_dependency("mail", "~> 2.5")
 end


### PR DESCRIPTION
Update mime-types dependency to support version 3, since padrino no longer needs to support ruby 1.9 https://github.com/padrino/padrino-framework/commit/3e93d59dd36c1818fcb2d4dba4a97ea6ef1a33cb

mime-types 2.x End of Life support was on 2017-11-21 https://github.com/mime-types/ruby-mime-types/