### PR TITLE
Fix bug for nested require_dependencies

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -90,7 +90,7 @@ module Padrino
       return unless options[:force] || file_changed?(file)
       return require(file) if feature_excluded?(file)
 
-      Storage.prepare(file) # might call #safe_load recursively
+      Storage.prepare(file, MTIMES) # might call #safe_load recursively
       logger.devel(file_new?(file) ? :loading : :reload, began_at, file)
       begin
         with_silence{ require(file) }
@@ -101,7 +101,7 @@ module Padrino
           logger.exception exception, :short
           logger.error "Failed to load #{file}; removing partially defined constants"
         end
-        Storage.rollback(file)
+        Storage.rollback(file, MTIMES)
         raise
       end
     end

--- a/padrino-core/test/fixtures/dependencies/nested/j.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/j.rb
@@ -1,0 +1,2 @@
+class J < K
+end

--- a/padrino-core/test/fixtures/dependencies/nested/k.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/k.rb
@@ -1,0 +1,2 @@
+class K
+end

--- a/padrino-core/test/fixtures/dependencies/nested/l.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/l.rb
@@ -1,0 +1,4 @@
+Padrino.require_dependencies(
+  Padrino.root("fixtures/dependencies/nested/m.rb"),
+  Padrino.root("fixtures/dependencies/nested/n.rb")
+)

--- a/padrino-core/test/fixtures/dependencies/nested/m.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/m.rb
@@ -1,0 +1,5 @@
+class M
+  def self.hello
+    "hello"
+  end
+end

--- a/padrino-core/test/fixtures/dependencies/nested/n.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/n.rb
@@ -1,0 +1,2 @@
+class N < J
+end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -65,5 +65,16 @@ describe "Dependencies" do
         end
       end
     end
+
+    it 'should not remove constants that are newly commited in nested require_dependencies' do
+      capture_io do
+        Padrino.require_dependencies(
+          Padrino.root("fixtures/dependencies/nested/j.rb"),
+          Padrino.root("fixtures/dependencies/nested/k.rb"),
+          Padrino.root("fixtures/dependencies/nested/l.rb")
+        )
+      end
+      assert_equal "hello", M.hello
+    end
   end
 end


### PR DESCRIPTION
There are problems with nested `require_dependencies`. 

Minimal example that reproduces this bug is: [padrino-nested-require.tar.gz](https://github.com/padrino/padrino-framework/files/2514459/padrino-nested-require.tar.gz)

This is how I got this bug:
```
$ bundle install
$ bundle exec ruby toplevel.rb
  ERROR -  NameError - uninitialized constant ALib:
...
Traceback (most recent call last):
toplevel.rb:10:in `<main>': uninitialized constant ModelWithNoDepOnLib (NameError)
Did you mean?  ModelThatDependsOnLib
```

Here is how this bug occurs:
* A file `toplevel.rb` calls `require_dependencies` to load `lib/a_lib.rb`, `lib/dependent_lib.rb`, `an_app/app.rb`
* The first loading of `lib/a_lib.rb` fails because it depends on `lib/dependent_lib.rb`
* `lib/dependent_lib.rb` are loaded with no error because it does not depend on any other files.
* Then `require_dependencies` tries to load `an_app/app.rb`, which may call nested `require_dependencies`.
* Nested `require_dependencies` loads `an_app/models/model_with_no_dep_on_lib.rb` with no error.
* Then nested `require_dependencies` tries to load `an_app/models/model_that_depends_on_lib.rb`, but it fails because `model_that_depends_on_lib.rb` depends on `lib/a_lib.rb`.
* After all, nested `require_dependencies` gives up to load files, raising `NameError - uninitialized constant ALib`
* Outer `require_dependencies` catches this exception and it assumes that entire process of loading `an_app/app.rb` fails, although `model_with_no_dep_on_lib.rb` was loaded and commited successfully.
* Outer `require_dependencies` rollbacks every constants that is created before preparing `an_app/app.rb`
* As a result, all constants defined in `an_app/models/model_with_no_dep_on_lib.rb` are removed, even though they are commited and not to be loaded in next nested `require_dependencies`.

Modify `Gemfile` in the example above as follows:

```
gem "padrino", github: "genkami/padrino-framework", ref: "b5186fe3"
```

Then execute `bundle exec ruby toplevel.rb` again.  No error may happen.