### PR TITLE
Fix for cascading mailer path being added to template path when using…

### DIFF
--- a/padrino-mailer/lib/padrino-mailer/ext.rb
+++ b/padrino-mailer/lib/padrino-mailer/ext.rb
@@ -261,7 +261,7 @@ module Mail # @private
       engine ||= message_name
 
       if mailer_name && !engine.to_s.index('/')
-        settings.views += "/#{mailer_name}" 
+        settings.views += "/#{mailer_name}" unless settings.views.include?("/#{mailer_name}")
         engine = engine.to_s.sub(%r{^#{mailer_name}/}, '')
       end
 


### PR DESCRIPTION
… partials in email templates

As per #2231, when using multiple partials within an email template, the mailer name keeps getting added to the file path for each subsequent partial in the same template, resulting in an `Errno::ENOENT: No such file or directory @ rb_sysopen` error.

Added a check to `settings.view` in the render routine to see if the mailer path was already in the string before adding it.