### PR TITLE
Specify full class name to fix failing migrations.

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/datamapper.rb
@@ -159,7 +159,7 @@ MIGRATION
 def create_migration_file(migration_name, name, columns)
   output_migration_file(migration_name, name, columns,
     :base => DM_MIGRATION, :change_format => DM_CHANGE_MG,
-    :add => Proc.new { |field, kind| "add_column :#{field}, #{kind.classify}" },
+    :add => Proc.new { |field, kind| "add_column :#{field}, DataMapper::Property::#{kind.classify}" },
     :remove => Proc.new { |field, kind| "drop_column :#{field}" }
   )
 end

--- a/padrino-gen/test/test_migration_generator.rb
+++ b/padrino-gen/test/test_migration_generator.rb
@@ -143,8 +143,8 @@ describe "MigrationGenerator" do
       response_success = capture_io { generate(:migration, *migration_params) }
       migration_file_path = "#{@apptmp}/sample_project/db/migrate/001_add_email_to_users.rb"
       assert_match_in_file(/migration\s1.*?:add_email_to_users/m, migration_file_path)
-      assert_match_in_file(/modify_table :users.*?add_column :email, String/m, migration_file_path)
-      assert_match_in_file(/add_column :age, Integer/m, migration_file_path)
+      assert_match_in_file(/modify_table :users.*?add_column :email, DataMapper::Property::String/m, migration_file_path)
+      assert_match_in_file(/add_column :age, DataMapper::Property::Integer/m, migration_file_path)
       assert_match_in_file(/modify_table :users.*?drop_column :email/m, migration_file_path)
       assert_match_in_file(/drop_column :age/m, migration_file_path)
     end
@@ -156,8 +156,8 @@ describe "MigrationGenerator" do
       assert_match_in_file(/migration\s1.*?:remove_email_from_users/m, migration_file_path)
       assert_match_in_file(/modify_table :users.*?drop_column :email/m, migration_file_path)
       assert_match_in_file(/drop_column :age/m, migration_file_path)
-      assert_match_in_file(/modify_table :users.*?add_column :email, String/m, migration_file_path)
-      assert_match_in_file(/add_column :age, Integer/m, migration_file_path)
+      assert_match_in_file(/modify_table :users.*?add_column :email, DataMapper::Property::String/m, migration_file_path)
+      assert_match_in_file(/add_column :age, DataMapper::Property::Integer/m, migration_file_path)
     end
 
     it 'should properly version migration files' do


### PR DESCRIPTION
Fix the following migration problem:
```
migration 2, :add_balance_to_users do
  up do
    modify_table :users do
      add_column :balance, Decimal
    end
  end

  down do
    modify_table :users do
      drop_column :balance
    end
  end
end
```
```
/usr/local/lib/ruby/gems/2.5.0/gems/data_objects-0.10.17/lib/data_objects/pooling.rb:149: warning: constant ::Fixnum is deprecated
  DEBUG -  (0.000138) PRAGMA table_info("migration_info")
  DEBUG -  (0.000008) PRAGMA table_info("migration_info")
  DEBUG -  (0.000017) SELECT "migration_name" FROM "migration_info" WHERE "migration_name" = 'create_users'
  DEBUG -  (0.000005) PRAGMA table_info("migration_info")
  DEBUG -  (0.000005) PRAGMA table_info("migration_info")
  DEBUG -  (0.000013) SELECT "migration_name" FROM "migration_info" WHERE "migration_name" = 'add_balance_to_users'
 == Performing Up Migration #2: add_balance_to_users
rake aborted!
NameError: uninitialized constant Decimal
db/migrate/002_add_balance_to_users.rb:4:in `block (3 levels) in <top (required)>'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/sql/table_modifier.rb:14:in `instance_eval'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/sql/table_modifier.rb:14:in `initialize'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:150:in `new'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:150:in `modify_table'
db/migrate/002_add_balance_to_users.rb:3:in `block (2 levels) in <top (required)>'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:103:in `block in perform_up'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:190:in `block in say_with_time'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:190:in `say_with_time'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration.rb:102:in `perform_up'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration_runner.rb:57:in `block in migrate_up!'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration_runner.rb:55:in `each'
/usr/local/lib/ruby/gems/2.5.0/gems/dm-migrations-1.2.0/lib/dm-migrations/migration_runner.rb:55:in `migrate_up!'
/usr/local/lib/ruby/gems/2.5.0/gems/padrino-gen-0.14.3/lib/padrino-gen/padrino-tasks/datamapper.rb:28:in `block (3 levels) in <top (required)>'
/usr/local/lib/ruby/gems/2.5.0/gems/padrino-gen-0.14.3/lib/padrino-gen/padrino-tasks/datamapper.rb:48:in `block (2 levels) in <top (required)>'
/usr/local/lib/ruby/gems/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => dm:migrate:up
(See full trace by running task with --trace)
```