### PR TITLE
padrino-gen: fix for ActiveRecord 6.1

### DIFF
--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -2,28 +2,30 @@ AR = (<<-AR) unless defined?(AR)
 ##
 # You can use other adapters like:
 #
-#   ActiveRecord::Base.configurations[:development] = {
-#     :adapter   => 'mysql2',
-#     :encoding  => 'utf8',
-#     :reconnect => true,
-#     :database  => 'your_database',
-#     :pool      => 5,
-#     :username  => 'root',
-#     :password  => '',
-#     :host      => 'localhost',
-#     :socket    => '/tmp/mysql.sock'
+#   ActiveRecord::Base.configurations = {
+#     :development => {
+#       :adapter   => 'mysql2',
+#       :encoding  => 'utf8',
+#       :reconnect => true,
+#       :database  => 'your_database',
+#       :pool      => 5,
+#       :username  => 'root',
+#       :password  => '',
+#       :host      => 'localhost',
+#       :socket    => '/tmp/mysql.sock'
+#     }
 #   }
 #
-ActiveRecord::Base.configurations[:development] = {
+ActiveRecord::Base.configurations = {
+  :development => {
 !DB_DEVELOPMENT!
-}
-
-ActiveRecord::Base.configurations[:production] = {
+  },
+  :production => {
 !DB_PRODUCTION!
-}
-
-ActiveRecord::Base.configurations[:test] = {
+  },
+  :test => {
 !DB_TEST!
+  }
 }
 
 # Setup our logger
@@ -52,48 +54,52 @@ ActiveSupport.use_standard_json_time_format = true
 ActiveSupport.escape_html_entities_in_json = false
 
 # Now we can establish connection with our db.
-ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+if ActiveRecord::VERSION::MAJOR.to_i < 6
+  ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+else
+  ActiveRecord::Base.establish_connection(Padrino.env)
+end
 
 # Timestamps are in the utc by default.
 ActiveRecord::Base.default_timezone = :utc
 AR
 
 MYSQL = (<<-MYSQL) unless defined?(MYSQL)
-  :adapter   => 'mysql',
-  :encoding  => 'utf8',
-  :reconnect => true,
-  :database  => !DB_NAME!,
-  :pool      => 5,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :socket    => '/tmp/mysql.sock'
+    :adapter   => 'mysql',
+    :encoding  => 'utf8',
+    :reconnect => true,
+    :database  => !DB_NAME!,
+    :pool      => 5,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :socket    => '/tmp/mysql.sock'
 MYSQL
 
 MYSQL2 = (<<-MYSQL2) unless defined?(MYSQL2)
-  :adapter   => 'mysql2',
-  :encoding  => 'utf8',
-  :reconnect => true,
-  :database  => !DB_NAME!,
-  :pool      => 5,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :socket    => '/tmp/mysql.sock'
+    :adapter   => 'mysql2',
+    :encoding  => 'utf8',
+    :reconnect => true,
+    :database  => !DB_NAME!,
+    :pool      => 5,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :socket    => '/tmp/mysql.sock'
 MYSQL2
 
 POSTGRES = (<<-POSTGRES) unless defined?(POSTGRES)
-  :adapter   => 'postgresql',
-  :database  => !DB_NAME!,
-  :username  => 'root',
-  :password  => '',
-  :host      => 'localhost',
-  :port      => 5432
+    :adapter   => 'postgresql',
+    :database  => !DB_NAME!,
+    :username  => 'root',
+    :password  => '',
+    :host      => 'localhost',
+    :port      => 5432
 POSTGRES
 
 SQLITE = (<<-SQLITE) unless defined?(SQLITE)
-  :adapter => 'sqlite3',
-  :database => !DB_NAME!
+    :adapter => 'sqlite3',
+    :database => !DB_NAME!
 SQLITE
 
 CONNECTION_POOL_MIDDLEWARE = <<-MIDDLEWARE

--- a/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/orms/activerecord.rb
@@ -59,9 +59,6 @@ if ActiveRecord::VERSION::MAJOR.to_i < 6
 else
   ActiveRecord::Base.establish_connection(Padrino.env)
 end
-
-# Timestamps are in the utc by default.
-ActiveRecord::Base.default_timezone = :utc
 AR
 
 MYSQL = (<<-MYSQL) unless defined?(MYSQL)

--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -420,6 +420,10 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
     ActiveRecord.version < Gem::Version.create("6.0.0")
   end
 
+  def less_than_active_record_6_1?
+    ActiveRecord.version < Gem::Version.create("6.1.0")
+  end
+
   def with_database(env_name)
     if less_than_active_record_6_0?
       config = ActiveRecord::Base.configurations.with_indifferent_access[env_name]
@@ -429,7 +433,7 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       db_configs = ActiveRecord::Base.configurations.configs_for(env_name: env_name.to_s)
 
       db_configs.each do |db_config|
-        yield db_config.config.with_indifferent_access
+        yield configuration_hash(db_config)
       end
     end
   end
@@ -441,9 +445,15 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
       end
     else
       ActiveRecord::Base.configurations.configs_for.each do |db_config|
-        yield db_config.config.with_indifferent_access
+        yield configuration_hash(db_config)
       end
     end
+  end
+
+  def configuration_hash(configuration)
+    return configuration if less_than_active_record_6_0?
+    config = less_than_active_record_6_1 ? configuration.config : configuration.configuration_hash
+    config.with_indifferent_access
   end
 
   task 'db:migrate' => 'ar:migrate'

--- a/padrino-gen/test/fixtures/database_template.rb
+++ b/padrino-gen/test/fixtures/database_template.rb
@@ -1,0 +1,66 @@
+##
+# You can use other adapters like:
+#
+#   ActiveRecord::Base.configurations = {
+#     :development => {
+#       :adapter   => 'mysql2',
+#       :encoding  => 'utf8',
+#       :reconnect => true,
+#       :database  => 'your_database',
+#       :pool      => 5,
+#       :username  => 'root',
+#       :password  => '',
+#       :host      => 'localhost',
+#       :socket    => '/tmp/mysql.sock'
+#     }
+#   }
+#
+ActiveRecord::Base.configurations = {
+  :development => {
+    :adapter => 'sqlite3',
+    :database => Padrino.root('db', 'sample_project_development.db')
+
+  },
+  :production => {
+    :adapter => 'sqlite3',
+    :database => Padrino.root('db', 'sample_project_production.db')
+
+  },
+  :test => {
+    :adapter => 'sqlite3',
+    :database => Padrino.root('db', 'sample_project_test.db')
+
+  }
+}
+
+# Setup our logger
+ActiveRecord::Base.logger = logger
+
+if ActiveRecord::VERSION::MAJOR.to_i < 4
+  # Raise exception on mass assignment protection for Active Record models.
+  ActiveRecord::Base.mass_assignment_sanitizer = :strict
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL).
+  ActiveRecord::Base.auto_explain_threshold_in_seconds = 0.5
+end
+
+# Doesn't include Active Record class name as root for JSON serialized output.
+ActiveRecord::Base.include_root_in_json = false
+
+# Store the full class name (including module namespace) in STI type column.
+ActiveRecord::Base.store_full_sti_class = true
+
+# Use ISO 8601 format for JSON serialized times and dates.
+ActiveSupport.use_standard_json_time_format = true
+
+# Don't escape HTML entities in JSON, leave that for the #json_escape helper
+# if you're including raw JSON in an HTML page.
+ActiveSupport.escape_html_entities_in_json = false
+
+# Now we can establish connection with our db.
+if ActiveRecord::VERSION::MAJOR.to_i < 6
+  ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])
+else
+  ActiveRecord::Base.establish_connection(Padrino.env)
+end

--- a/padrino-gen/test/test_component_generator.rb
+++ b/padrino-gen/test/test_component_generator.rb
@@ -26,6 +26,8 @@ describe "ComponentGenerator" do
       assert_match_in_file(/gem 'activerecord', '>= 3.1', :require => 'active_record'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/gem 'sqlite3'/, "#{@apptmp}/sample_project/Gemfile")
       refute_match(/Switch renderer to/, out)
+      database_template_path = File.join(File.dirname(__FILE__), 'fixtures', 'database_template.rb')
+      assert FileUtils.compare_file("#{@apptmp}/sample_project/config/database.rb", database_template_path)
       components_chosen = YAML.load_file("#{@apptmp}/sample_project/.components")
       assert_equal 'activerecord', components_chosen[:orm]
     end


### PR DESCRIPTION
Picking up @terceiro's work in #2249. Modifications needed to be made to maintain compatibility with AR versions < 6.1.

Need to investigate how to test these changes.

Closes #2238, #2255 