### PR TITLE
Update ORM generator for ActiveRecord changes

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/orm.rb
+++ b/padrino-admin/lib/padrino-admin/generators/orm.rb
@@ -124,8 +124,8 @@ module Padrino
 
         def update_attributes(params=nil)
           case orm
-            when :activerecord, :minirecord, :mongomapper, :mongoid, :couchrest, :dynamoid then "@#{name_singular}.update_attributes(#{params})"
-            when :datamapper, :ohm then "@#{name_singular}.update(#{params})"
+            when :mongomapper, :mongoid, :couchrest, :dynamoid then "@#{name_singular}.update_attributes(#{params})"
+            when :activerecord, :minirecord, :datamapper, :ohm then "@#{name_singular}.update(#{params})"
             when :sequel then "@#{name_singular}.modified! && @#{name_singular}.update(#{params})"
             else raise OrmError, "Adapter #{orm} is not yet supported!"
           end


### PR DESCRIPTION
Fixes #2266. Already generated admin code for ActiveRecord will need to replace `update_attributes` with `update` when upgrading to version 6.1 or greater.