### PR TITLE
Fix loading order of app's dependencies

### DIFF
--- a/padrino-core/lib/padrino-core/loader.rb
+++ b/padrino-core/lib/padrino-core/loader.rb
@@ -54,7 +54,7 @@ module Padrino
       Padrino.logger
       Reloader.lock!
       before_load.each(&:call)
-      require_dependencies(*dependency_paths)
+      dependency_paths.each{ |path| require_dependencies(path) }
       after_load.each(&:call)
       logger.devel "Loaded Padrino in #{Time.now - began_at} seconds"
       precompile_all_routes!


### PR DESCRIPTION
I also met the same error in: https://github.com/padrino/padrino-framework/pull/2193
If we load apps at the first time and libraries won't be there, `config/apps.rb` gets NameError. Because `config/apps.rb` was loaded before `lib/a.rb`, in particular, app crashed when loading a model.
This PR is for loading `lib/*.rb` before `config/apps.rb`
```
➜  server git:(test_pham) ✗ cat lib/a.rb
A_result = [B]
A = "a"
➜  server git:(test_pham) ✗ cat lib/b.rb
B_result = "B result"

B = "B"
➜  server git:(test_pham) ✗ cat config/apps.rb
require 'Model'
A
```
