### PR TITLE
Adapt a test to sinatra/sinatra#1645.

### DIFF
--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2122,7 +2122,7 @@ describe "Routing" do
     mock_app { set :environment, :development }
     get "/"
     assert_equal 404, status
-    assert_match %r{GET /}, body
+    assert_match %r{GET &#x2F;}, body
   end
 
   it 'should render a custom NotFound page' do


### PR DESCRIPTION
Sinatra will add escaping to their static 404 page, which will be applied in the next release(2.1.1).
Our tests follow it.