### PR TITLE
Avoid mocha warning in tests

### DIFF
--- a/padrino-helpers/test/helper.rb
+++ b/padrino-helpers/test/helper.rb
@@ -2,7 +2,7 @@ ENV['RACK_ENV'] = 'test'
 
 require 'minitest/autorun'
 require 'minitest/pride'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'rack/test'
 require 'builder'
 require 'padrino-helpers'


### PR DESCRIPTION
This PR avoids a test warning output by Mocha.

We use minitest, so we set up the `mocha/minitest`.