### PR TITLE
Remove FakeWeb, use Webmock

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ Style/BlockDelimiters:
   Enabled: false
 Style/CharacterLiteral:
   Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
 Style/ClassCheck:
   Enabled: false
 Style/ClassVars:

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :development do
   end
 
   gem "builder",    ">= 2.1.2"
-  gem "webmock", ">= 0"
   gem "minitest", ">= 4.0"
   gem "mocha",    ">= 2.0"
   gem "oga",       ">= 2.5", "< 3"
@@ -52,6 +51,7 @@ group :development do
   gem 'rb-readline', '~> 0.4.2'
   gem 'rubocop', '~> 1.6', :platforms => [:mri]
   gem 'rubocop-minitest', '~>0.34.4', :platforms => [:mri]
+  gem "webmock", "~> 3.19"
   gem "yard",      ">= 0.7.2"
 
   platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :development do
   end
 
   gem "builder",    ">= 2.1.2"
-  gem "fakeweb",   ">= 1.2.8"
   gem "webmock", ">= 0"
   gem "minitest", ">= 4.0"
   gem "mocha",    ">= 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
 
   gem "builder",    ">= 2.1.2"
   gem "fakeweb",   ">= 1.2.8"
+  gem "webmock", ">= 0"
   gem "minitest", ">= 4.0"
   gem "mocha",    ">= 2.0"
   gem "oga",       ">= 2.5", "< 3"

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -17,13 +17,13 @@ class Minitest::Spec
   def stop_time_for_test
     time = Time.now
     Time.stubs(:now).returns(time)
-    return time
+    time
   end
 
   def stub_static_files
     # register fake URL to avoid downloading static files every time tests run
     fake_uri_base = "https://raw.github.com/padrino/padrino-static/master/"
