### PR TITLE
CI: Drop rbx-2 from build matrix, uninstallable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.6.3
   - 2.7.3
   - ruby-head
-  - rbx-2
   - jruby
   - jruby-head
 notifications:
@@ -44,7 +43,6 @@ matrix:
     - rvm: 2.6.3
       env: AS_VERSION=3.2
   allow_failures:
-    - rvm: rbx-2
     - rvm: jruby
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 group :db do
   gem "sequel"
-  gem "sqlite3", :platforms => [:mri, :rbx]
+  gem "sqlite3", :platforms => [:mri]
   gem "jdbc-sqlite3", "~> 3.7.2", :platform => :jruby
 end
 


### PR DESCRIPTION
Example invocation in CI looks like:

> 
> 17.63s$ rvm use rbx-2 --install --binary --fuzzy
> curl: (22) The requested URL returned error: 404 Not Found
> Required rbx-2 is not installed - installing.
> curl: (22) The requested URL returned error: 404 Not Found
> Searching for binary rubies, this might take some time.
> Requested binary installation but no rubies are available to download, consider skipping --binary flag.
> Gemset '' does not exist, 'rvm rbx-2 do rvm gemset create ' first, or append '--create'.
> The command "rvm use rbx-2 --install --binary --fuzzy" failed and exited with 2 during .