### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,6 @@ Padrino is the godfather of Sinatra. Follow us on
 {@padrinorb}[http://twitter.com/padrinorb]. Join us on {gitter}[https://gitter.im/padrino/padrino-framework]
 
 {<img src="https://api.travis-ci.org/padrino/padrino-framework.svg" alt="Build Status" />}[http://travis-ci.org/padrino/padrino-framework]
-{<img src="https://gemnasium.com/padrino/padrino-framework.svg" alt="Dependency Status" />}[https://gemnasium.com/padrino/padrino-framework]
 {<img src="http://img.shields.io/codeclimate/github/padrino/padrino-framework.svg" />}[https://codeclimate.com/github/padrino/padrino-framework]
 {<img src="https://badges.gitter.im/Join Chat.svg" />}[https://gitter.im/padrino/padrino-framework]
 {<img src='https://www.codetriage.com/padrino/padrino-framework/badges/users.svg' alt='Code Triagers Badge' />}[https://www.codetriage.com/padrino/padrino-framework]


### PR DESCRIPTION
According to https://docs.gitlab.com/ee/user/project/import/gemnasium.html there service migrated to gitlab. Since we are hosting padrino only on GitHub, we don't need that service.