### PR TITLE
Add Rackup to Gemspec

### DIFF
--- a/padrino-core/padrino-core.gemspec
+++ b/padrino-core/padrino-core.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-support", Padrino.version)
+  s.add_dependency("rackup", "~> 2.1")
   s.add_dependency("sinatra", "~> 4")
   s.add_dependency("thor", "~> 1.0")
 end


### PR DESCRIPTION
:clipboard: #2288
:clipboard: #2287

This adds `rackup` to the `padrino-core` gemspec so that we can startup the serve. See previous PR #2287 for more details.
