### PR TITLE
Resolve ActiveRecord schema format deprecation

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -136,7 +136,11 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
         ActiveRecord::MigrationContext.new("db/migrate/", ActiveRecord::SchemaMigration).migrate(env_migration_version)
       end
 
-      Rake::Task["ar:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+      if less_than_active_record_7_0?
+        Rake::Task["ar:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+      else
+        Rake::Task["ar:schema:dump"].invoke if ActiveRecord.schema_format == :ruby
+      end
     end
 
     namespace :migrate do
@@ -422,6 +426,10 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
 
   def less_than_active_record_6_1?
     ActiveRecord.version < Gem::Version.create("6.1.0")
+  end
+
+  def less_than_active_record_7_0?
+    ActiveRecord.version < Gem::Version.create("7.0.0")
   end
 
   def with_database(env_name)


### PR DESCRIPTION
Running the `ar:migrate` task with ActiveRecord 7.0 will provide the following deprecation warning:

```
DEPRECATION WARNING: ActiveRecord::Base.schema_format is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.schema_format` instead.
```

Now that 7.1 is released, `ActiveRecord::Base.schema_format` has been removed in the latest version of ActiveRecord.

This checks to see if at least ActiveRecord version 7.0 is being used. If not, there is no change to the task. However, if so, it now uses `ActiveRecord.schema_format` to check if the schema dump task should be invoked.