### PR TITLE
Change dependency load order

### DIFF
--- a/padrino-core/lib/padrino-core/loader.rb
+++ b/padrino-core/lib/padrino-core/loader.rb
@@ -54,7 +54,7 @@ module Padrino
       Padrino.logger
       Reloader.lock!
       before_load.each(&:call)
-      require_dependencies(*dependency_paths)
+      dependency_paths.each{ |path| require_dependencies(path) }
       after_load.each(&:call)
       logger.devel "Loaded Padrino in #{Time.now - began_at} seconds"
       precompile_all_routes!

--- a/padrino-core/lib/padrino-core/reloader/storage.rb
+++ b/padrino-core/lib/padrino-core/reloader/storage.rb
@@ -45,7 +45,12 @@ module Padrino
                              next if file == name
                              break if data[:constants].include?(klass)
                            end
-          Reloader.remove_constant(klass) if loaded_in_name
+          if loaded_in_name
+            @old_entries.each do |file, data|
+              data[:constants] << klass if file != name
+            end
+            Reloader.remove_constant(klass)
+          end
         end
         @old_entries.delete(name)
       end

--- a/padrino-core/test/fixtures/dependencies/nested_app/app/models/r_model.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/app/models/r_model.rb
@@ -1,0 +1,6 @@
+class RModel
+  include TModule
+  def self.hello
+    "hello"
+  end
+end

--- a/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
@@ -1,0 +1,9 @@
+class RollbackTargetSModel
+  def self.hello
+    "hello"
+  end
+end
+
+class SModel < OLib
+  include TModule
+end

--- a/padrino-core/test/fixtures/dependencies/nested_app/app/models/t_module.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/app/models/t_module.rb
@@ -1,5 +1,5 @@
 module TModule
   def hello_from_t_module
-    puts "hello_from_t_module"
+    "hello_from_t_module"
   end
 end

--- a/padrino-core/test/fixtures/dependencies/nested_app/app/models/t_module.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/app/models/t_module.rb
@@ -1,0 +1,5 @@
+module TModule
+  def hello_from_t_module
+    puts "hello_from_t_module"
+  end
+end

--- a/padrino-core/test/fixtures/dependencies/nested_app/config/apps.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/config/apps.rb
@@ -1,0 +1,5 @@
+Padrino.require_dependencies(
+  Padrino.root("fixtures/dependencies/nested_app/app/models/r_model.rb"),
+  Padrino.root("fixtures/dependencies/nested_app/app/models/s_model.rb"),
+  Padrino.root("fixtures/dependencies/nested_app/app/models/t_module.rb"),
+)

--- a/padrino-core/test/fixtures/dependencies/nested_app/lib/o_lib.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/lib/o_lib.rb
@@ -1,0 +1,2 @@
+class OLib < PLib
+end

--- a/padrino-core/test/fixtures/dependencies/nested_app/lib/p_lib.rb
+++ b/padrino-core/test/fixtures/dependencies/nested_app/lib/p_lib.rb
@@ -1,0 +1,2 @@
+class PLib
+end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -127,7 +127,6 @@ describe "Dependencies" do
             Padrino.root("fixtures/dependencies/nested_app/config/apps.rb"),
           )
         end
-	      puts @io.string
         assert_raises(NameError) do
           RModel.hello
         end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -131,7 +131,6 @@ describe "Dependencies" do
         assert_equal "hello_from_t_module", RModel.new.hello_from_t_module
         assert_equal "hello_from_t_module", SModel.new.hello_from_t_module
         assert_equal "hello", RollbackTargetSModel.hello
-        assert_match /Removed constant RollbackTargetSModel from Object/, @io.string
       end
     end
   end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -131,6 +131,7 @@ describe "Dependencies" do
         assert_equal "hello_from_t_module", RModel.new.hello_from_t_module
         assert_equal "hello_from_t_module", SModel.new.hello_from_t_module
         assert_equal "hello", RollbackTargetSModel.hello
+        assert_match /Removed constant RollbackTargetSModel from Object/, @io.string
       end
     end
   end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -120,16 +120,18 @@ describe "Dependencies" do
         Padrino::Logger.setup!
       end
 
