### PR TITLE
Fix remove_constant to stop removing constants that are already remove_constanted but not GCed

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -113,6 +113,7 @@ module Padrino
       return if constant_excluded?(const)
       base, _, object = const.to_s.rpartition('::')
       base = base.empty? ? Object : base.constantize
+      return unless base.const_get(object).equal?(const)
       base.send :remove_const, object
       logger.devel "Removed constant #{const} from #{base}"
     rescue NameError


### PR DESCRIPTION
I found a bug with `remove_constant` and GC.

I wll later give an example that potentially causes this bug.