### PR TITLE
Fix error that undefined method `schema_format' in AR 7.1

### DIFF
--- a/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
+++ b/padrino-gen/lib/padrino-gen/padrino-tasks/activerecord.rb
@@ -409,7 +409,11 @@ if PadrinoTasks.load?(:activerecord, defined?(ActiveRecord))
   end
 
   def dump_schema
-    Rake::Task["ar:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+    if less_than_active_record_7_0?
+      Rake::Task["ar:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+    else
+      Rake::Task["ar:schema:dump"].invoke if ActiveRecord.schema_format == :ruby
+    end
   end
 
   def resolve_structure_sql


### PR DESCRIPTION
Error occurred when invoke `ar:migrate:redo` in AR 7.1:

```
% bundle exec rake ar:migrate:redo MIGRATION_VERSION=1234
...
rake aborted!
NoMethodError: undefined method `schema_format' for ActiveRecord::Base:Class (NoMethodError)
/path/to/vendor/gems/ruby/3.2.0/gems/activerecord-7.1.5.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/path/to/vendor/gems/ruby/3.2.0/gems/padrino-gen-0.16.0.pre3/lib/padrino-gen/padrino-tasks/activerecord.rb:412:in `dump_schema'
/path/to/vendor/gems/ruby/3.2.0/gems/padrino-gen-0.16.0.pre3/lib/padrino-gen/padrino-tasks/activerecord.rb:394:in `migrate_as'
/path/to/vendor/gems/ruby/3.2.0/gems/padrino-gen-0.16.0.pre3/lib/padrino-gen/padrino-tasks/activerecord.rb:165:in `block (3 levels) in <top (required)>'
/path/to/vendor/gems/ruby/3.2.0/gems/padrino-gen-0.16.0.pre3/lib/padrino-gen/padrino-tasks/activerecord.rb:150:in `block (3 levels) in <top (required)>'
/path/to/vendor/gems/ruby/3.2.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
...
```

So I fixed it the same way as https://github.com/padrino/padrino-framework/pull/2275