### PR TITLE
Add circle ci badge and further ruby/jruby versions for running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,47 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2 
+  ruby: circleci/ruby@0.1.2
 
 jobs:
   build:
+    parameters:
+      ruby-version:
+        type: string
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: circleci/<< parameters.ruby-version >>
     executor: ruby/default
     steps:
       - checkout
       - run:
           name: Which bundler?
-          command: bundle -v
+          command: gem install bundler
       - ruby/bundle-install
+      - run:
+          name: Run tests
+          command: bundle exec rake test
+workflows:
+  build-and-test-stable:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              # https://github.com/CircleCI-Public/cimg-ruby
+              # only supports the last three ruby versions
+              ruby-version:
+                - "ruby:2.5.0"
+                - "ruby:2.5.9"
+                - "ruby:2.6.3"
+                - "ruby:2.6.9"
+                - "ruby:2.7.3"
+                - "ruby:2.7.5"
+                - "jruby:9.2.10.0"
+                - "jruby:9.2.14.0"
+                - "jruby:9.2.19.0"
+  build-and-test-latest:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              ruby-version:
+                - "ruby:latest"
+                - "jruby:latest"

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,12 +1,14 @@
 = Padrino
 
+
 Padrino is the godfather of Sinatra. Follow us on
 {www.padrinorb.com}[http://padrinorb.com] and on twitter
 {@padrinorb}[http://twitter.com/padrinorb]. Join us on {gitter}[https://gitter.im/padrino/padrino-framework]
 
-{<img src="https://api.travis-ci.org/padrino/padrino-framework.svg" alt="Build Status" />}[http://travis-ci.org/padrino/padrino-framework]
+{<img src="https://circleci.com/gh/padrino/padrino-framework/tree/master.svg?style=svg" alt="Build Status" />}[https://app.circleci.com/pipelines/github/padrino/padrino-framework]
 {<img src="https://api.codeclimate.com/v1/badges/900d6e424498f0e2b7ff/maintainability" alt="CodeClimate Maintainability score" />}[https://codeclimate.com/github/padrino/padrino-framework/maintainability]
 {<img src="https://badges.gitter.im/Join Chat.svg" />}[https://gitter.im/padrino/padrino-framework]
+{<img src='https://www.codetriage.com/padrino/padrino-framework/badges/users.svg' alt='Code Triagers Badge' />}[https://www.codetriage.com/padrino/padrino-framework]
 {<img src='https://www.codetriage.com/padrino/padrino-framework/badges/users.svg' alt='Code Triagers Badge' />}[https://www.codetriage.com/padrino/padrino-framework]
 
 == Preface


### PR DESCRIPTION
In order to activate the badge a repo owner must setup the project
![Screenshot_2022-01-23_06-36-07](https://user-images.githubusercontent.com/264708/150666386-6f7c7abe-0d71-4a08-91cc-b50847fec890.png)

I can PM you the invite link.

Cheers!
 