### PR TITLE
Pin haml to v5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
     puts "=> Using Hamlit Haml engine"
     gem "hamlit"
   else
-    gem "haml",      ">= 4.0.5"
+    gem "haml",      "~> 5"
   end
 
   case ENV['ERB_ENGINE']


### PR DESCRIPTION
Tests that use inline templates will need to be updated for Haml 6:

Output should be unescaped by using `!=`

```
%html
  != yield
```