### PR TITLE
Rename MiniTest to Minitest

### DIFF
--- a/padrino-admin/test/helper.rb
+++ b/padrino-admin/test/helper.rb
@@ -23,7 +23,7 @@ module Kernel
   end
 end
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   # Sets up a Sinatra::Base subclass defined with the block

--- a/padrino-cache/test/helper.rb
+++ b/padrino-cache/test/helper.rb
@@ -8,7 +8,7 @@ require 'padrino-cache'
 
 require 'ext/rack-test-methods'
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   # Sets up a Sinatra::Base subclass defined with the block

--- a/padrino-core/test/helper.rb
+++ b/padrino-core/test/helper.rb
@@ -13,7 +13,7 @@ require 'padrino-core'
 require 'ext/minitest-spec'
 require 'ext/rack-test-methods'
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   # Sets up a Sinatra::Base subclass defined with the block

--- a/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
+++ b/padrino-gen/lib/padrino-gen/generators/components/tests/minitest.rb
@@ -3,7 +3,7 @@ RACK_ENV = 'test' unless defined?(RACK_ENV)
 require File.expand_path(File.dirname(__FILE__) + "/../config/boot")
 Dir[File.expand_path(File.dirname(__FILE__) + "/../app/helpers/**/*.rb")].each(&method(:require))
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   # You can use this method to custom specify a Rack app

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -27,7 +27,7 @@ fake_uri_base = "https://raw.github.com/padrino/padrino-static/master/"
   FakeWeb.register_uri(:get, fake_uri_base + suffix, :body => '')
 end
 
-class MiniTest::Spec
+class Minitest::Spec
   def stop_time_for_test
     time = Time.now
     Time.stubs(:now).returns(time)

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -561,7 +561,7 @@ describe "ProjectGenerator" do
       assert_match_in_file(/gem 'minitest'/, "#{@apptmp}/sample_project/Gemfile")
       assert_match_in_file(/include Rack::Test::Methods/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/RACK_ENV = 'test' unless defined\?\(RACK_ENV\)/, "#{@apptmp}/sample_project/test/test_config.rb")
-      assert_match_in_file(/MiniTest::Spec/, "#{@apptmp}/sample_project/test/test_config.rb")
+      assert_match_in_file(/Minitest::Spec/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_match_in_file(/SampleProject::App\.tap/, "#{@apptmp}/sample_project/test/test_config.rb")
       assert_file_exists("#{@apptmp}/sample_project/test/test.rake")
       assert_match_in_file(/Rake::TestTask\.new\("test:\#/,"#{@apptmp}/sample_project/test/test.rake")

--- a/padrino-helpers/test/helper.rb
+++ b/padrino-helpers/test/helper.rb
@@ -14,7 +14,7 @@ require 'ext/minitest-spec'
 require 'ext/rack-test-methods'
 require 'padrino/test-methods'
 
-class MiniTest::Spec
+class Minitest::Spec
   include Padrino::Helpers::OutputHelpers
   include Padrino::Helpers::TagHelpers
   include Padrino::Helpers::AssetTagHelpers

--- a/padrino-mailer/test/helper.rb
+++ b/padrino-mailer/test/helper.rb
@@ -12,7 +12,7 @@ require 'padrino-mailer'
 
 require 'ext/rack-test-methods'
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   # Sets up a Sinatra::Base subclass defined with the block

--- a/padrino-support/test/test_utils.rb
+++ b/padrino-support/test/test_utils.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/helper')
 
-class MiniTest::Spec
+class Minitest::Spec
   def assert_query_equal(expected, actual, namespace=nil)
     assert_equal expected.split('&').sort, Padrino::Utils.build_uri_query(actual, namespace).split('&').sort
   end

--- a/padrino/test/ext/minitest-spec.rb
+++ b/padrino/test/ext/minitest-spec.rb
@@ -1,4 +1,4 @@
-class MiniTest::Spec
+class Minitest::Spec
   # Assert_file_exists('/tmp/app')
   def assert_file_exists(file_path)
     assert File.file?(file_path), "File at path '#{file_path}' does not exist!"


### PR DESCRIPTION
In minitest [5.0.0](https://github.com/minitest/minitest/blob/master/History.rdoc#500--2013-05-10-)

> Renamed MiniTest to Minitest. Your pinkies will thank me. (aliased to MiniTest)

Later in [5.10.0](https://github.com/minitest/minitest/blob/master/History.rdoc#5100--2016-11-30-)

> Deprecated ruby 1.8, 1.9, possibly 2.0, assert_send, & old MiniTest namespace.

Running minitest 5.20.0, the test suite was not running without these changes. This renames usages of `MiniTest` to `Minitest`.