### PR TITLE
Fix escape_html tests

### DIFF
--- a/padrino-helpers/test/test_format_helpers.rb
+++ b/padrino-helpers/test/test_format_helpers.rb
@@ -31,7 +31,7 @@ describe "FormatHelpers" do
 
     it 'should escape html tags' do
       actual_text = simple_format("Will you escape <b>that</b>?")
-      assert_equal "<p>Will you escape &lt;b&gt;that&lt;&#x2F;b&gt;?</p>", actual_text
+      assert_equal "<p>Will you escape &lt;b&gt;that&lt;/b&gt;?</p>", actual_text
     end
 
     it 'should support already sanitized text' do
@@ -118,18 +118,18 @@ describe "FormatHelpers" do
 
   describe 'for #h and #h! method' do
     it 'should escape the simple html' do
-      assert_equal '&lt;h1&gt;hello&lt;&#x2F;h1&gt;', h('<h1>hello</h1>')
-      assert_equal '&lt;h1&gt;hello&lt;&#x2F;h1&gt;', escape_html('<h1>hello</h1>')
+      assert_equal '&lt;h1&gt;hello&lt;/h1&gt;', h('<h1>hello</h1>')
+      assert_equal '&lt;h1&gt;hello&lt;/h1&gt;', escape_html('<h1>hello</h1>')
     end
     it 'should escape all brackets, quotes and ampersands' do
-      assert_equal '&lt;h1&gt;&lt;&gt;&quot;&amp;demo&amp;&quot;&lt;&gt;&lt;&#x2F;h1&gt;', h('<h1><>"&demo&"<></h1>')
+      assert_equal '&lt;h1&gt;&lt;&gt;&quot;&amp;demo&amp;&quot;&lt;&gt;&lt;/h1&gt;', h('<h1><>"&demo&"<></h1>')
     end
     it 'should return default text if text is empty' do
       assert_equal 'default', h!("", "default")
       assert_equal '&nbsp;', h!("")
     end
     it 'should return text escaped if not empty' do
-      assert_equal '&lt;h1&gt;hello&lt;&#x2F;h1&gt;', h!('<h1>hello</h1>')
+      assert_equal '&lt;h1&gt;hello&lt;/h1&gt;', h!('<h1>hello</h1>')
     end
     it 'should mark escaped text as safe' do
       assert_equal false, '<h1>hello</h1>'.html_safe?


### PR DESCRIPTION
HTML escape of forward slash is not the expected behavior. 
HTML escape of slash is not recommended by OWASP.
That's why forward slash is no longer escaped since [#2097](https://github.com/rack/rack/pull/2097). Further more, the escape_html method which uses `Rack::Utils.escape_html` is now delegated to `CGI.escapeHTML`. It also uses `ERB::Escape` if defined [introduced here](https://github.com/rack/rack/pull/2202/files#diff-85960cbd609e7f51a9881d1876b82d748f4ba8312a31e3329a5bb9bf791c60beR181). Both of these do not escape the forward slash.

Now that CI is green, here is a happy spongebob picture
![image (3) (1) (1) copy](https://github.com/user-attachments/assets/20542499-a4eb-4db4-9add-495d8b50c42f)