-    %W[
+    %w[
       js/dojo.js
       js/ext.js
       js/jquery.js
@@ -52,7 +52,7 @@ class Minitest::Spec
   def generate_with_parts(name, *params)
     features, constants = [$", Object.constants].map{|x| Marshal.load(Marshal.dump(x)) }
 
-    if root = params.find{|x| x.index(/\-r=|\-\-root=/) }
+    if root = params.find{|x| x.index(/-r=|--root=/) }
       root = root.split(/=/)[1]
       options, model_path = {}, File.expand_path(File.join(root, "/models/**/*.rb"))
       options = params.pop if params.last.is_a?(Hash)
@@ -77,7 +77,7 @@ class Minitest::Spec
     options = options.dup
     project_root = options.delete(:root)
     project_name = options.delete(:name)
-    components = options.sort_by{ |k, v| k.to_s }.map{ |component, value| "--#{component}=#{value}" }
+    components = options.sort_by{ |k, _v| k.to_s }.map{ |component, value| "--#{component}=#{value}" }
     params = [project_name, *components].push("-r=#{project_root}")
     Padrino.expects(:bin_gen).with(*params.unshift('project')).returns(true)
   end

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -11,28 +11,35 @@ require 'ext/minitest-spec'
 require 'mocha/minitest'
 require 'webmock/minitest'
 
-# include WebMock::API
-
 Padrino::Generators.load_components!
-
-# register fake URL to avoid downloading static files every time tests run
-fake_uri_base = "https://raw.github.com/padrino/padrino-static/master/"
-%W[
-  js/dojo.js ujs/dojo.js
-  js/ext.js ujs/ext.js
-  js/jquery.js ujs/jquery.js
-  js/mootools.js ujs/mootools.js
-  js/right.js ujs/right.js
-  js/protopak.js js/lowpro.js ujs/prototype.js
-].each do |suffix|
-  WebMock::API.stub_request(:get, fake_uri_base + suffix)
-end
 
 class Minitest::Spec
   def stop_time_for_test
     time = Time.now
     Time.stubs(:now).returns(time)
     return time
+  end
+
+  def stub_static_files
+    # register fake URL to avoid downloading static files every time tests run
+    fake_uri_base = "https://raw.github.com/padrino/padrino-static/master/"
+    %W[
+      js/dojo.js
+      js/ext.js
+      js/jquery.js
+      js/lowpro.js
+      js/mootools.js
+      js/protopak.js
+      js/right.js
+      ujs/dojo.js
+      ujs/ext.js
+      ujs/jquery.js
+      ujs/mootools.js
+      ujs/prototype.js
+      ujs/right.js
+    ].each do |suffix|
+      WebMock::API.stub_request(:get, fake_uri_base + suffix)
+    end
   end
 
   # generate(:controller, 'DemoItems', '-r=/tmp/sample_project')

--- a/padrino-gen/test/helper.rb
+++ b/padrino-gen/test/helper.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'rack/test'
-require 'fakeweb'
 require 'thor/group'
 require 'padrino-gen'
 require 'padrino-core'
@@ -9,8 +8,10 @@ require 'padrino-mailer'
 require 'padrino-helpers'
 
 require 'ext/minitest-spec'
-require 'ext/fakeweb-ruby24'
 require 'mocha/minitest'
+require 'webmock/minitest'
+
+# include WebMock::API
 
 Padrino::Generators.load_components!
 
@@ -24,7 +25,7 @@ fake_uri_base = "https://raw.github.com/padrino/padrino-static/master/"
   js/right.js ujs/right.js
   js/protopak.js js/lowpro.js ujs/prototype.js
 ].each do |suffix|
-  FakeWeb.register_uri(:get, fake_uri_base + suffix, :body => '')
+  WebMock::API.stub_request(:get, fake_uri_base + suffix)
 end
 
 class Minitest::Spec

--- a/padrino-gen/test/test_component_generator.rb
+++ b/padrino-gen/test/test_component_generator.rb
@@ -5,6 +5,7 @@ describe "ComponentGenerator" do
   def setup
     @apptmp = "#{Dir.tmpdir}/padrino-tests/#{SecureRandom.hex}"
     `mkdir -p #{@apptmp}`
+    stub_static_files
   end
 
   def teardown

--- a/padrino-gen/test/test_plugin_generator.rb
+++ b/padrino-gen/test/test_plugin_generator.rb
@@ -54,14 +54,14 @@ describe "PluginGenerator" do
 
     it 'should resolve generic url properly' do
       template_file = 'http://www.example.com/test.rb'
-      FakeWeb.register_uri :get, template_file, :body => ''
+      stub_request :get, template_file
       project_gen = Padrino::Generators::Project.new(['sample_project'], ["-p=#{template_file}", "-r=#{@apptmp}"], {})
       project_gen.expects(:apply).with(template_file).returns(true).once
       capture_io { project_gen.invoke_all }
     end
 
     it 'should resolve gist url properly' do
-      FakeWeb.register_uri(:get, "https://gist.github.com/357045", :body => '<a href="/raw/357045/4356/blog_template.rb">raw</a>')
+      stub_request(:get, "https://gist.github.com/357045").to_return(body: '<a href="/raw/357045/4356/blog_template.rb">raw</a>')
       template_file = 'https://gist.github.com/357045'
       resolved_path = 'https://gist.github.com/raw/357045/4356/blog_template.rb'
       project_gen = Padrino::Generators::Project.new(['sample_project'], ["-p=#{template_file}", "-r=#{@apptmp}"], {})
@@ -72,7 +72,7 @@ describe "PluginGenerator" do
     it 'should resolve official template' do
       template_file = 'sampleblog'
       resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/templates/sampleblog_template.rb"
-      FakeWeb.register_uri :get, resolved_path, :body => template_file
+      stub_request(:get, resolved_path).to_return(body: template_file)
       project_gen = Padrino::Generators::Project.new(['sample_project'], ["-p=#{template_file}", "-r=#{@apptmp}"], {})
       project_gen.expects(:apply).with(resolved_path).returns(true).once
       capture_io { project_gen.invoke_all }
@@ -88,7 +88,7 @@ describe "PluginGenerator" do
     it 'should resolve official plugin' do
       template_file = 'hoptoad'
       resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/plugins/hoptoad_plugin.rb"
-      FakeWeb.register_uri :get, resolved_path, :body => template_file
+      stub_request(:get, resolved_path).to_return(body: template_file)
       plugin_gen = Padrino::Generators::Plugin.new([ template_file], ["-r=#{@apptmp}/sample_project"],{})
       plugin_gen.expects(:in_app_root?).returns(true).once
       plugin_gen.expects(:apply).with(resolved_path).returns(true).once
@@ -98,7 +98,7 @@ describe "PluginGenerator" do
     it 'should print a warning if template cannot be found' do
       template_file  = 'hwat'
       resolved_path = "https://raw.github.com/padrino/padrino-recipes/master/plugins/hwat_plugin.rb"
-      FakeWeb.register_uri :get, resolved_path, :status => 404
+      stub_request(:get, resolved_path).to_return(status: 404)
       plugin_gen = Padrino::Generators::Plugin.new([ template_file], ["-r=#{@apptmp}/sample_project"],{})
       plugin_gen.expects(:in_app_root?).returns(true).once
       # Use regex to ignore trailing whitespace in message

--- a/padrino-gen/test/test_plugin_generator.rb
+++ b/padrino-gen/test/test_plugin_generator.rb
@@ -12,22 +12,22 @@ describe "PluginGenerator" do
 
   describe "the plugin generator" do
     it 'should respect --root option' do
-      path = File.expand_path('../fixtures/plugin_template.rb', __FILE__)
+      path = File.expand_path('fixtures/plugin_template.rb', __dir__)
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
-      out, err = capture_io { generate(:plugin, path, "--root=#{@apptmp}/sample_project") }
-      refute_match /You are not at the root/, out
+      out, _err = capture_io { generate(:plugin, path, "--root=#{@apptmp}/sample_project") }
+      refute_match(/You are not at the root/, out)
     end
   end
 
   describe "the plugin destroy option" do
     it 'should remove the plugin instance' do
-      path = File.expand_path('../fixtures/plugin_template.rb', __FILE__)
+      path = File.expand_path('fixtures/plugin_template.rb', __dir__)
       capture_io { generate(:project, 'sample_project', "--root=#{@apptmp}") }
       capture_io { generate(:plugin, path, "--root=#{@apptmp}/sample_project") }
       capture_io { generate(:plugin, path, "--root=#{@apptmp}/sample_project", '-d') }
       assert_no_file_exists("#{@apptmp}/sample_project/lib/hoptoad_initializer.rb")
-      assert_no_match_in_file(/enable \:raise_errors/,"#{@apptmp}/sample_project/app/app.rb")
-      assert_no_match_in_file(/rack\_hoptoad/, "#{@apptmp}/sample_project/Gemfile")
+      assert_no_match_in_file(/enable :raise_errors/,"#{@apptmp}/sample_project/app/app.rb")
+      assert_no_match_in_file(/rack_hoptoad/, "#{@apptmp}/sample_project/Gemfile")
     end
   end
 
@@ -124,7 +124,7 @@ describe "PluginGenerator" do
   describe "with git commands" do
     it 'should generate a repository correctly' do
       skip 'Change stubs here'
-      expects_generated_project :test => :rspec, :orm => :activerecord, :name => 'sample_git', :root => "#{@apptmp}"
+      expects_generated_project :test => :rspec, :orm => :activerecord, :name => 'sample_git', :root => @apptmp.to_s
       expects_git :init, :root => "#{@apptmp}/sample_git"
       expects_git :add, :arguments => '.', :root => "#{@apptmp}/sample_git"
       expects_git :commit, :arguments => 'hello', :root => "#{@apptmp}/sample_git"
@@ -135,7 +135,7 @@ describe "PluginGenerator" do
 
   describe "with rake invocations" do
     it 'should Run rake task and list tasks' do
-      expects_generated_project :test => :shoulda, :orm => :activerecord, :name => 'sample_rake', :root => "#{@apptmp}"
+      expects_generated_project :test => :shoulda, :orm => :activerecord, :name => 'sample_rake', :root => @apptmp.to_s
       expects_rake "custom", :root => "#{@apptmp}/sample_rake"
       rake_template_path = File.join(File.dirname(__FILE__), 'fixtures', 'rake_template.rb')
       capture_io { generate(:project, 'sample_rake', "-p=#{rake_template_path}", "-r=#{@apptmp}", '> /dev/null') }
@@ -144,7 +144,7 @@ describe "PluginGenerator" do
 
   describe "with admin commands" do
     it 'should generate correctly an admin' do
-      expects_generated_project :test => :shoulda, :orm => :activerecord, :name => 'sample_admin', :root => "#{@apptmp}"
+      expects_generated_project :test => :shoulda, :orm => :activerecord, :name => 'sample_admin', :root => @apptmp.to_s
       expects_generated :model, "post title:string body:text -r=#{@apptmp}/sample_admin"
       expects_rake "ar:create", :root => "#{@apptmp}/sample_admin"
       expects_generated :admin, "-r=#{@apptmp}/sample_admin"

--- a/padrino-gen/test/test_project_generator.rb
+++ b/padrino-gen/test/test_project_generator.rb
@@ -4,6 +4,7 @@ describe "ProjectGenerator" do
   def setup
     @apptmp = "#{Dir.tmpdir}/padrino-tests/#{SecureRandom.hex}"
     `mkdir -p #{@apptmp}`
+    stub_static_files
   end
 
   def teardown

--- a/padrino/test/ext/fakeweb-ruby24.rb
+++ b/padrino/test/ext/fakeweb-ruby24.rb
@@ -1,5 +1,0 @@
-# FakeWeb is dead. Ruby 2.4 apparently calls #close even if a socked is already closed.
-class FakeWeb::StubSocket
-  def close
-  end
-end


### PR DESCRIPTION
This removes [FakeWeb](https://github.com/chrisk/fakeweb) and replaces it with `webmock` instead.

`FakeWeb` hasn't been updated in quite some time (_7 years_) and no longer works on Ruby 3.1+ it seems. This fixes our test suite and generation to instead use `webmock`.
