### PR TITLE
fix translate issue after ruby 3.0

### DIFF
--- a/padrino-helpers/lib/padrino-helpers/translation_helpers.rb
+++ b/padrino-helpers/lib/padrino-helpers/translation_helpers.rb
@@ -14,7 +14,8 @@ module Padrino
       #  The translation for the specified keys.
       #
       def translate(*args)
-        I18n.translate(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        I18n.translate(*args, **options)
       end
       alias :t :translate
 


### PR DESCRIPTION
According to 
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