-      it 'some model not define' do
+      it 'should resolve interdependence by out/in side nested require_dependencies' do
         capture_io do
           Padrino.require_dependencies(
             Padrino.root("fixtures/dependencies/nested_app/lib/**/*.rb"),
-            Padrino.root("fixtures/dependencies/nested_app/config/apps.rb"),
+            Padrino.root("fixtures/dependencies/nested_app/config/apps.rb")
           )
         end
-        assert_raises(NameError) do
-          RModel.hello
-        end
+        assert_equal "hello", RModel.hello
+        assert_equal "hello_from_t_module", RModel.new.hello_from_t_module
+        assert_equal "hello_from_t_module", SModel.new.hello_from_t_module
+        assert_equal "hello", RollbackTargetSModel.hello
+        assert_match /Removed constant RollbackTargetSModel from Object/, @io.string
       end
     end
   end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -105,5 +105,33 @@ describe "Dependencies" do
         assert_match /Removed constant RollbackTarget from Object/, @io.string
       end
     end
+
+    describe 'when we require lib, app in one circle' do
+      before do
+        Padrino.clear!
+        @log_level_devel = Padrino::Logger::Config[:test]
+        @io = StringIO.new
+        Padrino::Logger::Config[:test] = { :log_level => :devel, :stream => @io }
+        Padrino::Logger.setup!
+      end
+
+      after do
+        Padrino::Logger::Config[:test] = @log_level_devel
+        Padrino::Logger.setup!
+      end
+
+      it 'some model not define' do
+        capture_io do
+          Padrino.require_dependencies(
+            Padrino.root("fixtures/dependencies/nested_app/lib/**/*.rb"),
+            Padrino.root("fixtures/dependencies/nested_app/config/apps.rb"),
+          )
+        end
+	      puts @io.string
+        assert_raises(NameError) do
+          RModel.hello
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Dear @namusyaka @ujifgc, 
I'm so sorry for late reply. 
As your suggestion, I add a test case and provide minimal code for reproducing the issue. 

#### Minimal code for reproducing the issue

Please check this repo
https://github.com/phamvanhung2e123/my_padrino_project

#### Explain more details


The real problem is that `require_dependencies` didn't work in the test case I provided.
This commit https://github.com/padrino/padrino-framework/commit/338111d4de0e9b0b6f507f029e7e56405789fdec fixed the problem in https://github.com/padrino/padrino-framework/pull/2193 but didn't work in my case
I am using Padrino version `0.12.3`. `RModel` is removed when rollback `config/apps.rb`

This is devel log
```
/lib/o_lib.rb
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant PLib
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0064s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/lib/p_lib.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0069s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/config/apps.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0061s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/r_model.rb
  DEVEL - 27/Nov/2018 18:36:36 Removed constant RModel from Object
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant RModel::TModule
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0065s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
  DEVEL - 27/Nov/2018 18:36:36 Removed constant RollbackTargetSModel from Object
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant OLib
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0061s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/t_module.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0074s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/r_model.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0057s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
  DEVEL - 27/Nov/2018 18:36:36 Removed constant RollbackTargetSModel from Object
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant OLib
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0058s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
  DEVEL - 27/Nov/2018 18:36:36 Removed constant RollbackTargetSModel from Object
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant OLib
  ERROR - 27/Nov/2018 18:36:36 NameError - uninitialized constant OLib:
 /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb:7:in `<top (required)>'
  DEVEL - 27/Nov/2018 18:36:36 Removed constant RModel from Object
  DEVEL - 27/Nov/2018 18:36:36 Cyclic dependency reload for NameError: uninitialized constant OLib
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0064s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/lib/o_lib.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0064s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/config/apps.rb
  DEVEL - 27/Nov/2018 18:36:36  LOADING (0.0094s) /Users/vanhungpham/git/padrino-framework/padrino-core/test/fixtures/dependencies/nested_app/app/models/s_model.rb
```
When I change to lastest Padrino, NameError is raised in lib.(Please check this repo for more details https://github.com/phamvanhung2e123/my_padrino_project)

#### How to fix
This PR is for loading `lib/*.rb` before `config/apps.rb`. It maybe an easy way to fix my case by loading `config/apps.rb` without rollback. Do you have any suggestions for the problem ? 
Could you please explain the reason to load `dependency_paths` by a circular loader?
(I read this PR, but cann't understand the reason https://github.com/padrino/padrino-framework/pull/1449)
Thank you for your time!