### PR TITLE
Make Rack handler detection compatible with Rack 3

### DIFF
--- a/padrino-core/lib/padrino-core/server.rb
+++ b/padrino-core/lib/padrino-core/server.rb
@@ -77,11 +77,9 @@ module Padrino
     #
     def self.detect_rack_handler
       Handlers.each do |handler|
-        
-          return handler if Rack::Handler.get(handler.to_s.downcase)
-        rescue LoadError
-        rescue NameError
-        
+        return handler if Rackup::Handler.get(handler.to_s.downcase)
+      rescue LoadError, NameError
+        # Ignored
       end
       fail "Server handler (#{Handlers.join(', ')}) not found."
     end


### PR DESCRIPTION
In Rack 3 it's `Rackup::Handler`, not `Rack::Handler`. Also, slightly fixed the formatting.