### PR TITLE
Fix ruby 3.x `Regexp.new` deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ workflows:
               # https://github.com/CircleCI-Public/cimg-ruby
               # only supports the last three ruby versions
               ruby-version:
-                - "ruby:2.7.5.203"
                 - "ruby:3.0.3"
                 - "jruby:9.3.3.0"
   build-and-test-latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
               # https://github.com/CircleCI-Public/cimg-ruby
               # only supports the last three ruby versions
               ruby-version:
+                - "ruby:2.7.5.203"
                 - "ruby:3.0.3"
                 - "jruby:9.3.3.0"
   build-and-test-latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - run:
           name: Install Bundler
-          command: gem install bundler
+          command: gem install bundler -v 2.4.22
       - run:
           name: Install dependencies
           command: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
               # https://github.com/CircleCI-Public/cimg-ruby
               # only supports the last three ruby versions
               ruby-version:
-                - "ruby:2.7.5.203"
+                - "ruby:2.7.5"
                 - "ruby:3.0.3"
                 - "jruby:9.3.3.0"
   build-and-test-latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,7 @@ workflows:
               # https://github.com/CircleCI-Public/cimg-ruby
               # only supports the last three ruby versions
               ruby-version:
-                - "ruby:2.6.9"
-                - "ruby:2.7.5"
+                - "ruby:2.7.5.203"
                 - "ruby:3.0.3"
                 - "jruby:9.3.3.0"
   build-and-test-latest:

--- a/padrino-core/lib/padrino-core/router.rb
+++ b/padrino-core/lib/padrino-core/router.rb
@@ -58,7 +58,7 @@ module Padrino
       raise ArgumentError, "app is required" if app.nil?
 
       path  = path.chomp('/')
-      match = Regexp.new("^#{Regexp.quote(path).gsub('/', '/+')}(.*)", nil, 'n')
+      match = Regexp.new("^#{Regexp.quote(path).gsub('/', '/+')}(.*)", Regexp::NOENCODING)
       host  = Regexp.new("^#{Regexp.quote(host)}$", true, 'n') unless host.nil? || host.is_a?(Regexp)
 
       @mapping << [host, path, match, app]

--- a/padrino-core/lib/padrino-core/router.rb
+++ b/padrino-core/lib/padrino-core/router.rb
@@ -59,7 +59,7 @@ module Padrino
 
       path  = path.chomp('/')
       match = Regexp.new("^#{Regexp.quote(path).gsub('/', '/+')}(.*)", Regexp::NOENCODING)
-      host  = Regexp.new("^#{Regexp.quote(host)}$", true, 'n') unless host.nil? || host.is_a?(Regexp)
+      host  = Regexp.new("^#{Regexp.quote(host)}$", Regexp::NOENCODING) unless host.nil? || host.is_a?(Regexp)
 
       @mapping << [host, path, match, app]
     end

--- a/padrino-core/test/test_logger.rb
+++ b/padrino-core/test/test_logger.rb
@@ -102,8 +102,7 @@ describe "PadrinoLogger" do
       @logger.error binary_data
       @logger.error utf8_data
       @logger.flush
-      assert @log.string.force_encoding(encoding).include?("?\n".encode(encoding))
-      assert @log.string.force_encoding(encoding).include?(utf8_data.encode(encoding))
+      assert_match /\.*фыв/m, @log.string.encode(Encoding.default_external)
     end
 
     it 'should log an application' do


### PR DESCRIPTION
👋 A couple a minor fixes here in the hopes of moving further towards ruby 3.x:

* ~Deprecate 2.6/2.7x (latest bundler versions support >2.7.5.203)~ This keeps ruby 2.7.5 for now
* Ruby 3.3 [deprecates](https://bugs.ruby-lang.org/issues/18797) the third argument in `Regexp.new`
* reverts 23a87fd64 fix for jruby @ujifgc 