### PR TITLE
Fix incomplete Storage.rollback

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -90,7 +90,7 @@ module Padrino
       return unless options[:force] || file_changed?(file)
       return require(file) if feature_excluded?(file)
 
-      Storage.prepare(file, MTIMES) # might call #safe_load recursively
+      Storage.prepare(file) # might call #safe_load recursively
       logger.devel(file_new?(file) ? :loading : :reload, began_at, file)
       begin
         with_silence{ require(file) }
@@ -101,7 +101,7 @@ module Padrino
           logger.exception exception, :short
           logger.error "Failed to load #{file}; removing partially defined constants"
         end
-        Storage.rollback(file, MTIMES)
+        Storage.rollback(file)
         raise
       end
     end

--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -139,6 +139,13 @@ module Padrino
       @special_files = Set.new(files)
     end
 
+    ###
+    # Macro for mtime remove.
+    #
+    def remove_modification_time(file)
+      MTIMES.delete(file)
+    end
+
     private
 
     ##

--- a/padrino-core/lib/padrino-core/reloader/storage.rb
+++ b/padrino-core/lib/padrino-core/reloader/storage.rb
@@ -41,7 +41,15 @@ module Padrino
 
       def rollback(name)
         new_constants = new_classes(@old_entries[name][:constants])
-        new_constants.each{ |klass| Reloader.remove_constant(klass) }
+        new_constants.each do |klass|
+          files.each do |file|
+            if file[1][:constants].include?(klass)
+              file_path = file[0]
+              Reloader.clear_modification_time(file_path)
+            end
+          end
+          Reloader.remove_constant(klass)
+        end
         @old_entries.delete(name)
       end
 

--- a/padrino-core/lib/padrino-core/reloader/storage.rb
+++ b/padrino-core/lib/padrino-core/reloader/storage.rb
@@ -18,13 +18,12 @@ module Padrino
         files.delete(name)
       end
 
-      def prepare(name, mtimes)
+      def prepare(name)
         file = remove(name)
         @old_entries ||= {}
         @old_entries[name] = {
           :constants => object_classes,
-          :features  => old_features = Set.new($LOADED_FEATURES.dup),
-          :mtimes => mtimes.dup
+          :features  => old_features = Set.new($LOADED_FEATURES.dup)
         }
         features = file && file[:features] || []
         features.each{ |feature| Reloader.safe_load(feature, :force => true) }
@@ -40,10 +39,8 @@ module Padrino
         @old_entries.delete(name)
       end
 
-      def rollback(name, mtimes)
-        new_constants = new_classes(@old_entries[name][:constants]).reject do |constant|
-          newly_commited_constant?(constant, mtimes, @old_entries[name][:mtimes])
-        end
+      def rollback(name)
+        new_constants = new_classes(@old_entries[name][:constants])
         new_constants.each{ |klass| Reloader.remove_constant(klass) }
         @old_entries.delete(name)
       end
@@ -79,26 +76,6 @@ module Padrino
       def new_classes(snapshot)
         object_classes do |klass|
           snapshot.include?(klass) ? nil : klass
-        end
-      end
-
-      ##
-      # Returns true if and only if constant is commited after prepare
-      #
-      def newly_commited_constant?(constant, mtimes, old_mtimes)
-        newly_commited_files(files, mtimes, old_mtimes).each do |_, entry|
-          return true if entry[:constants].include?(constant)
-        end
-        false
-      end
-
-      ##
-      # Returns a list of entries in "files" that is commited after prepare
-      #
-      def newly_commited_files(files, mtimes, old_mtimes)
-        files.select do |file, _|
-          next true unless old_mtimes[file]
-          old_mtimes[file] < mtimes[file]
         end
       end
     end


### PR DESCRIPTION
Incomplete rollback at load
`Padrino.root("fixtures/dependencies/nested/l.rb")` first time in test_dependencies. by #2193

The real problem is not to re-require the rollbacked files again.

This happens because rollback does not delete file path in `Reloader.MTIME`.

