### PR TITLE
Add compatibility with Sinatra 3

### DIFF
--- a/padrino-core/lib/padrino-core/application.rb
+++ b/padrino-core/lib/padrino-core/application.rb
@@ -29,11 +29,14 @@ module Padrino
     class << self
       def inherited(base)
         begun_at = Time.now
-        CALLERS_TO_IGNORE.concat(PADRINO_IGNORE_CALLERS)
         super(base)
         base.prerequisites.replace(self.prerequisites.dup)
         base.default_configuration!
         logger.devel :setup, begun_at, base
+      end
+
+      def callers_to_ignore
+        @callers_to_ignore ||= super + PADRINO_IGNORE_CALLERS
       end
 
       ##

--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-support", Padrino.version)
-  s.add_dependency("sinatra", ">= 2.0.0")
+  s.add_dependency("sinatra", ">= 2.2.4")
   s.add_dependency("thor", "~> 1.0")
 end

--- a/padrino-core/test/test_application.rb
+++ b/padrino-core/test/test_application.rb
@@ -51,7 +51,7 @@ describe "Application" do
     end
 
     it 'should have shared sessions accessible in project' do
-      Padrino.configure_apps { enable :sessions; set :session_secret, 'secret' }
+      Padrino.configure_apps { enable :sessions; set :session_secret, PadrinoTestApp2.session_secret }
       Padrino.mount("PadrinoTestApp").to("/write")
       Padrino.mount("PadrinoTestApp2").to("/read")
       PadrinoTestApp.send :default_configuration!

--- a/padrino-core/test/test_routing.rb
+++ b/padrino-core/test/test_routing.rb
@@ -2133,7 +2133,7 @@ describe "Routing" do
     mock_app { set :environment, :development }
     get "/"
     assert_equal 404, status
-    assert_match %r{GET /}, body
+    assert_match %r{Not Found}, body
   end
 
   it 'should render a custom NotFound page' do


### PR DESCRIPTION
Sinatra 2.2.4 and 3.0.5 add a `callers_to_ignore` method that can be overridden instead of directly mutating `CALLERS_TO_IGNORE`.