### PR TITLE
padrino-gen: fix for ActiveRecord 6.1

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -14,16 +14,16 @@ AR = (<<-AR) unless defined?(AR)
 #     :socket    => '/tmp/mysql.sock'
 #   }
 #
-ActiveRecord::Base.configurations[:development] = {
+ActiveRecord::Base.configurations = {
+  :development => {
 !DB_DEVELOPMENT!
-}
-
-ActiveRecord::Base.configurations[:production] = {
+  },
+  :production => {
 !DB_PRODUCTION!
-}
-
-ActiveRecord::Base.configurations[:test] = {
+  },
+  :test => {
 !DB_TEST!
+  }
 }
 
 # Setup our logger
@@ -52,48 +52,48 @@ ActiveSupport.use_standard_json_time_format = true
 ActiveSupport.escape_html_entities_in_json = false
 
 # Now we can establish connection with our db.
-ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+ActiveRecord::Base.establish_connection(Padrino.env)
 
 # Timestamps are in the utc by default.
 ActiveRecord::Base.default_timezone = :utc
 AR
 
 MYSQL = (<<-MYSQL) unless defined?(MYSQL)
-  :adapter   => 'mysql',
-  :encoding  => 'utf8',
-  :reconnect => true,
-  :database  => !DB_NAME!,
-  :pool      => 5,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :socket    => '/tmp/mysql.sock'
+    :adapter   => 'mysql',
+    :encoding  => 'utf8',
+    :reconnect => true,
+    :database  => !DB_NAME!,
+    :pool      => 5,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :socket    => '/tmp/mysql.sock'
 MYSQL
 
 MYSQL2 = (<<-MYSQL2) unless defined?(MYSQL2)
-  :adapter   => 'mysql2',
-  :encoding  => 'utf8',
-  :reconnect => true,
-  :database  => !DB_NAME!,
-  :pool      => 5,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :socket    => '/tmp/mysql.sock'
+    :adapter   => 'mysql2',
+    :encoding  => 'utf8',
+    :reconnect => true,
+    :database  => !DB_NAME!,
+    :pool      => 5,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :socket    => '/tmp/mysql.sock'
 MYSQL2
 
 POSTGRES = (<<-POSTGRES) unless defined?(POSTGRES)
-  :adapter   => 'postgresql',
-  :database  => !DB_NAME!,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :port      => 5432
+    :adapter   => 'postgresql',
+    :database  => !DB_NAME!,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :port      => 5432
 POSTGRES
 
 SQLITE = (<<-SQLITE) unless defined?(SQLITE)
-  :adapter => 'sqlite3',
-  :database => !DB_NAME!
+    :adapter => 'sqlite3',
+    :database => !DB_NAME!
 SQLITE
 
 CONNECTION_POOL_MIDDLEWARE = <<-MIDDLEWARE

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -429,7 +429,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       db_configs = ActiveRecord::Base.configurations.configs_for(env_name: env_name.to_s)
 
       db_configs.each do |db_config|
-        yield db_config.config.with_indifferent_access
+        yield db_config.configuration_hash.with_indifferent_access
       end
     end
   end
@@ -441,7 +441,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       end
     else
       ActiveRecord::Base.configurations.configs_for.each do |db_config|
-        yield db_config.config.with_indifferent_access
+        yield db_config.configuration_hash.with_indifferent_access
       end
     end
   end


### PR DESCRIPTION
These changes fix the following errors and warnings when trying to run
`rake db:create` against an empty, freshly generated, application:

    NoMethodError: undefined method `[]=' for
    #<ActiveRecord::DatabaseConfigurations:0x0000564fe41c5518>
    Did you mean?  []

    DEPRECATION WARNING: [] is deprecated and will be removed from Rails
    6.2 (Use configs_for)

    DEPRECATION WARNING: DatabaseConfig#config will be removed in 6.2.0
    in favor of DatabaseConfigurations#configuration_hash which returns
    a hash with symbol keys